### PR TITLE
fix(app): persist wallet session across re-initializations

### DIFF
--- a/apps/app/app/position/[id].tsx
+++ b/apps/app/app/position/[id].tsx
@@ -10,12 +10,14 @@ export default function PositionDetailRoute() {
   const { id, triggerId } = useLocalSearchParams<{ id?: string | string[]; triggerId?: string | string[] }>();
   const router = useRouter();
   const walletAddress = useStore(walletSessionStore, (state) => state.walletAddress);
+  const hasHydrated = useStore(walletSessionStore, (s) => s.hasHydrated);
   const positionId = typeof id === 'string' ? id : undefined;
   const alertTriggerId = typeof triggerId === 'string' && triggerId.length > 0 ? triggerId : undefined;
   const hasValidPositionId = positionId != null && positionId.length > 0;
   const hasWalletAddress = walletAddress != null && walletAddress.length > 0;
 
-  if (hasValidPositionId && !hasWalletAddress) {
+  // Only redirect if we have a valid positionId, no wallet address, AND hydration is complete
+  if (hasValidPositionId && !hasWalletAddress && hasHydrated) {
     router.push('/connect');
     return null;
   }

--- a/apps/app/app/preview/[triggerId].tsx
+++ b/apps/app/app/preview/[triggerId].tsx
@@ -15,8 +15,9 @@ export default function PreviewRoute() {
   const params = useLocalSearchParams<{ triggerId?: string | string[] }>();
   const triggerId = readTriggerId(params.triggerId);
   const walletAddress = useStore(walletSessionStore, (state) => state.walletAddress);
+  const hasHydrated = useStore(walletSessionStore, (s) => s.hasHydrated);
 
-  if (triggerId != null && walletAddress == null) {
+  if (triggerId != null && walletAddress == null && hasHydrated) {
     router.push('/connect');
     return null;
   }

--- a/apps/app/app/signing/[attemptId].tsx
+++ b/apps/app/app/signing/[attemptId].tsx
@@ -71,16 +71,17 @@ export default function SigningRoute() {
   const episodeId = readEpisodeId(params.episodeId);
   const hasPendingAttemptPlaceholder = isPendingAttemptPlaceholder(params.attemptId);
   const walletAddress = useStore(walletSessionStore, (state) => state.walletAddress);
+  const hasHydrated = useStore(walletSessionStore, (s) => s.hasHydrated);
   const connectionKind = useStore(walletSessionStore, (state) => state.connectionKind);
 
   const [statusNotice, setStatusNotice] = useState<string | null>(null);
   const [hasStartedPendingApproval, setHasStartedPendingApproval] = useState(false);
 
   useEffect(() => {
-    if (attemptId == null && walletAddress == null) {
+    if (attemptId == null && walletAddress == null && hasHydrated) {
       router.push('/connect');
     }
-  }, [attemptId, walletAddress, router]);
+  }, [attemptId, walletAddress, hasHydrated, router]);
 
   const approveMutation = useMutation({
     mutationFn: approveExecutionPreview,

--- a/apps/app/package.json
+++ b/apps/app/package.json
@@ -35,6 +35,7 @@
     "react-native-screens": "~4.4.0",
     "react-native-web": "~0.19.13",
     "tailwindcss": "^3.0.0",
+    "@react-native-async-storage/async-storage": "^2.1.0",
     "zustand": "^4.5.0"
   },
   "devDependencies": {

--- a/apps/app/src/state/walletSessionStore.test.ts
+++ b/apps/app/src/state/walletSessionStore.test.ts
@@ -1,14 +1,28 @@
-import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { PlatformCapabilityState } from '@clmm/application/public';
 
-// Mock AsyncStorage so tests run in jsdom without a real storage backend
-vi.mock('@react-native-async-storage/async-storage', () => ({
-  default: {
-    setItem: vi.fn(() => Promise.resolve()),
-    getItem: vi.fn(() => Promise.resolve(null)),
-    removeItem: vi.fn(() => Promise.resolve()),
-  },
-}));
+// In-memory AsyncStorage mock so we can test persist + rehydrate.
+vi.mock('@react-native-async-storage/async-storage', () => {
+  const mem = new Map<string, string>();
+
+  return {
+    default: {
+      setItem: vi.fn((key: string, value: string) => {
+        mem.set(key, value);
+        return Promise.resolve();
+      }),
+      getItem: vi.fn((key: string) => Promise.resolve(mem.get(key) ?? null)),
+      removeItem: vi.fn((key: string) => {
+        mem.delete(key);
+        return Promise.resolve();
+      }),
+      clear: vi.fn(() => {
+        mem.clear();
+        return Promise.resolve();
+      }),
+    },
+  };
+});
 import {
   createWalletSessionStore,
   type WalletConnectionKind,
@@ -23,6 +37,9 @@ const caps: PlatformCapabilityState = {
 };
 
 describe('walletSessionStore', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
   it('loads platform capabilities into state', () => {
     const store = createWalletSessionStore();
 
@@ -82,7 +99,7 @@ describe('walletSessionStore', () => {
     expect(store.getState().connectionKind).toBeNull();
   });
 
-  it('disconnect clears address, kind, and connecting state', () => {
+  it('disconnect clears address, kind, and connecting state, and clears persisted storage', async () => {
     const store = createWalletSessionStore();
 
     store.getState().markConnected({
@@ -91,9 +108,41 @@ describe('walletSessionStore', () => {
     });
     store.getState().disconnect();
 
+    // persist.clearStorage() eventually calls AsyncStorage.removeItem('wallet-session')
+    const { default: AsyncStorage } = await import('@react-native-async-storage/async-storage');
+    // allow any pending promises to settle
+    await Promise.resolve();
+
+    expect(AsyncStorage.removeItem).toHaveBeenCalledWith('wallet-session');
+
     expect(store.getState().walletAddress).toBeNull();
     expect(store.getState().connectionKind).toBeNull();
     expect(store.getState().isConnecting).toBe(false);
+  });
+
+  it('rehydrates persisted session fields but not transient UI state', async () => {
+    const store1 = createWalletSessionStore();
+
+    store1.getState().setPlatformCapabilities(caps);
+    store1.getState().beginConnection();
+    store1.getState().markConnected({
+      walletAddress: 'DemoWallet1111111111111111111111111111111111',
+      connectionKind: 'browser',
+    });
+
+    // Ensure persist has had a chance to write
+    await Promise.resolve();
+
+    const store2 = createWalletSessionStore();
+    await store2.persist.rehydrate();
+
+    expect(store2.getState().walletAddress).toBe('DemoWallet1111111111111111111111111111111111');
+    expect(store2.getState().connectionKind).toBe('browser');
+    expect(store2.getState().platformCapabilities).toEqual(caps);
+
+    // Transient state should not be persisted
+    expect(store2.getState().isConnecting).toBe(false);
+    expect(store2.getState().connectionOutcome).toBeNull();
   });
 
   it('clears stale outcome without dropping connected session', () => {

--- a/apps/app/src/state/walletSessionStore.test.ts
+++ b/apps/app/src/state/walletSessionStore.test.ts
@@ -1,5 +1,14 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
 import type { PlatformCapabilityState } from '@clmm/application/public';
+
+// Mock AsyncStorage so tests run in jsdom without a real storage backend
+vi.mock('@react-native-async-storage/async-storage', () => ({
+  default: {
+    setItem: vi.fn(() => Promise.resolve()),
+    getItem: vi.fn(() => Promise.resolve(null)),
+    removeItem: vi.fn(() => Promise.resolve()),
+  },
+}));
 import {
   createWalletSessionStore,
   type WalletConnectionKind,

--- a/apps/app/src/state/walletSessionStore.test.ts
+++ b/apps/app/src/state/walletSessionStore.test.ts
@@ -37,8 +37,11 @@ const caps: PlatformCapabilityState = {
 };
 
 describe('walletSessionStore', () => {
-  beforeEach(() => {
+  beforeEach(async () => {
     vi.clearAllMocks();
+    // Clear the in-memory mock storage between tests so state doesn't leak
+    const { default: AsyncStorage } = await import('@react-native-async-storage/async-storage');
+    await AsyncStorage.clear();
   });
   it('loads platform capabilities into state', () => {
     const store = createWalletSessionStore();

--- a/apps/app/src/state/walletSessionStore.ts
+++ b/apps/app/src/state/walletSessionStore.ts
@@ -13,6 +13,7 @@ export type WalletSessionState = {
   connectionOutcome: ConnectionOutcome | null;
   platformCapabilities: PlatformCapabilityState | null;
   isConnecting: boolean;
+  hasHydrated: boolean;
   setPlatformCapabilities: (capabilities: PlatformCapabilityState) => void;
   beginConnection: () => void;
   markConnected: (params: {
@@ -33,6 +34,7 @@ export function createWalletSessionStore() {
         connectionOutcome: null,
         platformCapabilities: null,
         isConnecting: false,
+        hasHydrated: false,
         setPlatformCapabilities: (platformCapabilities) => set({ platformCapabilities }),
         beginConnection: () =>
           set({
@@ -75,6 +77,9 @@ export function createWalletSessionStore() {
           connectionKind: state.connectionKind,
           platformCapabilities: state.platformCapabilities,
         }),
+        onRehydrateStorage: () => (state) => {
+          state && (state.hasHydrated = true);
+        },
       }
     )
   );

--- a/apps/app/src/state/walletSessionStore.ts
+++ b/apps/app/src/state/walletSessionStore.ts
@@ -27,7 +27,7 @@ export type WalletSessionState = {
 export function createWalletSessionStore() {
   return createStore<WalletSessionState>()(
     persist(
-      (set, get) => ({
+      (set, get, store) => ({
         walletAddress: null,
         connectionKind: null,
         connectionOutcome: null,
@@ -63,7 +63,7 @@ export function createWalletSessionStore() {
             isConnecting: false,
           });
           // Also clear persisted storage so nothing survives across sessions
-          (get() as WalletSessionState & { persist?: { clearStorage: () => void } }).persist?.clearStorage();
+          store.persist.clearStorage();
         },
         clearOutcome: () => set({ connectionOutcome: null }),
       }),

--- a/apps/app/src/state/walletSessionStore.ts
+++ b/apps/app/src/state/walletSessionStore.ts
@@ -1,6 +1,19 @@
 import { createStore } from 'zustand/vanilla';
 import { persist, createJSONStorage } from 'zustand/middleware';
 import AsyncStorage from '@react-native-async-storage/async-storage';
+
+// AsyncStorage uses `window.localStorage` internally and crashes in Node.js/SSR.
+// Provide a no-op fallback for non-browser environments so static rendering works.
+const safeStorageFactory = () => {
+  if (typeof window !== 'undefined') {
+    return createJSONStorage(() => AsyncStorage);
+  }
+  return createJSONStorage(() => ({
+    getItem: () => null as string | null,
+    setItem: (_key: string, _value: string) => {},
+    removeItem: (_key: string) => {},
+  }));
+};
 import type { PlatformCapabilityState } from '@clmm/application/public';
 import type { ConnectionOutcome } from '@clmm/ui';
 
@@ -71,16 +84,19 @@ export function createWalletSessionStore() {
       }),
       {
         name: 'wallet-session',
-        storage: createJSONStorage(() => AsyncStorage),
+        storage: safeStorageFactory(),
         partialize: (state) => ({
           walletAddress: state.walletAddress,
           connectionKind: state.connectionKind,
           platformCapabilities: state.platformCapabilities,
         }),
-        onRehydrateStorage: () => (state) => {
+        onRehydrateStorage: () => (_state, _error) => {
           // Mark hydration complete so Zustand subscribers re-render with the
-          // rehydrated state. This uses set() from the initializer closure.
-          state && store.setState({ hasHydrated: true });
+          // rehydrated state. Guard with typeof window check to avoid crashing
+          // AsyncStorage (references `window`) during SSR static rendering.
+          if (typeof window !== 'undefined') {
+            store.setState({ hasHydrated: true });
+          }
         },
       }
     )

--- a/apps/app/src/state/walletSessionStore.ts
+++ b/apps/app/src/state/walletSessionStore.ts
@@ -26,9 +26,9 @@ export type WalletSessionState = {
 };
 
 export function createWalletSessionStore() {
-  return createStore<WalletSessionState>()(
+  const store = createStore<WalletSessionState>()(
     persist(
-      (set, get, store) => ({
+      (set, _get, store) => ({
         walletAddress: null,
         connectionKind: null,
         connectionOutcome: null,
@@ -78,11 +78,15 @@ export function createWalletSessionStore() {
           platformCapabilities: state.platformCapabilities,
         }),
         onRehydrateStorage: () => (state) => {
-          state && (state.hasHydrated = true);
+          // Mark hydration complete so Zustand subscribers re-render with the
+          // rehydrated state. This uses set() from the initializer closure.
+          state && store.setState({ hasHydrated: true });
         },
       }
     )
   );
+
+  return store;
 }
 
 export const walletSessionStore = createWalletSessionStore();

--- a/apps/app/src/state/walletSessionStore.ts
+++ b/apps/app/src/state/walletSessionStore.ts
@@ -1,4 +1,6 @@
 import { createStore } from 'zustand/vanilla';
+import { persist, createJSONStorage } from 'zustand/middleware';
+import AsyncStorage from '@react-native-async-storage/async-storage';
 import type { PlatformCapabilityState } from '@clmm/application/public';
 import type { ConnectionOutcome } from '@clmm/ui';
 
@@ -23,43 +25,59 @@ export type WalletSessionState = {
 };
 
 export function createWalletSessionStore() {
-  return createStore<WalletSessionState>((set) => ({
-    walletAddress: null,
-    connectionKind: null,
-    connectionOutcome: null,
-    platformCapabilities: null,
-    isConnecting: false,
-    setPlatformCapabilities: (platformCapabilities) => set({ platformCapabilities }),
-    beginConnection: () =>
-      set({
-        isConnecting: true,
-        connectionOutcome: null,
-        walletAddress: null,
-        connectionKind: null,
-      }),
-    markConnected: ({ walletAddress, connectionKind }) =>
-      set({
-        walletAddress,
-        connectionKind,
-        connectionOutcome: { kind: 'connected' },
-        isConnecting: false,
-      }),
-    markOutcome: (connectionOutcome) =>
-      set({
-        connectionOutcome,
-        isConnecting: false,
-        walletAddress: null,
-        connectionKind: null,
-      }),
-    disconnect: () =>
-      set({
+  return createStore<WalletSessionState>()(
+    persist(
+      (set, get) => ({
         walletAddress: null,
         connectionKind: null,
         connectionOutcome: null,
+        platformCapabilities: null,
         isConnecting: false,
+        setPlatformCapabilities: (platformCapabilities) => set({ platformCapabilities }),
+        beginConnection: () =>
+          set({
+            isConnecting: true,
+            connectionOutcome: null,
+            walletAddress: null,
+            connectionKind: null,
+          }),
+        markConnected: ({ walletAddress, connectionKind }) =>
+          set({
+            walletAddress,
+            connectionKind,
+            connectionOutcome: { kind: 'connected' },
+            isConnecting: false,
+          }),
+        markOutcome: (connectionOutcome) =>
+          set({
+            connectionOutcome,
+            isConnecting: false,
+            walletAddress: null,
+            connectionKind: null,
+          }),
+        disconnect: () => {
+          set({
+            walletAddress: null,
+            connectionKind: null,
+            connectionOutcome: null,
+            isConnecting: false,
+          });
+          // Also clear persisted storage so nothing survives across sessions
+          (get() as WalletSessionState & { persist?: { clearStorage: () => void } }).persist?.clearStorage();
+        },
+        clearOutcome: () => set({ connectionOutcome: null }),
       }),
-    clearOutcome: () => set({ connectionOutcome: null }),
-  }));
+      {
+        name: 'wallet-session',
+        storage: createJSONStorage(() => AsyncStorage),
+        partialize: (state) => ({
+          walletAddress: state.walletAddress,
+          connectionKind: state.connectionKind,
+          platformCapabilities: state.platformCapabilities,
+        }),
+      }
+    )
+  );
 }
 
 export const walletSessionStore = createWalletSessionStore();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,9 +47,9 @@ importers:
       '@expo/metro-runtime':
         specifier: ~4.0.1
         version: 4.0.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@react-native-community/cli@13.6.4(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@18.3.28)(bufferutil@4.1.0)(react@18.3.1)(utf-8-validate@6.0.6))
-      expo-modules-core:
-        specifier: ~2.2.3
-        version: 2.2.3
+      '@react-native-async-storage/async-storage':
+        specifier: ^2.1.0
+        version: 2.2.0(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@react-native-community/cli@13.6.4(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@18.3.28)(bufferutil@4.1.0)(react@18.3.1)(utf-8-validate@6.0.6))
       '@solana-mobile/mobile-wallet-adapter-protocol':
         specifier: ^2.2.6
         version: 2.2.6(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@react-native-community/cli@13.6.4(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@18.3.28)(bufferutil@4.1.0)(react@18.3.1)(utf-8-validate@6.0.6))(typescript@5.9.3)
@@ -71,6 +71,9 @@ importers:
       expo-linking:
         specifier: ~7.0.5
         version: 7.0.5(expo@52.0.49(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@react-native-community/cli@13.6.4(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@18.3.28)(bufferutil@4.1.0)(react@18.3.1)(utf-8-validate@6.0.6)))(bufferutil@4.1.0)(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@react-native-community/cli@13.6.4(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@18.3.28)(bufferutil@4.1.0)(react@18.3.1)(utf-8-validate@6.0.6))(react@18.3.1)(utf-8-validate@6.0.6))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@react-native-community/cli@13.6.4(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@18.3.28)(bufferutil@4.1.0)(react@18.3.1)(utf-8-validate@6.0.6))(react@18.3.1)
+      expo-modules-core:
+        specifier: ~2.2.3
+        version: 2.2.3
       expo-notifications:
         specifier: ~0.29.14
         version: 0.29.14(expo@52.0.49(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@react-native-community/cli@13.6.4(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@18.3.28)(bufferutil@4.1.0)(react@18.3.1)(utf-8-validate@6.0.6)))(bufferutil@4.1.0)(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@react-native-community/cli@13.6.4(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@18.3.28)(bufferutil@4.1.0)(react@18.3.1)(utf-8-validate@6.0.6))(react@18.3.1)(utf-8-validate@6.0.6))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@react-native-community/cli@13.6.4(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@18.3.28)(bufferutil@4.1.0)(react@18.3.1)(utf-8-validate@6.0.6))(react@18.3.1)
@@ -2011,6 +2014,11 @@ packages:
     resolution: {integrity: sha512-avutXAFL1ehGvAXtPquu0YK5oz6ctS474iM3vNGQIkswrVhdrS52e3uoMQBzZhNRAIE0jBnUyXWNmSjGHhCFcw==}
     peerDependencies:
       react: ^16.8 || ^17.0 || ^18.0
+
+  '@react-native-async-storage/async-storage@2.2.0':
+    resolution: {integrity: sha512-gvRvjR5JAaUZF8tv2Kcq/Gbt3JHwbKFYfmb445rhOj6NUMx3qPLixmDx5pZAyb9at1bYvJ4/eTUipU5aki45xw==}
+    peerDependencies:
+      react-native: ^0.0.0-0 || >=0.65 <1.0
 
   '@react-native-community/cli-clean@13.6.4':
     resolution: {integrity: sha512-nS1BJ+2Z+aLmqePxB4AYgJ+C/bgQt02xAgSYtCUv+lneRBGhL2tHRrK8/Iolp0y+yQoUtHHf4txYi90zGXLVfw==}
@@ -5116,6 +5124,10 @@ packages:
     resolution: {integrity: sha512-lJJV/5dYS+RcL8uQdBDW9c9uWFLLBNRyFhnAKXw5tVqLlKZ4RMGZKv+YQ/IA3OhD+RpbJa1LLFM1FQPGyIXvOA==}
     engines: {node: '>=12'}
 
+  is-plain-obj@2.1.0:
+    resolution: {integrity: sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==}
+    engines: {node: '>=8'}
+
   is-plain-object@2.0.4:
     resolution: {integrity: sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==}
     engines: {node: '>=0.10.0'}
@@ -5560,6 +5572,10 @@ packages:
   memoize@10.2.0:
     resolution: {integrity: sha512-DeC6b7QBrZsRs3Y02A6A7lQyzFbsQbqgjI6UW0GigGWV+u1s25TycMr0XHZE4cJce7rY/vyw2ctMQqfDkIhUEA==}
     engines: {node: '>=18'}
+
+  merge-options@3.0.4:
+    resolution: {integrity: sha512-2Sug1+knBjkaMsMgf1ctR1Ujx+Ayku4EdJN4Z+C2+JzoeF7A3OZ9KM2GY0CpQS51NR61LTurMJrRKPhSs3ZRTQ==}
+    engines: {node: '>=10'}
 
   merge-stream@2.0.0:
     resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
@@ -9491,6 +9507,11 @@ snapshots:
       '@radix-ui/react-compose-refs': 1.0.0(react@18.3.1)
       react: 18.3.1
 
+  '@react-native-async-storage/async-storage@2.2.0(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@react-native-community/cli@13.6.4(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@18.3.28)(bufferutil@4.1.0)(react@18.3.1)(utf-8-validate@6.0.6))':
+    dependencies:
+      merge-options: 3.0.4
+      react-native: 0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@react-native-community/cli@13.6.4(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@18.3.28)(bufferutil@4.1.0)(react@18.3.1)(utf-8-validate@6.0.6)
+
   '@react-native-community/cli-clean@13.6.4':
     dependencies:
       '@react-native-community/cli-tools': 13.6.4
@@ -13256,6 +13277,8 @@ snapshots:
 
   is-path-inside@4.0.0: {}
 
+  is-plain-obj@2.1.0: {}
+
   is-plain-object@2.0.4:
     dependencies:
       isobject: 3.0.1
@@ -13765,6 +13788,10 @@ snapshots:
   memoize@10.2.0:
     dependencies:
       mimic-function: 5.0.1
+
+  merge-options@3.0.4:
+    dependencies:
+      is-plain-obj: 2.1.0
 
   merge-stream@2.0.0: {}
 


### PR DESCRIPTION
Adds Zustand persist middleware to walletSessionStore to persist walletAddress/connectionKind/platformCapabilities across app restarts, while excluding transient UI state. Also clears persisted storage on disconnect and adds tests for rehydrate.