### PR TITLE
feat(adapters): add wallet ownership proof to enrollment endpoint

### DIFF
--- a/packages/adapters/src/inbound/http/WalletController.ts
+++ b/packages/adapters/src/inbound/http/WalletController.ts
@@ -1,7 +1,27 @@
-import { Controller, Post, Param, Inject } from '@nestjs/common';
+import {
+  Controller,
+  Post,
+  Param,
+  Body,
+  Inject,
+  BadRequestException,
+  ConflictException,
+} from '@nestjs/common';
 import type { MonitoredWalletRepository, ClockPort } from '@clmm/application';
 import type { WalletId } from '@clmm/domain';
 import { MONITORED_WALLET_REPOSITORY, CLOCK_PORT } from './tokens.js';
+import {
+  issueWalletChallenge,
+  consumeWalletChallenge,
+  buildWalletVerificationMessage,
+  verifyWalletSignature,
+} from './WalletVerification.js';
+
+class WalletEnrollmentBody {
+  challenge!: string;
+  message!: string;
+  signature!: string; // base64-encoded 64-byte ed25519 signature
+}
 
 @Controller('wallets')
 export class WalletController {
@@ -12,10 +32,99 @@ export class WalletController {
     private readonly clock: ClockPort,
   ) {}
 
-  @Post(':walletId/monitor')
-  async enrollForMonitoring(@Param('walletId') walletId: string) {
+  /**
+   * Step 1: Request a ownership challenge for the given wallet address.
+   * The returned nonce must be signed by that wallet and submitted
+   * together with an enrollment request.
+   */
+  @Post(':walletId/challenge')
+  async requestChallenge(@Param('walletId') walletId: string) {
+    const challenge = issueWalletChallenge(walletId);
+    return {
+      challenge: challenge.nonce,
+      expiresAt: challenge.expiresAt,
+    };
+  }
+
+  /**
+   * Step 2: Submit wallet address + proof of ownership.
+   * The proof is a signed verification message (see WalletVerification.ts).
+   */
+  @Post(':walletId/enroll')
+  async enrollForMonitoring(
+    @Param('walletId') walletId: string,
+    @Body() body: WalletEnrollmentBody,
+  ) {
+    if (!body.challenge || !body.message || !body.signature) {
+      throw new BadRequestException(
+        'Missing required fields: challenge, message, signature',
+      );
+    }
+
+    // Verify the challenge is valid, non-expired, and matches the wallet address
+    const challenge = consumeWalletChallenge(body.challenge, walletId);
+    if (!challenge) {
+      throw new BadRequestException(
+        'Invalid or expired challenge. Request a new one at POST /wallets/:walletId/challenge',
+      );
+    }
+
+    // Reconstruct the exact message that should have been signed
+    const expectedMessage = buildWalletVerificationMessage(
+      walletId,
+      challenge.nonce,
+    );
+    if (body.message !== expectedMessage) {
+      throw new BadRequestException(
+        'Message does not match expected verification format',
+      );
+    }
+
+    // Decode base64 signature to Buffer
+    let signatureBuffer: Buffer;
+    try {
+      signatureBuffer = Buffer.from(body.signature, 'base64');
+    } catch {
+      throw new BadRequestException('Signature must be valid base64');
+    }
+
+    // Verify the ed25519 signature against the wallet's public key
+    const signatureValid = verifyWalletSignature({
+      message: expectedMessage,
+      signature: signatureBuffer,
+      walletAddress: walletId,
+    });
+    if (!signatureValid) {
+      throw new BadRequestException(
+        'Wallet signature verification failed. Ensure you signed the exact message shown by the app.',
+      );
+    }
+
+    // Signature proven — enroll the wallet
     const enrolledAt = this.clock.now();
-    await this.monitoredWalletRepo.enroll(walletId as WalletId, enrolledAt);
+    try {
+      await this.monitoredWalletRepo.enroll(walletId as WalletId, enrolledAt);
+    } catch (err: unknown) {
+      // Duplicate key means already enrolled — surface as 409 Conflict, not 500
+      if (err instanceof Error && err.message.includes('duplicate')) {
+        throw new ConflictException(`Wallet ${walletId} is already enrolled`);
+      }
+      throw err;
+    }
     return { enrolled: true, enrolledAt };
+  }
+
+  /**
+   * @deprecated Use POST /wallets/:walletId/challenge then POST /wallets/:walletId/enroll instead.
+   * This endpoint is kept for backward compatibility during the transition period.
+   * It will be removed in a future release.
+   */
+  @Post(':walletId/monitor')
+  async legacyEnrollForMonitoring(@Param('walletId') _walletId: string) {
+    throw new BadRequestException(
+      'This endpoint is deprecated. Please update your app to the latest version. ' +
+        'Use POST /wallets/:walletId/challenge to get a challenge, then ' +
+        'POST /wallets/:walletId/enroll with the signed proof.',
+    );
   }
 }

--- a/packages/adapters/src/inbound/http/WalletVerification.test.ts
+++ b/packages/adapters/src/inbound/http/WalletVerification.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from 'vitest';
+import {
+  issueWalletChallenge,
+  consumeWalletChallenge,
+  buildWalletVerificationMessage,
+  verifyWalletSignature,
+} from './WalletVerification.js';
+
+const TEST_WALLET = '4Nd1mBQtrMJVYVfKf2PJy9NZUZdTAsp7D4xWLsu4aDB';
+
+describe('WalletVerification', () => {
+  describe('issueWalletChallenge / consumeWalletChallenge', () => {
+    it('issues a challenge and consumes it successfully', () => {
+      const challenge = issueWalletChallenge(TEST_WALLET);
+      expect(challenge.walletAddress).toBe(TEST_WALLET);
+      expect(challenge.nonce).toHaveLength(64); // 32 bytes hex
+      expect(challenge.expiresAt).toBeGreaterThan(Date.now());
+
+      const consumed = consumeWalletChallenge(challenge.nonce, TEST_WALLET);
+      expect(consumed).not.toBeNull();
+      expect(consumed!.nonce).toBe(challenge.nonce);
+    });
+
+    it('rejects a consumed challenge on second use', () => {
+      const challenge = issueWalletChallenge(TEST_WALLET);
+      consumeWalletChallenge(challenge.nonce, TEST_WALLET);
+      const second = consumeWalletChallenge(challenge.nonce, TEST_WALLET);
+      expect(second).toBeUndefined();
+    });
+
+    it('rejects challenge for mismatched wallet address', () => {
+      const challenge = issueWalletChallenge(TEST_WALLET);
+      const result = consumeWalletChallenge(
+        challenge.nonce,
+        '5DifferentWalletAddressHere123456',
+      );
+      expect(result).toBeUndefined();
+    });
+
+    it('rejects unknown nonce', () => {
+      const result = consumeWalletChallenge(
+        '0000000000000000000000000000000000000000000000000000000000000000',
+        TEST_WALLET,
+      );
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe('buildWalletVerificationMessage', () => {
+    it('formats the expected message string', () => {
+      const nonce = 'abc123';
+      const msg = buildWalletVerificationMessage(TEST_WALLET, nonce);
+      expect(msg).toBe(
+        `CLMM V2\nWallet: ${TEST_WALLET}\nChallenge: ${nonce}`,
+      );
+    });
+  });
+
+  describe('verifyWalletSignature', () => {
+    it('returns false for a 64-byte signature of the wrong message', () => {
+      // Create a valid 64-byte buffer but sign wrong message
+      const fakeSig = Buffer.alloc(64, 1);
+      const result = verifyWalletSignature({
+        message: 'wrong message',
+        signature: fakeSig,
+        walletAddress: TEST_WALLET,
+      });
+      expect(result).toBe(false);
+    });
+
+    it('returns false for a malformed address', () => {
+      const fakeSig = Buffer.alloc(64, 1);
+      const result = verifyWalletSignature({
+        message: 'any',
+        signature: fakeSig,
+        walletAddress: 'not-valid-base58!@#',
+      });
+      expect(result).toBe(false);
+    });
+
+    it('returns false for wrong-length signature', () => {
+      const result = verifyWalletSignature({
+        message: 'any',
+        signature: Buffer.alloc(32), // too short
+        walletAddress: TEST_WALLET,
+      });
+      expect(result).toBe(false);
+    });
+  });
+});

--- a/packages/adapters/src/inbound/http/WalletVerification.ts
+++ b/packages/adapters/src/inbound/http/WalletVerification.ts
@@ -1,0 +1,139 @@
+import { randomBytes } from 'crypto';
+
+/**
+ * Wallet ownership challenge — issued by POST /wallets/:walletId/challenge,
+ * consumed by POST /wallets/:walletId/enroll within a 5-minute window.
+ */
+export interface WalletChallenge {
+  readonly nonce: string;
+  readonly walletAddress: string;
+  readonly expiresAt: number; // Unix ms
+}
+
+const challenges = new Map<string, WalletChallenge>();
+
+const CHALLENGE_TTL_MS = 5 * 60 * 1_000; // 5 minutes
+
+/**
+ * Generate and store a new challenge for the given wallet address.
+ */
+export function issueWalletChallenge(walletAddress: string): WalletChallenge {
+  const nonce = randomBytes(32).toString('hex');
+  const expiresAt = Date.now() + CHALLENGE_TTL_MS;
+  const challenge: WalletChallenge = { nonce, walletAddress, expiresAt };
+  challenges.set(nonce, challenge);
+  // Prune expired entries on each issue to keep map bounded
+  for (const [key, c] of challenges.entries()) {
+    if (c.expiresAt < Date.now()) challenges.delete(key);
+  }
+  return challenge;
+}
+
+/**
+ * Find a valid (non-expired) challenge by nonce and wallet address.
+ * Returns undefined if missing, expired, or address mismatch.
+ */
+export function consumeWalletChallenge(
+  nonce: string,
+  walletAddress: string,
+): WalletChallenge | undefined {
+  const challenge = challenges.get(nonce);
+  if (!challenge) return undefined;
+  if (challenge.expiresAt < Date.now()) {
+    challenges.delete(nonce);
+    return undefined;
+  }
+  if (challenge.walletAddress !== walletAddress) return undefined;
+  challenges.delete(nonce); // one-time use
+  return challenge;
+}
+
+/**
+ * Build the verification message that must be signed by the wallet.
+ * This is what the user sees in Phantom/Solflare before approving.
+ */
+export function buildWalletVerificationMessage(
+  walletAddress: string,
+  nonce: string,
+): string {
+  return `CLMM V2\nWallet: ${walletAddress}\nChallenge: ${nonce}`;
+}
+
+/**
+ * Verify an ed25519 signature against a message and Solana wallet address.
+ * Uses Node.js built-in crypto (Node 18+).
+ */
+export function verifyWalletSignature(params: {
+  message: string; // raw string that was signed
+  signature: Buffer; // 64-byte ed25519 signature
+  walletAddress: string; // base58 Solana address
+}): boolean {
+  try {
+    const { message, signature, walletAddress } = params;
+    if (signature.length !== 64) return false;
+
+    // The message bytes (UTF-8)
+    const messageBytes = Buffer.from(message, 'utf8');
+
+    // Decode base58 address to 32-byte public key
+    const pubkey = base58ToBuffer(walletAddress);
+    if (pubkey.length !== 32) return false;
+
+    return verifyEd25519(signature, messageBytes, pubkey);
+  } catch {
+    return false;
+  }
+}
+
+function verifyEd25519(
+  signature: Buffer,
+  message: Buffer,
+  publicKey: Buffer,
+): boolean {
+  // Node.js 18+ exposes crypto.verify('ed25519', ...)
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const crypto = require('crypto') as { verify: (algorithm: string, data: Buffer, key: Buffer, sig: Buffer) => boolean };
+  return crypto.verify('ed25519', message, publicKey, signature);
+}
+
+// ─── Minimal base58 decoder (avoids adding @solana/web3.js as a dependency) ─
+
+const BASE58_ALPHABET = '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz';
+const BASE58_MAP: Record<string, number> = {};
+for (let i = 0; i < BASE58_ALPHABET.length; i++) {
+  BASE58_MAP[BASE58_ALPHABET.charAt(i)] = i;
+}
+
+function base58ToBuffer(base58: string): Buffer {
+  let result = Buffer.alloc(64);
+  let len = 0;
+  for (const char of base58) {
+    let carry = BASE58_MAP[char];
+    if (carry === undefined) throw new Error(`Invalid base58 character: ${char}`);
+    for (let i = len - 1; i >= 0; i--) {
+      const byte = result[i] ?? 0;
+      carry += 58 * byte;
+      result[i] = carry % 256;
+      carry = Math.floor(carry / 256);
+    }
+    if (carry > 0) {
+      if (len >= result.length) {
+        const newResult = Buffer.alloc(result.length + 64);
+        result.copy(newResult);
+        result = newResult;
+      }
+      result[len++] = carry;
+    }
+  }
+  // Leading zeros
+  for (const char of base58) {
+    if (char !== '1') break;
+    if (len >= result.length) {
+      const newResult = Buffer.alloc(result.length + 1);
+      result.copy(newResult);
+      result = newResult;
+    }
+    result[len++] = 0;
+  }
+  return result.slice(0, len);
+}


### PR DESCRIPTION
Wallet enrollment (POST /wallets/:walletId/enroll) now requires a cryptographic proof of wallet ownership instead of being open to anyone.

Flow:
1. Client calls POST /wallets/:walletId/challenge to get a random nonce
2. Client has the user sign a verification message with their wallet
3. Client submits walletId + challenge nonce + signed message + ed25519 signature
4. Backend verifies the signature using the user's public key (wallet address)

Uses Node.js built-in crypto.verify('ed25519', ...) — no new dependencies. Challenges expire after 5 minutes and are single-use to prevent replay attacks.