### PR TITLE
fix(infra): add retry-with-backoff on Solana RPC calls for 429 rate-l…

### DIFF
--- a/packages/adapters/src/inbound/jobs/WorkerLifecycle.ts
+++ b/packages/adapters/src/inbound/jobs/WorkerLifecycle.ts
@@ -81,7 +81,7 @@ export class WorkerLifecycle implements OnModuleInit, OnModuleDestroy {
       },
     );
 
-    await this.boss.schedule(BreachScanJobHandler.JOB_NAME, '*/1 * * * *', {}, {
+    await this.boss.schedule(BreachScanJobHandler.JOB_NAME, '*/5 * * * *', {}, {
       tz: 'UTC',
     });
 

--- a/packages/adapters/src/inbound/jobs/WorkerLifecycle.ts
+++ b/packages/adapters/src/inbound/jobs/WorkerLifecycle.ts
@@ -81,7 +81,7 @@ export class WorkerLifecycle implements OnModuleInit, OnModuleDestroy {
       },
     );
 
-    await this.boss.schedule(BreachScanJobHandler.JOB_NAME, '*/5 * * * *', {}, {
+    await this.boss.schedule(BreachScanJobHandler.JOB_NAME, '*/1 * * * *', {}, {
       tz: 'UTC',
     });
 

--- a/packages/adapters/src/outbound/solana-position-reads/OrcaPositionReadAdapter.ts
+++ b/packages/adapters/src/outbound/solana-position-reads/OrcaPositionReadAdapter.ts
@@ -20,6 +20,7 @@ import {
   makeClockTimestamp,
   evaluateRangeState,
 } from '@clmm/domain';
+import { withRetry } from '../../utils/rpcRetry.js';
 
 export class OrcaPositionReadAdapter implements SupportedPositionReadPort {
   constructor(private readonly rpcUrl: string) {}
@@ -102,7 +103,9 @@ export class OrcaPositionReadAdapter implements SupportedPositionReadPort {
     const rpc = this.getRpc();
     const ownerAddress = this.walletIdToAddress(walletId);
 
-    const positions = await fetchPositionsForOwner(rpc, ownerAddress);
+    const positions = await withRetry(() => fetchPositionsForOwner(rpc, ownerAddress), {
+      maxAttempts: 4,
+    });
 
     const liquidityPositions: LiquidityPosition[] = [];
 
@@ -112,7 +115,10 @@ export class OrcaPositionReadAdapter implements SupportedPositionReadPort {
 
         let whirlpoolData;
         try {
-          whirlpoolData = await fetchWhirlpool(rpc, address(whirlpoolAddress.toString()));
+          whirlpoolData = await withRetry(
+            () => fetchWhirlpool(rpc, address(whirlpoolAddress.toString())),
+            { maxAttempts: 4 },
+          );
         } catch {
           continue;
         }

--- a/packages/adapters/src/outbound/solana-position-reads/SolanaRangeObservationAdapter.ts
+++ b/packages/adapters/src/outbound/solana-position-reads/SolanaRangeObservationAdapter.ts
@@ -11,6 +11,7 @@ import { fetchWhirlpool, fetchPosition } from '@orca-so/whirlpools-client';
 import type { RangeObservationPort } from '@clmm/application';
 import type { PositionId, ClockTimestamp } from '@clmm/domain';
 import { makeClockTimestamp } from '@clmm/domain';
+import { withRetry } from '../../utils/rpcRetry.js';
 
 export class SolanaRangeObservationAdapter implements RangeObservationPort {
   constructor(private readonly rpcUrl: string) {}
@@ -29,7 +30,10 @@ export class SolanaRangeObservationAdapter implements RangeObservationPort {
 
     let positionAccount;
     try {
-      positionAccount = await fetchPosition(rpc, positionAddress);
+      positionAccount = await withRetry(
+        () => fetchPosition(rpc, positionAddress),
+        { maxAttempts: 4 },
+      );
     } catch {
       throw new Error(`SolanaRangeObservationAdapter: could not fetch position ${positionId}`);
     }
@@ -39,7 +43,10 @@ export class SolanaRangeObservationAdapter implements RangeObservationPort {
 
     let whirlpoolData;
     try {
-      whirlpoolData = await fetchWhirlpool(rpc, whirlpoolAddress);
+      whirlpoolData = await withRetry(
+        () => fetchWhirlpool(rpc, whirlpoolAddress),
+        { maxAttempts: 4 },
+      );
     } catch {
       throw new Error(`SolanaRangeObservationAdapter: could not fetch whirlpool ${whirlpoolAddress}`);
     }

--- a/packages/adapters/src/outbound/swap-execution/SolanaExecutionPreparationAdapter.ts
+++ b/packages/adapters/src/outbound/swap-execution/SolanaExecutionPreparationAdapter.ts
@@ -36,6 +36,7 @@ import type { Instruction } from '@solana/kit';
 import type { ExecutionPreparationPort } from '@clmm/application';
 import type { ExecutionPlan, WalletId, PositionId, PoolId, ClockTimestamp, LiquidityPosition } from '@clmm/domain';
 import { makeClockTimestamp } from '@clmm/domain';
+import { withRetry } from '../../utils/rpcRetry.js';
 
 const JUPITER_SWAP_API_BASES = [
   'https://lite-api.jup.ag/swap/v1',
@@ -125,11 +126,17 @@ export class SolanaExecutionPreparationAdapter implements ExecutionPreparationPo
     try {
       const positionMint = address(positionId);
       const [positionAddress] = await getPositionAddress(positionMint);
-      const positionAccount = await fetchPosition(rpc, positionAddress);
+      const positionAccount = await withRetry(
+        () => fetchPosition(rpc, positionAddress),
+        { maxAttempts: 4 },
+      );
       const position = positionAccount.data;
       const whirlpoolAddress = position.whirlpool;
 
-      const whirlpoolAccount = await fetchWhirlpool(rpc, whirlpoolAddress);
+      const whirlpoolAccount = await withRetry(
+        () => fetchWhirlpool(rpc, whirlpoolAddress),
+        { maxAttempts: 4 },
+      );
       const whirlpool = whirlpoolAccount.data;
 
       const bounds = {

--- a/packages/adapters/src/outbound/swap-execution/SolanaExecutionSubmissionAdapter.ts
+++ b/packages/adapters/src/outbound/swap-execution/SolanaExecutionSubmissionAdapter.ts
@@ -11,6 +11,7 @@ import type { Base64EncodedWireTransaction, Signature } from '@solana/kit';
 import type { ExecutionSubmissionPort } from '@clmm/application';
 import type { TransactionReference, ExecutionLifecycleState, ClockTimestamp } from '@clmm/domain';
 import { makeClockTimestamp } from '@clmm/domain';
+import { withRetry } from '../../utils/rpcRetry.js';
 
 function uint8ArrayToBase64(bytes: Uint8Array): string {
   const binary = String.fromCharCode(...bytes);
@@ -32,7 +33,10 @@ export class SolanaExecutionSubmissionAdapter implements ExecutionSubmissionPort
 
     const base64 = uint8ArrayToBase64(signedPayload) as Base64EncodedWireTransaction;
 
-    const signature = await rpc.sendTransaction(base64, { encoding: 'base64', skipPreflight: true }).send();
+    const signature = await withRetry(
+      () => rpc.sendTransaction(base64, { encoding: 'base64', skipPreflight: true }).send(),
+      { maxAttempts: 4 },
+    );
 
     const reference: TransactionReference = {
       signature: signature.toString(),
@@ -56,7 +60,13 @@ export class SolanaExecutionSubmissionAdapter implements ExecutionSubmissionPort
 
     for (const ref of references) {
       try {
-        const status = await rpc.getSignatureStatuses([ref.signature as unknown as Signature], { searchTransactionHistory: true }).send();
+        const status = await withRetry(
+          () =>
+            rpc
+              .getSignatureStatuses([ref.signature as unknown as Signature], { searchTransactionHistory: true })
+              .send(),
+          { maxAttempts: 4 },
+        );
         const sigStatus = status.value[0];
 
         if (sigStatus?.err) {

--- a/packages/adapters/src/utils/rpcRetry.ts
+++ b/packages/adapters/src/utils/rpcRetry.ts
@@ -11,20 +11,25 @@
  */
 
 /**
- * HTTP 429 indicators matched explicitly to avoid false positives from
- * numeric error codes that happen to contain "429" (e.g. 0x429).
+ * HTTP 429 indicators matched on a lowercased message to catch all variants
+ * regardless of capitalisation (e.g. "429 Too Many Requests from upstream").
+ * Numeric Solana error codes (#8100002) are checked case-sensitively.
  */
 const SOLANA_RATE_LIMIT_CODE = '8100002';
-const SOLANA_429_INDICATORS = ['HTTP error (429)', 'Too Many Requests', `#${SOLANA_RATE_LIMIT_CODE}`];
+const SOLANA_429_INDICATORS_LOWER = ['http error (429)', 'too many requests'];
 
 /**
  * Returns true if the error is a Solana RPC rate-limit error (HTTP 429).
  * Handles both the Solana error-code form (#8100002) and the plain HTTP 429 form.
- * Only matches explicit HTTP 429 indicators — not arbitrary "429" substrings.
+ * Performs case-insensitive matching for the HTTP text variants to catch all
+ * capitalisation forms (e.g. "429 Too Many Requests from upstream").
  */
 export function isSolanaRateLimitError(error: unknown): boolean {
   if (error instanceof Error) {
-    return SOLANA_429_INDICATORS.some((indicator) => error.message.includes(indicator));
+    const msg = error.message;
+    if (msg.includes(`#${SOLANA_RATE_LIMIT_CODE}`)) return true;
+    const msgLower = msg.toLowerCase();
+    return SOLANA_429_INDICATORS_LOWER.some((indicator) => msgLower.includes(indicator));
   }
   return false;
 }

--- a/packages/adapters/src/utils/rpcRetry.ts
+++ b/packages/adapters/src/utils/rpcRetry.ts
@@ -2,21 +2,24 @@
  * Solana RPC retry utility.
  *
  * The public Solana RPC (api.mainnet-beta.solana.com) and some private RPCs
- * return HTTP 429 ("Too Many Requests") when rate-limited. This manifests as
- * a Solana error with code 8100002 (#8100002).
+ * return HTTP 429 ("Too Many Requests") when rate-limited. Solana surfaces
+ * this in two ways:
+ *   1. Error code #8100002 embedded in the message  (e.g. "…#8100002…")
+ *   2. Plain HTTP 429 text  (e.g. "SolanaError: HTTP error (429): Too Many Requests")
  *
- * This module provides `withRetry` which wraps an async RPC call and
- * automatically retries with exponential backoff + jitter on 429 errors.
+ * Both forms indicate a transient rate-limit condition and should be retried.
  */
 
 const SOLANA_RATE_LIMIT_CODE = '8100002';
+const SOLANA_429_TEXT = '429';
 
 /**
  * Returns true if the error is a Solana RPC rate-limit error (HTTP 429).
+ * Handles both the Solana error-code form (#8100002) and the plain HTTP 429 form.
  */
 export function isSolanaRateLimitError(error: unknown): boolean {
   if (error instanceof Error) {
-    return error.message.includes(`#${SOLANA_RATE_LIMIT_CODE}`);
+    return error.message.includes(`#${SOLANA_RATE_LIMIT_CODE}`) || error.message.includes(SOLANA_429_TEXT);
   }
   return false;
 }

--- a/packages/adapters/src/utils/rpcRetry.ts
+++ b/packages/adapters/src/utils/rpcRetry.ts
@@ -10,16 +10,21 @@
  * Both forms indicate a transient rate-limit condition and should be retried.
  */
 
+/**
+ * HTTP 429 indicators matched explicitly to avoid false positives from
+ * numeric error codes that happen to contain "429" (e.g. 0x429).
+ */
 const SOLANA_RATE_LIMIT_CODE = '8100002';
-const SOLANA_429_TEXT = '429';
+const SOLANA_429_INDICATORS = ['HTTP error (429)', 'Too Many Requests', `#${SOLANA_RATE_LIMIT_CODE}`];
 
 /**
  * Returns true if the error is a Solana RPC rate-limit error (HTTP 429).
  * Handles both the Solana error-code form (#8100002) and the plain HTTP 429 form.
+ * Only matches explicit HTTP 429 indicators — not arbitrary "429" substrings.
  */
 export function isSolanaRateLimitError(error: unknown): boolean {
   if (error instanceof Error) {
-    return error.message.includes(`#${SOLANA_RATE_LIMIT_CODE}`) || error.message.includes(SOLANA_429_TEXT);
+    return SOLANA_429_INDICATORS.some((indicator) => error.message.includes(indicator));
   }
   return false;
 }

--- a/packages/adapters/src/utils/rpcRetry.ts
+++ b/packages/adapters/src/utils/rpcRetry.ts
@@ -1,0 +1,82 @@
+/**
+ * Solana RPC retry utility.
+ *
+ * The public Solana RPC (api.mainnet-beta.solana.com) and some private RPCs
+ * return HTTP 429 ("Too Many Requests") when rate-limited. This manifests as
+ * a Solana error with code 8100002 (#8100002).
+ *
+ * This module provides `withRetry` which wraps an async RPC call and
+ * automatically retries with exponential backoff + jitter on 429 errors.
+ */
+
+const SOLANA_RATE_LIMIT_CODE = '8100002';
+
+/**
+ * Returns true if the error is a Solana RPC rate-limit error (HTTP 429).
+ */
+export function isSolanaRateLimitError(error: unknown): boolean {
+  if (error instanceof Error) {
+    return error.message.includes(`#${SOLANA_RATE_LIMIT_CODE}`);
+  }
+  return false;
+}
+
+/**
+ * Default retry configuration.
+ */
+const DEFAULT_MAX_ATTEMPTS = 4;
+const BASE_DELAY_MS = 500;
+const MAX_DELAY_MS = 16_000;
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function sleep(ms: number): Promise<void> {
+  return new Promise<void>((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
+
+/**
+ * Execute an async RPC call with automatic retry on Solana rate-limit errors.
+ * Uses exponential backoff with jitter (decorrelated jitter variant).
+ *
+ * @param fn - The async RPC call to execute.
+ * @param options.maxAttempts - Maximum number of attempts (default 4).
+ * @param options.baseDelayMs - Initial delay in ms (default 500).
+ * @param options.maxDelayMs - Maximum delay cap in ms (default 16000).
+ * @throws The last error if all attempts are exhausted.
+ */
+export async function withRetry<T>(
+  fn: () => Promise<T>,
+  options: {
+    maxAttempts?: number;
+    baseDelayMs?: number;
+    maxDelayMs?: number;
+  } = {},
+): Promise<T> {
+  const { maxAttempts = DEFAULT_MAX_ATTEMPTS, baseDelayMs = BASE_DELAY_MS, maxDelayMs = MAX_DELAY_MS } = options;
+
+  let lastError: unknown;
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    try {
+      return await fn();
+    } catch (error: unknown) {
+      lastError = error;
+
+      // Only retry on Solana rate-limit errors (HTTP 429)
+      if (!isSolanaRateLimitError(error)) {
+        throw error;
+      }
+
+      if (attempt === maxAttempts) {
+        break;
+      }
+
+      // Exponential backoff with decorrelated jitter
+      const delay = Math.min(baseDelayMs * 2 ** (attempt - 1) + Math.random() * baseDelayMs, maxDelayMs);
+      await sleep(delay);
+    }
+  }
+
+  throw lastError;
+}


### PR DESCRIPTION
- New utils/rpcRetry.ts: withRetry() + isSolanaRateLimitError()
  - Detects Solana error code #8100002 (HTTP 429)
  - Exponential backoff + jitter (500ms → 1s → 2s → 4s), max 4 attempts
- Wrapped all Solana RPC calls in:
  - OrcaPositionReadAdapter (fetchPositionsForOwner, fetchWhirlpool)
  - SolanaRangeObservationAdapter (fetchPosition, fetchWhirlpool)
  - SolanaExecutionPreparationAdapter (fetchPosition, fetchWhirlpool)
  - SolanaExecutionSubmissionAdapter (sendTransaction, getSignatureStatuses)
- Only retries on Solana rate-limit errors; all other errors propagate immediately
- Infrastructure still needs: paid SOLANA_RPC_URL (Helius/QuickNode/Triton)