### PR TITLE
chore: slow breach-scan cadence from */1 to */5

### DIFF
--- a/packages/adapters/src/inbound/jobs/WorkerLifecycle.ts
+++ b/packages/adapters/src/inbound/jobs/WorkerLifecycle.ts
@@ -81,7 +81,7 @@ export class WorkerLifecycle implements OnModuleInit, OnModuleDestroy {
       },
     );
 
-    await this.boss.schedule(BreachScanJobHandler.JOB_NAME, '*/1 * * * *', {}, {
+    await this.boss.schedule(BreachScanJobHandler.JOB_NAME, '*/5 * * * *', {}, {
       tz: 'UTC',
     });
 


### PR DESCRIPTION
Note: materially delays breach detection — confirmation requires 3 consecutive observations (MVP_CONFIRMATION_THRESHOLD), so qualification stretches from ~3 min to ~15 min. Any episode resolving in <5 min may be missed entirely. Separate PR to discuss tradeoffs before merging.