### PR TITLE
refactor(adapters): solana read path efficiency

### DIFF
--- a/packages/adapters/src/composition/AdaptersModule.ts
+++ b/packages/adapters/src/composition/AdaptersModule.ts
@@ -1,5 +1,6 @@
 import 'reflect-metadata';
 import { Module } from '@nestjs/common';
+import { SolanaPositionSnapshotReader } from '../outbound/solana-position-reads/SolanaPositionSnapshotReader.js';
 import { OrcaPositionReadAdapter } from '../outbound/solana-position-reads/OrcaPositionReadAdapter.js';
 import { SolanaRangeObservationAdapter } from '../outbound/solana-position-reads/SolanaRangeObservationAdapter.js';
 import { OperationalStorageAdapter } from '../outbound/storage/OperationalStorageAdapter.js';
@@ -46,13 +47,14 @@ const systemIds: IdGeneratorPort = {
   generateId: () => `${Date.now()}-${++_idCounter}`,
 };
 
-const orcaPositionRead = new OrcaPositionReadAdapter(rpcUrl);
+const snapshotReader = new SolanaPositionSnapshotReader(rpcUrl);
+const orcaPositionRead = new OrcaPositionReadAdapter(rpcUrl, snapshotReader, db);
 const rangeObservation = new SolanaRangeObservationAdapter(rpcUrl);
-const operationalStorage = new OperationalStorageAdapter(db, systemIds, orcaPositionRead);
+const operationalStorage = new OperationalStorageAdapter(db, systemIds);
 const historyStorage = new OffChainHistoryStorageAdapter(db);
 const monitoredWalletStorage = new MonitoredWalletStorageAdapter(db);
 const notificationDedupStorage = new NotificationDedupStorageAdapter(db);
-const solanaPreparation = new SolanaExecutionPreparationAdapter(rpcUrl);
+const solanaPreparation = new SolanaExecutionPreparationAdapter(rpcUrl, snapshotReader);
 const solanaSubmission = new SolanaExecutionSubmissionAdapter(rpcUrl);
 const durableNotificationEvent = new DurableNotificationEventAdapter(db, systemIds);
 const telemetry = new TelemetryAdapter();

--- a/packages/adapters/src/inbound/http/AppModule.ts
+++ b/packages/adapters/src/inbound/http/AppModule.ts
@@ -9,6 +9,7 @@ import { WalletController } from './WalletController.js';
 import { OperationalStorageAdapter } from '../../outbound/storage/OperationalStorageAdapter.js';
 import { OffChainHistoryStorageAdapter } from '../../outbound/storage/OffChainHistoryStorageAdapter.js';
 import { MonitoredWalletStorageAdapter } from '../../outbound/storage/MonitoredWalletStorageAdapter.js';
+import { SolanaPositionSnapshotReader } from '../../outbound/solana-position-reads/SolanaPositionSnapshotReader.js';
 import { OrcaPositionReadAdapter } from '../../outbound/solana-position-reads/OrcaPositionReadAdapter.js';
 import { JupiterQuoteAdapter } from '../../outbound/swap-execution/JupiterQuoteAdapter.js';
 import { SolanaExecutionPreparationAdapter } from '../../outbound/swap-execution/SolanaExecutionPreparationAdapter.js';
@@ -43,11 +44,12 @@ const systemIds: IdGeneratorPort = {
   generateId: () => `${Date.now()}-${++_idCounter}`,
 };
 
-const orcaPositionRead = new OrcaPositionReadAdapter(rpcUrl);
-const operationalStorage = new OperationalStorageAdapter(db, systemIds, orcaPositionRead);
+const snapshotReader = new SolanaPositionSnapshotReader(rpcUrl);
+const orcaPositionRead = new OrcaPositionReadAdapter(rpcUrl, snapshotReader, db);
+const operationalStorage = new OperationalStorageAdapter(db, systemIds);
 const historyStorage = new OffChainHistoryStorageAdapter(db);
 const jupiterQuote = new JupiterQuoteAdapter();
-const solanaPreparation = new SolanaExecutionPreparationAdapter(rpcUrl);
+const solanaPreparation = new SolanaExecutionPreparationAdapter(rpcUrl, snapshotReader);
 const solanaSubmission = new SolanaExecutionSubmissionAdapter(rpcUrl);
 const monitoredWalletStorage = new MonitoredWalletStorageAdapter(db);
 

--- a/packages/adapters/src/inbound/jobs/BreachScanJobHandler.ts
+++ b/packages/adapters/src/inbound/jobs/BreachScanJobHandler.ts
@@ -1,7 +1,7 @@
 /**
  * BreachScanJobHandler
  * pg-boss job handler — scans supported positions for breaches
- * Runs on a schedule (e.g., every 60 seconds) via WorkerModule
+ * Runs on a schedule (e.g., every 5 minutes) via WorkerModule
  */
 import { Inject, Injectable } from '@nestjs/common';
 import { scanPositionsForBreaches, recordExecutionAbandonment } from '@clmm/application';

--- a/packages/adapters/src/inbound/jobs/WorkerLifecycle.ts
+++ b/packages/adapters/src/inbound/jobs/WorkerLifecycle.ts
@@ -4,6 +4,7 @@ import { BreachScanJobHandler } from './BreachScanJobHandler.js';
 import { NotificationDispatchJobHandler } from './NotificationDispatchJobHandler.js';
 import { ReconciliationJobHandler } from './ReconciliationJobHandler.js';
 import { TriggerQualificationJobHandler } from './TriggerQualificationJobHandler.js';
+import { BREACH_SCAN_CRON } from './breach-scan-schedule.js';
 import { PG_BOSS_INSTANCE } from './tokens.js';
 
 @Injectable()
@@ -81,7 +82,7 @@ export class WorkerLifecycle implements OnModuleInit, OnModuleDestroy {
       },
     );
 
-    await this.boss.schedule(BreachScanJobHandler.JOB_NAME, '*/5 * * * *', {}, {
+    await this.boss.schedule(BreachScanJobHandler.JOB_NAME, BREACH_SCAN_CRON, {}, {
       tz: 'UTC',
     });
 

--- a/packages/adapters/src/inbound/jobs/breach-scan-schedule.ts
+++ b/packages/adapters/src/inbound/jobs/breach-scan-schedule.ts
@@ -1,0 +1,2 @@
+export const BREACH_SCAN_CRON = '*/5 * * * *';
+export const BREACH_SCAN_INTERVAL_MS = 5 * 60_000;

--- a/packages/adapters/src/index.ts
+++ b/packages/adapters/src/index.ts
@@ -8,6 +8,7 @@ export { NativeNotificationPermissionAdapter } from './outbound/capabilities/Nat
 export { WebNotificationPermissionAdapter } from './outbound/capabilities/WebNotificationPermissionAdapter';
 
 // Server-side adapters (imported by NestJS modules internally — re-exported for completeness)
+export { SolanaPositionSnapshotReader } from './outbound/solana-position-reads/SolanaPositionSnapshotReader';
 export { OrcaPositionReadAdapter } from './outbound/solana-position-reads/OrcaPositionReadAdapter';
 export { SolanaRangeObservationAdapter } from './outbound/solana-position-reads/SolanaRangeObservationAdapter';
 export { JupiterQuoteAdapter } from './outbound/swap-execution/JupiterQuoteAdapter';

--- a/packages/adapters/src/outbound/solana-position-reads/OrcaPositionReadAdapter.test.ts
+++ b/packages/adapters/src/outbound/solana-position-reads/OrcaPositionReadAdapter.test.ts
@@ -346,13 +346,28 @@ describe('OrcaPositionReadAdapter', () => {
         monitoringReadiness: { kind: 'active' },
       });
 
-      const adapter = new OrcaPositionReadAdapter(mockRpcUrl, mockReader, mockDb as never);
+      const insertedRows: Array<{ walletId: string; positionId: string }> = [];
+      const mockDbWithTracking = {
+        insert: () => ({
+          values: (row: { walletId: string; positionId: string }) => {
+            insertedRows.push(row);
+            return {
+              onConflictDoUpdate: () => Promise.resolve(),
+            };
+          },
+        }),
+      };
+
+      const adapter = new OrcaPositionReadAdapter(mockRpcUrl, mockReader, mockDbWithTracking as never);
       const result = await adapter.getPosition(MOCK_WALLET, makePositionId(MOCK_POSITION_MINT));
 
       expect(result).not.toBeNull();
       expect(result?.positionId).toBe(MOCK_POSITION_MINT);
       expect(result?.walletId).toBe(MOCK_WALLET);
       expect(result?.rangeState.kind).toBe('in-range');
+      expect(insertedRows).toHaveLength(1);
+      expect(insertedRows[0]?.walletId).toBe(MOCK_WALLET);
+      expect(insertedRows[0]?.positionId).toBe(makePositionId(MOCK_POSITION_MINT));
       // eslint-disable-next-line @typescript-eslint/unbound-method
       const fetchSinglePosition = mockReader.fetchSinglePosition;
       expect(fetchSinglePosition).toHaveBeenCalledOnce();

--- a/packages/adapters/src/outbound/solana-position-reads/OrcaPositionReadAdapter.test.ts
+++ b/packages/adapters/src/outbound/solana-position-reads/OrcaPositionReadAdapter.test.ts
@@ -252,6 +252,31 @@ describe('OrcaPositionReadAdapter', () => {
       expect(upsertedRows[0]!.walletId).toBe(MOCK_WALLET);
       expect(upsertedRows[0]!.positionId).toBe(MOCK_POSITION_MINT);
     });
+
+    it('excludes positions whose whirlpool data is missing from the batched reader result', async () => {
+      const { fetchPositionsForOwner } = await import('@orca-so/whirlpools');
+
+      vi.mocked(fetchPositionsForOwner).mockResolvedValue([
+        {
+          address: 'PositionAddress123456789012345678901234',
+          isPositionBundle: false,
+          data: {
+            whirlpool: MOCK_WHIRLPOOL,
+            tickLowerIndex: -18304,
+            tickUpperIndex: -17956,
+            positionMint: MOCK_POSITION_MINT,
+          },
+        },
+      ] as unknown as Awaited<ReturnType<typeof fetchPositionsForOwner>>);
+
+      const mockReader = new SolanaPositionSnapshotReader(mockRpcUrl);
+      vi.mocked(mockReader.fetchWhirlpoolsBatched).mockResolvedValue(new Map());
+
+      const adapter = new OrcaPositionReadAdapter(mockRpcUrl, mockReader, mockDb as never);
+      const positions = await adapter.listSupportedPositions(MOCK_WALLET);
+
+      expect(positions).toEqual([]);
+    });
   });
 
   describe('getPosition', () => {
@@ -274,6 +299,12 @@ describe('OrcaPositionReadAdapter', () => {
       expect(result?.positionId).toBe(MOCK_POSITION_MINT);
       expect(result?.walletId).toBe(MOCK_WALLET);
       expect(result?.rangeState.kind).toBe('in-range');
+      expect(mockReader.fetchSinglePosition).toHaveBeenCalledOnce();
+      expect(mockReader.fetchSinglePosition).toHaveBeenCalledWith(
+        expect.anything(),
+        makePositionId(MOCK_POSITION_MINT),
+        MOCK_WALLET,
+      );
     });
 
     it('returns null when the wallet does not own the requested position', async () => {

--- a/packages/adapters/src/outbound/solana-position-reads/OrcaPositionReadAdapter.test.ts
+++ b/packages/adapters/src/outbound/solana-position-reads/OrcaPositionReadAdapter.test.ts
@@ -3,16 +3,20 @@
  */
 import { describe, it, expect, vi } from 'vitest';
 import { OrcaPositionReadAdapter } from './OrcaPositionReadAdapter';
+import { SolanaPositionSnapshotReader } from './SolanaPositionSnapshotReader';
 import { makePositionId } from '@clmm/domain';
 import type { WalletId } from '@clmm/domain';
 
-// Mock the Orca SDK functions
-vi.mock('@orca-so/whirlpools', () => ({
-  fetchPositionsForOwner: vi.fn(),
+vi.mock('./SolanaPositionSnapshotReader', () => ({
+  SolanaPositionSnapshotReader: vi.fn().mockImplementation(() => ({
+    fetchSinglePosition: vi.fn(),
+    fetchWhirlpoolsBatched: vi.fn(),
+    getRpc: vi.fn(() => ({})),
+  })),
 }));
 
-vi.mock('@orca-so/whirlpools-client', () => ({
-  fetchWhirlpool: vi.fn(),
+vi.mock('@orca-so/whirlpools', () => ({
+  fetchPositionsForOwner: vi.fn(),
 }));
 
 // Valid base58 Solana addresses (32 bytes = 44 base58 chars)
@@ -23,10 +27,17 @@ const MOCK_WHIRLPOOL = '7qbRF6YsyGuLUVs6Y1q64bdVrfe4ZcUUz1JRdoVNUJnm';
 describe('OrcaPositionReadAdapter', () => {
   const mockRpcUrl = 'https://api.mainnet-beta.solana.com';
 
+  const mockDb = {
+    insert: () => ({
+      values: (row: { walletId: string; positionId: string; firstSeenAt: number; lastSeenAt: number }) => ({
+        onConflictDoUpdate: () => Promise.resolve(),
+      }),
+    }),
+  };
+
   describe('listSupportedPositions', () => {
     it('returns array of LiquidityPosition for wallet', async () => {
       const { fetchPositionsForOwner } = await import('@orca-so/whirlpools');
-      const { fetchWhirlpool } = await import('@orca-so/whirlpools-client');
 
       vi.mocked(fetchPositionsForOwner).mockResolvedValue([
         {
@@ -39,18 +50,14 @@ describe('OrcaPositionReadAdapter', () => {
             positionMint: MOCK_POSITION_MINT,
           },
         },
-        // boundary: Orca SDK Position type has many fields; test uses minimal shape
       ] as unknown as Awaited<ReturnType<typeof fetchPositionsForOwner>>);
 
-      vi.mocked(fetchWhirlpool).mockResolvedValue({
-        data: {
-          tickCurrentIndex: -18130,
-          sqrtPrice: 79228162514264337593543950336n,
-        },
-        // boundary: Orca SDK Whirlpool type has many fields; test uses minimal shape
-      } as unknown as Awaited<ReturnType<typeof fetchWhirlpool>>);
+      const mockReader = new SolanaPositionSnapshotReader(mockRpcUrl);
+      vi.mocked(mockReader.fetchWhirlpoolsBatched).mockResolvedValue(
+        new Map([[MOCK_WHIRLPOOL, { tickCurrentIndex: -18130 }]]),
+      );
 
-      const adapter = new OrcaPositionReadAdapter(mockRpcUrl);
+      const adapter = new OrcaPositionReadAdapter(mockRpcUrl, mockReader, mockDb as never);
       const positions = await adapter.listSupportedPositions(MOCK_WALLET);
 
       expect(Array.isArray(positions)).toBe(true);
@@ -60,7 +67,6 @@ describe('OrcaPositionReadAdapter', () => {
 
     it('computes correct rangeState when price is in range', async () => {
       const { fetchPositionsForOwner } = await import('@orca-so/whirlpools');
-      const { fetchWhirlpool } = await import('@orca-so/whirlpools-client');
 
       vi.mocked(fetchPositionsForOwner).mockResolvedValue([
         {
@@ -73,18 +79,14 @@ describe('OrcaPositionReadAdapter', () => {
             positionMint: MOCK_POSITION_MINT,
           },
         },
-        // boundary: Orca SDK Position type has many fields; test uses minimal shape
       ] as unknown as Awaited<ReturnType<typeof fetchPositionsForOwner>>);
 
-      vi.mocked(fetchWhirlpool).mockResolvedValue({
-        data: {
-          tickCurrentIndex: -18130,
-          sqrtPrice: 79228162514264337593543950336n,
-        },
-        // boundary: Orca SDK Whirlpool type has many fields; test uses minimal shape
-      } as unknown as Awaited<ReturnType<typeof fetchWhirlpool>>);
+      const mockReader = new SolanaPositionSnapshotReader(mockRpcUrl);
+      vi.mocked(mockReader.fetchWhirlpoolsBatched).mockResolvedValue(
+        new Map([[MOCK_WHIRLPOOL, { tickCurrentIndex: -18130 }]]),
+      );
 
-      const adapter = new OrcaPositionReadAdapter(mockRpcUrl);
+      const adapter = new OrcaPositionReadAdapter(mockRpcUrl, mockReader, mockDb as never);
       const positions = await adapter.listSupportedPositions(MOCK_WALLET);
 
       expect(positions[0]!.rangeState.kind).toBe('in-range');
@@ -92,7 +94,6 @@ describe('OrcaPositionReadAdapter', () => {
 
     it('computes below-range when current tick is below lower bound', async () => {
       const { fetchPositionsForOwner } = await import('@orca-so/whirlpools');
-      const { fetchWhirlpool } = await import('@orca-so/whirlpools-client');
 
       vi.mocked(fetchPositionsForOwner).mockResolvedValue([
         {
@@ -105,18 +106,14 @@ describe('OrcaPositionReadAdapter', () => {
             positionMint: MOCK_POSITION_MINT,
           },
         },
-        // boundary: Orca SDK Position type has many fields; test uses minimal shape
       ] as unknown as Awaited<ReturnType<typeof fetchPositionsForOwner>>);
 
-      vi.mocked(fetchWhirlpool).mockResolvedValue({
-        data: {
-          tickCurrentIndex: -20000,
-          sqrtPrice: 79228162514264337593543950336n,
-        },
-        // boundary: Orca SDK Whirlpool type has many fields; test uses minimal shape
-      } as unknown as Awaited<ReturnType<typeof fetchWhirlpool>>);
+      const mockReader = new SolanaPositionSnapshotReader(mockRpcUrl);
+      vi.mocked(mockReader.fetchWhirlpoolsBatched).mockResolvedValue(
+        new Map([[MOCK_WHIRLPOOL, { tickCurrentIndex: -20000 }]]),
+      );
 
-      const adapter = new OrcaPositionReadAdapter(mockRpcUrl);
+      const adapter = new OrcaPositionReadAdapter(mockRpcUrl, mockReader, mockDb as never);
       const positions = await adapter.listSupportedPositions(MOCK_WALLET);
 
       expect(positions[0]!.rangeState.kind).toBe('below-range');
@@ -124,7 +121,6 @@ describe('OrcaPositionReadAdapter', () => {
 
     it('computes above-range when current tick is above upper bound', async () => {
       const { fetchPositionsForOwner } = await import('@orca-so/whirlpools');
-      const { fetchWhirlpool } = await import('@orca-so/whirlpools-client');
 
       vi.mocked(fetchPositionsForOwner).mockResolvedValue([
         {
@@ -137,18 +133,14 @@ describe('OrcaPositionReadAdapter', () => {
             positionMint: MOCK_POSITION_MINT,
           },
         },
-        // boundary: Orca SDK Position type has many fields; test uses minimal shape
       ] as unknown as Awaited<ReturnType<typeof fetchPositionsForOwner>>);
 
-      vi.mocked(fetchWhirlpool).mockResolvedValue({
-        data: {
-          tickCurrentIndex: 0,
-          sqrtPrice: 79228162514264337593543950336n,
-        },
-        // boundary: Orca SDK Whirlpool type has many fields; test uses minimal shape
-      } as unknown as Awaited<ReturnType<typeof fetchWhirlpool>>);
+      const mockReader = new SolanaPositionSnapshotReader(mockRpcUrl);
+      vi.mocked(mockReader.fetchWhirlpoolsBatched).mockResolvedValue(
+        new Map([[MOCK_WHIRLPOOL, { tickCurrentIndex: 0 }]]),
+      );
 
-      const adapter = new OrcaPositionReadAdapter(mockRpcUrl);
+      const adapter = new OrcaPositionReadAdapter(mockRpcUrl, mockReader, mockDb as never);
       const positions = await adapter.listSupportedPositions(MOCK_WALLET);
 
       expect(positions[0]!.rangeState.kind).toBe('above-range');
@@ -156,7 +148,6 @@ describe('OrcaPositionReadAdapter', () => {
 
     it('skips position bundles', async () => {
       const { fetchPositionsForOwner } = await import('@orca-so/whirlpools');
-      const { fetchWhirlpool } = await import('@orca-so/whirlpools-client');
 
       vi.mocked(fetchPositionsForOwner).mockResolvedValue([
         {
@@ -174,18 +165,14 @@ describe('OrcaPositionReadAdapter', () => {
             positionMint: MOCK_POSITION_MINT,
           },
         },
-        // boundary: Orca SDK Position type has many fields; test uses minimal shape
       ] as unknown as Awaited<ReturnType<typeof fetchPositionsForOwner>>);
 
-      vi.mocked(fetchWhirlpool).mockResolvedValue({
-        data: {
-          tickCurrentIndex: -7500,
-          sqrtPrice: 79228162514264337593543950336n,
-        },
-        // boundary: Orca SDK Whirlpool type has many fields; test uses minimal shape
-      } as unknown as Awaited<ReturnType<typeof fetchWhirlpool>>);
+      const mockReader = new SolanaPositionSnapshotReader(mockRpcUrl);
+      vi.mocked(mockReader.fetchWhirlpoolsBatched).mockResolvedValue(
+        new Map([[MOCK_WHIRLPOOL, { tickCurrentIndex: -7500 }]]),
+      );
 
-      const adapter = new OrcaPositionReadAdapter(mockRpcUrl);
+      const adapter = new OrcaPositionReadAdapter(mockRpcUrl, mockReader, mockDb as never);
       const positions = await adapter.listSupportedPositions(MOCK_WALLET);
 
       expect(positions.length).toBe(1);
@@ -193,7 +180,6 @@ describe('OrcaPositionReadAdapter', () => {
 
     it('returns bundled positions owned by the wallet', async () => {
       const { fetchPositionsForOwner } = await import('@orca-so/whirlpools');
-      const { fetchWhirlpool } = await import('@orca-so/whirlpools-client');
 
       vi.mocked(fetchPositionsForOwner).mockResolvedValue([
         {
@@ -211,30 +197,23 @@ describe('OrcaPositionReadAdapter', () => {
             },
           ],
         },
-        // boundary: Orca SDK bundled position shape is broader; test uses minimal shape
       ] as unknown as Awaited<ReturnType<typeof fetchPositionsForOwner>>);
 
-      vi.mocked(fetchWhirlpool).mockResolvedValue({
-        data: {
-          tickCurrentIndex: -18130,
-          sqrtPrice: 79228162514264337593543950336n,
-        },
-        // boundary: Orca SDK Whirlpool type has many fields; test uses minimal shape
-      } as unknown as Awaited<ReturnType<typeof fetchWhirlpool>>);
+      const mockReader = new SolanaPositionSnapshotReader(mockRpcUrl);
+      vi.mocked(mockReader.fetchWhirlpoolsBatched).mockResolvedValue(
+        new Map([[MOCK_WHIRLPOOL, { tickCurrentIndex: -18130 }]]),
+      );
 
-      const adapter = new OrcaPositionReadAdapter(mockRpcUrl);
+      const adapter = new OrcaPositionReadAdapter(mockRpcUrl, mockReader, mockDb as never);
       const positions = await adapter.listSupportedPositions(MOCK_WALLET);
 
       expect(positions).toHaveLength(1);
       expect(positions[0]!.positionId).toBe(MOCK_POSITION_MINT);
       expect(positions[0]!.rangeState.kind).toBe('in-range');
     });
-  });
 
-  describe('getPosition', () => {
-    it('returns the requested position when the wallet owns it', async () => {
+    it('scan-time ownership writes upserts wallet_position_ownership for each position found during listSupportedPositions', async () => {
       const { fetchPositionsForOwner } = await import('@orca-so/whirlpools');
-      const { fetchWhirlpool } = await import('@orca-so/whirlpools-client');
 
       vi.mocked(fetchPositionsForOwner).mockResolvedValue([
         {
@@ -249,14 +228,46 @@ describe('OrcaPositionReadAdapter', () => {
         },
       ] as unknown as Awaited<ReturnType<typeof fetchPositionsForOwner>>);
 
-      vi.mocked(fetchWhirlpool).mockResolvedValue({
-        data: {
-          tickCurrentIndex: -18130,
-          sqrtPrice: 79228162514264337593543950336n,
-        },
-      } as unknown as Awaited<ReturnType<typeof fetchWhirlpool>>);
+      const mockReader = new SolanaPositionSnapshotReader(mockRpcUrl);
+      vi.mocked(mockReader.fetchWhirlpoolsBatched).mockResolvedValue(
+        new Map([[MOCK_WHIRLPOOL, { tickCurrentIndex: -18130 }]]),
+      );
 
-      const adapter = new OrcaPositionReadAdapter(mockRpcUrl);
+      const upsertedRows: Array<{ walletId: string; positionId: string }> = [];
+      const mockDbWithTracking = {
+        insert: () => ({
+          values: (row: { walletId: string; positionId: string }) => {
+            upsertedRows.push(row);
+            return {
+              onConflictDoUpdate: () => Promise.resolve(),
+            };
+          },
+        }),
+      };
+
+      const adapter = new OrcaPositionReadAdapter(mockRpcUrl, mockReader, mockDbWithTracking as never);
+      await adapter.listSupportedPositions(MOCK_WALLET);
+
+      expect(upsertedRows).toHaveLength(1);
+      expect(upsertedRows[0]!.walletId).toBe(MOCK_WALLET);
+      expect(upsertedRows[0]!.positionId).toBe(MOCK_POSITION_MINT);
+    });
+  });
+
+  describe('getPosition', () => {
+    it('returns the requested position when the wallet owns it', async () => {
+      const mockReader = new SolanaPositionSnapshotReader(mockRpcUrl);
+      vi.mocked(mockReader.fetchSinglePosition).mockResolvedValue({
+        positionId: makePositionId(MOCK_POSITION_MINT),
+        walletId: MOCK_WALLET,
+        poolId: MOCK_WHIRLPOOL as any,
+        bounds: { lowerBound: -18304, upperBound: -17956 },
+        lastObservedAt: 1_000_000 as any,
+        rangeState: { kind: 'in-range', currentPrice: -18130 },
+        monitoringReadiness: { kind: 'active' },
+      });
+
+      const adapter = new OrcaPositionReadAdapter(mockRpcUrl, mockReader, mockDb as never);
       const result = await adapter.getPosition(MOCK_WALLET, makePositionId(MOCK_POSITION_MINT));
 
       expect(result).not.toBeNull();
@@ -266,30 +277,10 @@ describe('OrcaPositionReadAdapter', () => {
     });
 
     it('returns null when the wallet does not own the requested position', async () => {
-      const { fetchPositionsForOwner } = await import('@orca-so/whirlpools');
-      const { fetchWhirlpool } = await import('@orca-so/whirlpools-client');
+      const mockReader = new SolanaPositionSnapshotReader(mockRpcUrl);
+      vi.mocked(mockReader.fetchSinglePosition).mockResolvedValue(null);
 
-      vi.mocked(fetchPositionsForOwner).mockResolvedValue([
-        {
-          address: 'PositionAddress123456789012345678901234',
-          isPositionBundle: false,
-          data: {
-            whirlpool: MOCK_WHIRLPOOL,
-            tickLowerIndex: -18304,
-            tickUpperIndex: -17956,
-            positionMint: MOCK_POSITION_MINT,
-          },
-        },
-      ] as unknown as Awaited<ReturnType<typeof fetchPositionsForOwner>>);
-
-      vi.mocked(fetchWhirlpool).mockResolvedValue({
-        data: {
-          tickCurrentIndex: -18130,
-          sqrtPrice: 79228162514264337593543950336n,
-        },
-      } as unknown as Awaited<ReturnType<typeof fetchWhirlpool>>);
-
-      const adapter = new OrcaPositionReadAdapter(mockRpcUrl);
+      const adapter = new OrcaPositionReadAdapter(mockRpcUrl, mockReader, mockDb as never);
       const result = await adapter.getPosition(
         MOCK_WALLET,
         makePositionId('9w7A9sXjC8eGdxzpcM8f7mPy8tLQGvY1z9WnK3m2LcQa'),

--- a/packages/adapters/src/outbound/solana-position-reads/OrcaPositionReadAdapter.test.ts
+++ b/packages/adapters/src/outbound/solana-position-reads/OrcaPositionReadAdapter.test.ts
@@ -253,6 +253,60 @@ describe('OrcaPositionReadAdapter', () => {
       expect(upsertedRows[0]!.positionId).toBe(MOCK_POSITION_MINT);
     });
 
+    it('upserts ownership rows even when a whirlpool lookup fails for one scanned position', async () => {
+      const { fetchPositionsForOwner } = await import('@orca-so/whirlpools');
+
+      vi.mocked(fetchPositionsForOwner).mockResolvedValue([
+        {
+          address: 'PositionAddress123456789012345678901234',
+          isPositionBundle: false,
+          data: {
+            whirlpool: MOCK_WHIRLPOOL,
+            tickLowerIndex: -18304,
+            tickUpperIndex: -17956,
+            positionMint: MOCK_POSITION_MINT,
+          },
+        },
+        {
+          address: 'PositionAddress223456789012345678901234',
+          isPositionBundle: false,
+          data: {
+            whirlpool: 'missing-whirlpool-1',
+            tickLowerIndex: -1000,
+            tickUpperIndex: 1000,
+            positionMint: makePositionId('missing-position-1'),
+          },
+        },
+      ] as unknown as Awaited<ReturnType<typeof fetchPositionsForOwner>>);
+
+      const mockReader = new SolanaPositionSnapshotReader(mockRpcUrl);
+      mockReader.fetchWhirlpoolsBatched = vi.fn().mockResolvedValue(
+        new Map([[MOCK_WHIRLPOOL, { tickCurrentIndex: -18130 }]]),
+      );
+
+      const upsertedRows: Array<{ walletId: string; positionId: string }> = [];
+      const mockDbWithTracking = {
+        insert: () => ({
+          values: (row: { walletId: string; positionId: string }) => {
+            upsertedRows.push(row);
+            return {
+              onConflictDoUpdate: () => Promise.resolve(),
+            };
+          },
+        }),
+      };
+
+      const adapter = new OrcaPositionReadAdapter(mockRpcUrl, mockReader, mockDbWithTracking as never);
+      const positions = await adapter.listSupportedPositions(MOCK_WALLET);
+
+      expect(positions).toHaveLength(1);
+      expect(upsertedRows).toHaveLength(2);
+      expect(upsertedRows.map((row) => row.positionId)).toEqual([
+        MOCK_POSITION_MINT,
+        makePositionId('missing-position-1'),
+      ]);
+    });
+
     it('excludes positions whose whirlpool data is missing from the batched reader result', async () => {
       const { fetchPositionsForOwner } = await import('@orca-so/whirlpools');
 

--- a/packages/adapters/src/outbound/solana-position-reads/OrcaPositionReadAdapter.test.ts
+++ b/packages/adapters/src/outbound/solana-position-reads/OrcaPositionReadAdapter.test.ts
@@ -29,7 +29,7 @@ describe('OrcaPositionReadAdapter', () => {
 
   const mockDb = {
     insert: () => ({
-      values: (row: { walletId: string; positionId: string; firstSeenAt: number; lastSeenAt: number }) => ({
+      values: (_row: { walletId: string; positionId: string; firstSeenAt: number; lastSeenAt: number }) => ({
         onConflictDoUpdate: () => Promise.resolve(),
       }),
     }),
@@ -53,7 +53,7 @@ describe('OrcaPositionReadAdapter', () => {
       ] as unknown as Awaited<ReturnType<typeof fetchPositionsForOwner>>);
 
       const mockReader = new SolanaPositionSnapshotReader(mockRpcUrl);
-      vi.mocked(mockReader.fetchWhirlpoolsBatched).mockResolvedValue(
+      mockReader.fetchWhirlpoolsBatched = vi.fn().mockResolvedValue(
         new Map([[MOCK_WHIRLPOOL, { tickCurrentIndex: -18130 }]]),
       );
 
@@ -82,7 +82,7 @@ describe('OrcaPositionReadAdapter', () => {
       ] as unknown as Awaited<ReturnType<typeof fetchPositionsForOwner>>);
 
       const mockReader = new SolanaPositionSnapshotReader(mockRpcUrl);
-      vi.mocked(mockReader.fetchWhirlpoolsBatched).mockResolvedValue(
+      mockReader.fetchWhirlpoolsBatched = vi.fn().mockResolvedValue(
         new Map([[MOCK_WHIRLPOOL, { tickCurrentIndex: -18130 }]]),
       );
 
@@ -109,7 +109,7 @@ describe('OrcaPositionReadAdapter', () => {
       ] as unknown as Awaited<ReturnType<typeof fetchPositionsForOwner>>);
 
       const mockReader = new SolanaPositionSnapshotReader(mockRpcUrl);
-      vi.mocked(mockReader.fetchWhirlpoolsBatched).mockResolvedValue(
+      mockReader.fetchWhirlpoolsBatched = vi.fn().mockResolvedValue(
         new Map([[MOCK_WHIRLPOOL, { tickCurrentIndex: -20000 }]]),
       );
 
@@ -136,7 +136,7 @@ describe('OrcaPositionReadAdapter', () => {
       ] as unknown as Awaited<ReturnType<typeof fetchPositionsForOwner>>);
 
       const mockReader = new SolanaPositionSnapshotReader(mockRpcUrl);
-      vi.mocked(mockReader.fetchWhirlpoolsBatched).mockResolvedValue(
+      mockReader.fetchWhirlpoolsBatched = vi.fn().mockResolvedValue(
         new Map([[MOCK_WHIRLPOOL, { tickCurrentIndex: 0 }]]),
       );
 
@@ -168,7 +168,7 @@ describe('OrcaPositionReadAdapter', () => {
       ] as unknown as Awaited<ReturnType<typeof fetchPositionsForOwner>>);
 
       const mockReader = new SolanaPositionSnapshotReader(mockRpcUrl);
-      vi.mocked(mockReader.fetchWhirlpoolsBatched).mockResolvedValue(
+      mockReader.fetchWhirlpoolsBatched = vi.fn().mockResolvedValue(
         new Map([[MOCK_WHIRLPOOL, { tickCurrentIndex: -7500 }]]),
       );
 
@@ -200,7 +200,7 @@ describe('OrcaPositionReadAdapter', () => {
       ] as unknown as Awaited<ReturnType<typeof fetchPositionsForOwner>>);
 
       const mockReader = new SolanaPositionSnapshotReader(mockRpcUrl);
-      vi.mocked(mockReader.fetchWhirlpoolsBatched).mockResolvedValue(
+      mockReader.fetchWhirlpoolsBatched = vi.fn().mockResolvedValue(
         new Map([[MOCK_WHIRLPOOL, { tickCurrentIndex: -18130 }]]),
       );
 
@@ -229,7 +229,7 @@ describe('OrcaPositionReadAdapter', () => {
       ] as unknown as Awaited<ReturnType<typeof fetchPositionsForOwner>>);
 
       const mockReader = new SolanaPositionSnapshotReader(mockRpcUrl);
-      vi.mocked(mockReader.fetchWhirlpoolsBatched).mockResolvedValue(
+      mockReader.fetchWhirlpoolsBatched = vi.fn().mockResolvedValue(
         new Map([[MOCK_WHIRLPOOL, { tickCurrentIndex: -18130 }]]),
       );
 
@@ -270,7 +270,7 @@ describe('OrcaPositionReadAdapter', () => {
       ] as unknown as Awaited<ReturnType<typeof fetchPositionsForOwner>>);
 
       const mockReader = new SolanaPositionSnapshotReader(mockRpcUrl);
-      vi.mocked(mockReader.fetchWhirlpoolsBatched).mockResolvedValue(new Map());
+      mockReader.fetchWhirlpoolsBatched = vi.fn().mockResolvedValue(new Map());
 
       const adapter = new OrcaPositionReadAdapter(mockRpcUrl, mockReader, mockDb as never);
       const positions = await adapter.listSupportedPositions(MOCK_WALLET);
@@ -282,12 +282,12 @@ describe('OrcaPositionReadAdapter', () => {
   describe('getPosition', () => {
     it('returns the requested position when the wallet owns it', async () => {
       const mockReader = new SolanaPositionSnapshotReader(mockRpcUrl);
-      vi.mocked(mockReader.fetchSinglePosition).mockResolvedValue({
+      mockReader.fetchSinglePosition = vi.fn().mockResolvedValue({
         positionId: makePositionId(MOCK_POSITION_MINT),
         walletId: MOCK_WALLET,
-        poolId: MOCK_WHIRLPOOL as any,
+        poolId: MOCK_WHIRLPOOL,
         bounds: { lowerBound: -18304, upperBound: -17956 },
-        lastObservedAt: 1_000_000 as any,
+        lastObservedAt: 1_000_000,
         rangeState: { kind: 'in-range', currentPrice: -18130 },
         monitoringReadiness: { kind: 'active' },
       });
@@ -299,8 +299,10 @@ describe('OrcaPositionReadAdapter', () => {
       expect(result?.positionId).toBe(MOCK_POSITION_MINT);
       expect(result?.walletId).toBe(MOCK_WALLET);
       expect(result?.rangeState.kind).toBe('in-range');
-      expect(mockReader.fetchSinglePosition).toHaveBeenCalledOnce();
-      expect(mockReader.fetchSinglePosition).toHaveBeenCalledWith(
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      const fetchSinglePosition = mockReader.fetchSinglePosition;
+      expect(fetchSinglePosition).toHaveBeenCalledOnce();
+      expect(fetchSinglePosition).toHaveBeenCalledWith(
         expect.anything(),
         makePositionId(MOCK_POSITION_MINT),
         MOCK_WALLET,
@@ -309,7 +311,7 @@ describe('OrcaPositionReadAdapter', () => {
 
     it('returns null when the wallet does not own the requested position', async () => {
       const mockReader = new SolanaPositionSnapshotReader(mockRpcUrl);
-      vi.mocked(mockReader.fetchSinglePosition).mockResolvedValue(null);
+      mockReader.fetchSinglePosition = vi.fn().mockResolvedValue(null);
 
       const adapter = new OrcaPositionReadAdapter(mockRpcUrl, mockReader, mockDb as never);
       const result = await adapter.getPosition(

--- a/packages/adapters/src/outbound/solana-position-reads/OrcaPositionReadAdapter.ts
+++ b/packages/adapters/src/outbound/solana-position-reads/OrcaPositionReadAdapter.ts
@@ -183,6 +183,25 @@ export class OrcaPositionReadAdapter implements SupportedPositionReadPort {
 
   async getPosition(walletId: WalletId, positionId: PositionId): Promise<LiquidityPosition | null> {
     const rpc = this.getRpc();
-    return this.snapshotReader.fetchSinglePosition(rpc, positionId, walletId);
+    const position = await this.snapshotReader.fetchSinglePosition(rpc, positionId, walletId);
+    if (!position) {
+      return null;
+    }
+
+    const now = Date.now();
+    await this.db
+      .insert(walletPositionOwnership)
+      .values({
+        walletId,
+        positionId,
+        firstSeenAt: now,
+        lastSeenAt: now,
+      })
+      .onConflictDoUpdate({
+        target: [walletPositionOwnership.walletId, walletPositionOwnership.positionId],
+        set: { lastSeenAt: now },
+      });
+
+    return position;
   }
 }

--- a/packages/adapters/src/outbound/solana-position-reads/OrcaPositionReadAdapter.ts
+++ b/packages/adapters/src/outbound/solana-position-reads/OrcaPositionReadAdapter.ts
@@ -163,12 +163,12 @@ export class OrcaPositionReadAdapter implements SupportedPositionReadPort {
     }
 
     const now = Date.now();
-    for (const position of liquidityPositions) {
+    for (const entry of allEntries) {
       await this.db
         .insert(walletPositionOwnership)
         .values({
           walletId,
-          positionId: position.positionId,
+          positionId: makePositionId(entry.positionMint),
           firstSeenAt: now,
           lastSeenAt: now,
         })

--- a/packages/adapters/src/outbound/solana-position-reads/OrcaPositionReadAdapter.ts
+++ b/packages/adapters/src/outbound/solana-position-reads/OrcaPositionReadAdapter.ts
@@ -10,7 +10,6 @@
 import { createSolanaRpc, address } from '@solana/kit';
 import type { Address } from '@solana/kit';
 import { fetchPositionsForOwner } from '@orca-so/whirlpools';
-import { fetchWhirlpool } from '@orca-so/whirlpools-client';
 
 import type { SupportedPositionReadPort } from '@clmm/application';
 import type { LiquidityPosition, WalletId, PositionId } from '@clmm/domain';
@@ -21,8 +20,16 @@ import {
   evaluateRangeState,
 } from '@clmm/domain';
 
+import { SolanaPositionSnapshotReader } from './SolanaPositionSnapshotReader.js';
+import type { Db } from '../storage/db.js';
+import { walletPositionOwnership } from '../storage/schema/index.js';
+
 export class OrcaPositionReadAdapter implements SupportedPositionReadPort {
-  constructor(private readonly rpcUrl: string) {}
+  constructor(
+    private readonly rpcUrl: string,
+    private readonly snapshotReader: SolanaPositionSnapshotReader,
+    private readonly db: Db,
+  ) {}
 
   private isOwnedPositionEntry(value: unknown): value is {
     whirlpool: Address | string;
@@ -104,47 +111,78 @@ export class OrcaPositionReadAdapter implements SupportedPositionReadPort {
 
     const positions = await fetchPositionsForOwner(rpc, ownerAddress);
 
-    const liquidityPositions: LiquidityPosition[] = [];
+    const allEntries: Array<{
+      whirlpool: string;
+      tickLowerIndex: number;
+      tickUpperIndex: number;
+      positionMint: string;
+    }> = [];
 
     for (const positionData of positions) {
-      for (const position of this.getOwnedPositionEntries(positionData)) {
-        const whirlpoolAddress = position.whirlpool;
-
-        let whirlpoolData;
-        try {
-          whirlpoolData = await fetchWhirlpool(rpc, address(whirlpoolAddress.toString()));
-        } catch {
-          continue;
-        }
-
-        const poolId = makePoolId(whirlpoolAddress.toString());
-        const positionId = makePositionId(position.positionMint.toString());
-
-        const bounds = {
-          lowerBound: position.tickLowerIndex,
-          upperBound: position.tickUpperIndex,
-        };
-
-        const currentTick = whirlpoolData.data.tickCurrentIndex;
-        const rangeState = evaluateRangeState(bounds, currentTick);
-
-        liquidityPositions.push({
-          positionId,
-          walletId,
-          poolId,
-          bounds,
-          lastObservedAt: makeClockTimestamp(Date.now()),
-          rangeState,
-          monitoringReadiness: { kind: 'active' },
+      for (const entry of this.getOwnedPositionEntries(positionData)) {
+        allEntries.push({
+          whirlpool: entry.whirlpool.toString(),
+          tickLowerIndex: entry.tickLowerIndex,
+          tickUpperIndex: entry.tickUpperIndex,
+          positionMint: entry.positionMint.toString(),
         });
       }
+    }
+
+    const whirlpoolAddresses = allEntries.map((e) => e.whirlpool);
+    const whirlpoolMap = await this.snapshotReader.fetchWhirlpoolsBatched(rpc, whirlpoolAddresses);
+
+    const liquidityPositions: LiquidityPosition[] = [];
+
+    for (const entry of allEntries) {
+      const whirlpoolData = whirlpoolMap.get(entry.whirlpool);
+      if (!whirlpoolData) {
+        continue;
+      }
+
+      const poolId = makePoolId(entry.whirlpool);
+      const positionId = makePositionId(entry.positionMint);
+
+      const bounds = {
+        lowerBound: entry.tickLowerIndex,
+        upperBound: entry.tickUpperIndex,
+      };
+
+      const currentTick = whirlpoolData.tickCurrentIndex;
+      const rangeState = evaluateRangeState(bounds, currentTick);
+
+      liquidityPositions.push({
+        positionId,
+        walletId,
+        poolId,
+        bounds,
+        lastObservedAt: makeClockTimestamp(Date.now()),
+        rangeState,
+        monitoringReadiness: { kind: 'active' },
+      });
+    }
+
+    const now = Date.now();
+    for (const position of liquidityPositions) {
+      await this.db
+        .insert(walletPositionOwnership)
+        .values({
+          walletId,
+          positionId: position.positionId,
+          firstSeenAt: now,
+          lastSeenAt: now,
+        })
+        .onConflictDoUpdate({
+          target: [walletPositionOwnership.walletId, walletPositionOwnership.positionId],
+          set: { lastSeenAt: now },
+        });
     }
 
     return liquidityPositions;
   }
 
   async getPosition(walletId: WalletId, positionId: PositionId): Promise<LiquidityPosition | null> {
-    const positions = await this.listSupportedPositions(walletId);
-    return positions.find((position) => position.positionId === positionId) ?? null;
+    const rpc = this.getRpc();
+    return this.snapshotReader.fetchSinglePosition(rpc, positionId, walletId);
   }
 }

--- a/packages/adapters/src/outbound/solana-position-reads/SolanaPositionSnapshotReader.test.ts
+++ b/packages/adapters/src/outbound/solana-position-reads/SolanaPositionSnapshotReader.test.ts
@@ -247,5 +247,37 @@ describe('SolanaPositionSnapshotReader', () => {
 
       expect(result.size).toBe(0);
     });
+
+    it('limits concurrent whirlpool fetches while still returning all successful results', async () => {
+      const { fetchWhirlpool } = await import('@orca-so/whirlpools-client');
+      const reader = new SolanaPositionSnapshotReader('https://api.mainnet-beta.solana.com');
+      const rpc = {} as ReturnType<typeof createSolanaRpc>;
+
+      let inFlight = 0;
+      let maxInFlight = 0;
+
+      vi.mocked(fetchWhirlpool).mockImplementation(async (_rpc: unknown, addr: { toString: () => string }) => {
+        inFlight += 1;
+        maxInFlight = Math.max(maxInFlight, inFlight);
+
+        await new Promise((resolve) => setTimeout(resolve, 5));
+
+        inFlight -= 1;
+        return {
+          data: { tickCurrentIndex: Number(addr.toString().slice(-1)) },
+        } as never;
+      });
+
+      const result = await reader.fetchWhirlpoolsBatched(rpc, [
+        '7qbRF6YsyGuLUVs6Y1q64bdVrfe4ZcUUz1JRdoVNUJnm',
+        '8qbRF6YsyGuLUVs6Y1q64bdVrfe4ZcUUz1JRdoVNUJno',
+        '9qbRF6YsyGuLUVs6Y1q64bdVrfe4ZcUUz1JRdoVNUJnp',
+        'AqbRF6YsyGuLUVs6Y1q64bdVrfe4ZcUUz1JRdoVNUJnq',
+        'BqbRF6YsyGuLUVs6Y1q64bdVrfe4ZcUUz1JRdoVNUJnr',
+      ]);
+
+      expect(result.size).toBe(5);
+      expect(maxInFlight).toBeLessThanOrEqual(2);
+    });
   });
 });

--- a/packages/adapters/src/outbound/solana-position-reads/SolanaPositionSnapshotReader.test.ts
+++ b/packages/adapters/src/outbound/solana-position-reads/SolanaPositionSnapshotReader.test.ts
@@ -1,0 +1,251 @@
+/**
+ * SolanaPositionSnapshotReader TDD tests
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { SolanaPositionSnapshotReader } from './SolanaPositionSnapshotReader';
+import type { WalletId, PositionId } from '@clmm/domain';
+import { address, createSolanaRpc } from '@solana/kit';
+
+vi.mock('@orca-so/whirlpools-client', () => ({
+  getPositionAddress: vi.fn(),
+  fetchPosition: vi.fn(),
+  fetchWhirlpool: vi.fn(),
+}));
+
+const MOCK_WALLET = '4Nd1mBQtrMJVYVfKf2PJy9NZUZdTAsp7D4xWLs4gDB4T' as WalletId;
+const MOCK_POSITION_MINT = '2Wgh4mq6rp1q6H1G6K3ZsR3LBdqT5qVJb5KfF3U7Y2hX' as PositionId;
+const MOCK_WHIRLPOOL = '7qbRF6YsyGuLUVs6Y1q64bdVrfe4ZcUUz1JRdoVNUJnm';
+const MOCK_POSITION_PDA = '5Xh2nBQtrMJVYVfKf2PJy9NZUZdTAsp7D4xWLs4gDB4U';
+
+describe('SolanaPositionSnapshotReader', () => {
+  const mockRpcUrl = 'https://api.mainnet-beta.solana.com';
+  let mockRpcWithOwnership: { getTokenAccountsByOwner: () => { send: () => Promise<{ value: Array<unknown> }> } };
+  let mockRpcWithoutOwnership: { getTokenAccountsByOwner: () => { send: () => Promise<{ value: Array<unknown> }> } };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    
+    mockRpcWithOwnership = {
+      getTokenAccountsByOwner: () => ({
+        send: () => Promise.resolve({ value: [{ account: { data: { parsed: { info: { tokenAmount: { amount: '1' } } } } } }] }),
+      }),
+    } as unknown as typeof mockRpcWithOwnership;
+
+    mockRpcWithoutOwnership = {
+      getTokenAccountsByOwner: () => ({
+        send: () => Promise.resolve({ value: [] }),
+      }),
+    } as unknown as typeof mockRpcWithoutOwnership;
+  });
+
+  describe('fetchSinglePosition', () => {
+    it('returns LiquidityPosition when position exists and is owned by wallet', async () => {
+      const { getPositionAddress, fetchPosition, fetchWhirlpool } = await import('@orca-so/whirlpools-client');
+
+      vi.mocked(getPositionAddress).mockResolvedValue([address(MOCK_POSITION_PDA)] as unknown as Awaited<ReturnType<typeof getPositionAddress>>);
+      vi.mocked(fetchPosition).mockResolvedValue({
+        data: {
+          whirlpool: address(MOCK_WHIRLPOOL),
+          tickLowerIndex: -18304,
+          tickUpperIndex: -17956,
+          positionMint: address(MOCK_POSITION_MINT),
+        },
+      } as unknown as Awaited<ReturnType<typeof fetchPosition>>);
+
+      vi.mocked(fetchWhirlpool).mockResolvedValue({
+        data: {
+          tickCurrentIndex: -18130,
+          sqrtPrice: 79228162514264337593543950336n,
+        },
+      } as unknown as Awaited<ReturnType<typeof fetchWhirlpool>>);
+
+      const reader = new SolanaPositionSnapshotReader(mockRpcUrl);
+      const result = await reader.fetchSinglePosition(mockRpcWithOwnership as never, MOCK_POSITION_MINT, MOCK_WALLET);
+
+      expect(result).not.toBeNull();
+      expect(result!.positionId).toBe(MOCK_POSITION_MINT);
+      expect(result!.walletId).toBe(MOCK_WALLET);
+      expect(result!.bounds.lowerBound).toBe(-18304);
+      expect(result!.bounds.upperBound).toBe(-17956);
+      expect(result!.rangeState.kind).toBe('in-range');
+      expect(result!.monitoringReadiness.kind).toBe('active');
+    });
+
+    it('returns null when position is not owned by wallet', async () => {
+      const { getPositionAddress, fetchPosition } = await import('@orca-so/whirlpools-client');
+
+      vi.mocked(getPositionAddress).mockResolvedValue([address(MOCK_POSITION_PDA)] as unknown as Awaited<ReturnType<typeof getPositionAddress>>);
+      vi.mocked(fetchPosition).mockResolvedValue({
+        data: {
+          whirlpool: address(MOCK_WHIRLPOOL),
+          tickLowerIndex: -18304,
+          tickUpperIndex: -17956,
+          positionMint: address(MOCK_POSITION_MINT),
+        },
+      } as unknown as Awaited<ReturnType<typeof fetchPosition>>);
+
+      const reader = new SolanaPositionSnapshotReader(mockRpcUrl);
+      const result = await reader.fetchSinglePosition(mockRpcWithoutOwnership as never, MOCK_POSITION_MINT, MOCK_WALLET);
+
+      expect(result).toBeNull();
+    });
+
+    it('returns null when fetchPosition throws', async () => {
+      const { getPositionAddress, fetchPosition } = await import('@orca-so/whirlpools-client');
+
+      vi.mocked(getPositionAddress).mockResolvedValue([address(MOCK_POSITION_PDA)] as unknown as Awaited<ReturnType<typeof getPositionAddress>>);
+      vi.mocked(fetchPosition).mockRejectedValue(new Error('Failed to fetch position'));
+
+      const reader = new SolanaPositionSnapshotReader(mockRpcUrl);
+      const result = await reader.fetchSinglePosition(mockRpcWithOwnership as never, MOCK_POSITION_MINT, MOCK_WALLET);
+
+      expect(result).toBeNull();
+    });
+
+    it('returns null when fetchWhirlpool throws', async () => {
+      const { getPositionAddress, fetchPosition, fetchWhirlpool } = await import('@orca-so/whirlpools-client');
+
+      vi.mocked(getPositionAddress).mockResolvedValue([address(MOCK_POSITION_PDA)] as unknown as Awaited<ReturnType<typeof getPositionAddress>>);
+      vi.mocked(fetchPosition).mockResolvedValue({
+        data: {
+          whirlpool: address(MOCK_WHIRLPOOL),
+          tickLowerIndex: -18304,
+          tickUpperIndex: -17956,
+          positionMint: address(MOCK_POSITION_MINT),
+        },
+      } as unknown as Awaited<ReturnType<typeof fetchPosition>>);
+      vi.mocked(fetchWhirlpool).mockRejectedValue(new Error('Failed to fetch whirlpool'));
+
+      const reader = new SolanaPositionSnapshotReader(mockRpcUrl);
+      const result = await reader.fetchSinglePosition(mockRpcWithOwnership as never, MOCK_POSITION_MINT, MOCK_WALLET);
+
+      expect(result).toBeNull();
+    });
+
+    it('computes below-range rangeState when current tick is below lower bound', async () => {
+      const { getPositionAddress, fetchPosition, fetchWhirlpool } = await import('@orca-so/whirlpools-client');
+
+      vi.mocked(getPositionAddress).mockResolvedValue([address(MOCK_POSITION_PDA)] as unknown as Awaited<ReturnType<typeof getPositionAddress>>);
+      vi.mocked(fetchPosition).mockResolvedValue({
+        data: {
+          whirlpool: address(MOCK_WHIRLPOOL),
+          tickLowerIndex: -10000,
+          tickUpperIndex: -5000,
+          positionMint: address(MOCK_POSITION_MINT),
+        },
+      } as unknown as Awaited<ReturnType<typeof fetchPosition>>);
+
+      vi.mocked(fetchWhirlpool).mockResolvedValue({
+        data: {
+          tickCurrentIndex: -20000,
+          sqrtPrice: 79228162514264337593543950336n,
+        },
+      } as unknown as Awaited<ReturnType<typeof fetchWhirlpool>>);
+
+      const reader = new SolanaPositionSnapshotReader(mockRpcUrl);
+      const result = await reader.fetchSinglePosition(mockRpcWithOwnership as never, MOCK_POSITION_MINT, MOCK_WALLET);
+
+      expect(result).not.toBeNull();
+      expect(result!.rangeState.kind).toBe('below-range');
+    });
+
+    it('computes above-range rangeState when current tick is above upper bound', async () => {
+      const { getPositionAddress, fetchPosition, fetchWhirlpool } = await import('@orca-so/whirlpools-client');
+
+      vi.mocked(getPositionAddress).mockResolvedValue([address(MOCK_POSITION_PDA)] as unknown as Awaited<ReturnType<typeof getPositionAddress>>);
+      vi.mocked(fetchPosition).mockResolvedValue({
+        data: {
+          whirlpool: address(MOCK_WHIRLPOOL),
+          tickLowerIndex: -10000,
+          tickUpperIndex: -5000,
+          positionMint: address(MOCK_POSITION_MINT),
+        },
+      } as unknown as Awaited<ReturnType<typeof fetchPosition>>);
+
+      vi.mocked(fetchWhirlpool).mockResolvedValue({
+        data: {
+          tickCurrentIndex: 0,
+          sqrtPrice: 79228162514264337593543950336n,
+        },
+      } as unknown as Awaited<ReturnType<typeof fetchWhirlpool>>);
+
+      const reader = new SolanaPositionSnapshotReader(mockRpcUrl);
+      const result = await reader.fetchSinglePosition(mockRpcWithOwnership as never, MOCK_POSITION_MINT, MOCK_WALLET);
+
+      expect(result).not.toBeNull();
+      expect(result!.rangeState.kind).toBe('above-range');
+    });
+  });
+
+  describe('verifyOwnership', () => {
+    it('returns true when wallet owns the position mint', async () => {
+      const reader = new SolanaPositionSnapshotReader(mockRpcUrl);
+      const result = await reader.verifyOwnership(mockRpcWithOwnership as never, MOCK_WALLET, MOCK_POSITION_MINT);
+
+      expect(result).toBe(true);
+    });
+
+    it('returns false when wallet does not own the position mint', async () => {
+      const nonOwnerWallet = '9w7A9sXjC8eGdxzpcM8f7mPy8tLQGvY1z9WnK3m2LcQa' as WalletId;
+      const reader = new SolanaPositionSnapshotReader(mockRpcUrl);
+      const result = await reader.verifyOwnership(mockRpcWithoutOwnership as never, nonOwnerWallet, MOCK_POSITION_MINT);
+
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('fetchWhirlpoolsBatched', () => {
+    it('deduplicates whirlpool addresses and fetches each once', async () => {
+      const { fetchWhirlpool } = await import('@orca-so/whirlpools-client');
+      const mockRpc = {} as ReturnType<typeof createSolanaRpc>;
+
+      const addresses = [
+        '7qbRF6YsyGuLUVs6Y1q64bdVrfe4ZcUUz1JRdoVNUJnm',
+        '7qbRF6YsyGuLUVs6Y1q64bdVrfe4ZcUUz1JRdoVNUJnm',
+        '8qbRF6YsyGuLUVs6Y1q64bdVrfe4ZcUUz1JRdoVNUJno',
+        '8qbRF6YsyGuLUVs6Y1q64bdVrfe4ZcUUz1JRdoVNUJno',
+        '9qbRF6YsyGuLUVs6Y1q64bdVrfe4ZcUUz1JRdoVNUJnp',
+      ];
+
+      vi.mocked(fetchWhirlpool).mockResolvedValue({
+        data: { tickCurrentIndex: -18130 },
+      } as unknown as Awaited<ReturnType<typeof fetchWhirlpool>>);
+
+      const reader = new SolanaPositionSnapshotReader(mockRpcUrl);
+      const result = await reader.fetchWhirlpoolsBatched(mockRpc, addresses);
+
+      expect(result.size).toBe(3);
+      expect(fetchWhirlpool).toHaveBeenCalledTimes(3);
+    });
+
+    it('omits whirlpools that fail to fetch', async () => {
+      const { fetchWhirlpool } = await import('@orca-so/whirlpools-client');
+      const mockRpc = {} as ReturnType<typeof createSolanaRpc>;
+
+      const pool1 = '7qbRF6YsyGuLUVs6Y1q64bdVrfe4ZcUUz1JRdoVNUJnm';
+      const pool2 = '8qbRF6YsyGuLUVs6Y1q64bdVrfe4ZcUUz1JRdoVNUJno';
+
+      vi.mocked(fetchWhirlpool).mockImplementation(async (_rpc: unknown, addr: { toString: () => string }) => {
+        if (addr.toString() === pool2) {
+          throw new Error('Failed to fetch');
+        }
+        return { data: { tickCurrentIndex: -18130 } } as unknown as Awaited<ReturnType<typeof fetchWhirlpool>>;
+      });
+
+      const reader = new SolanaPositionSnapshotReader(mockRpcUrl);
+      const result = await reader.fetchWhirlpoolsBatched(mockRpc, [pool1, pool2]);
+
+      expect(result.has(pool1)).toBe(true);
+      expect(result.has(pool2)).toBe(false);
+    });
+
+    it('returns empty map for empty input', async () => {
+      const mockRpc = {} as ReturnType<typeof createSolanaRpc>;
+
+      const reader = new SolanaPositionSnapshotReader(mockRpcUrl);
+      const result = await reader.fetchWhirlpoolsBatched(mockRpc, []);
+
+      expect(result.size).toBe(0);
+    });
+  });
+});

--- a/packages/adapters/src/outbound/solana-position-reads/SolanaPositionSnapshotReader.ts
+++ b/packages/adapters/src/outbound/solana-position-reads/SolanaPositionSnapshotReader.ts
@@ -98,16 +98,21 @@ export class SolanaPositionSnapshotReader {
       return results;
     }
 
-    const fetches = uniqueAddresses.map(async (addr) => {
-      try {
-        const whirlpoolAccount = await fetchWhirlpool(rpc, address(addr));
-        results.set(addr, { tickCurrentIndex: whirlpoolAccount.data.tickCurrentIndex });
-      } catch {
-        // Skip failed fetches — positions referencing this pool will be excluded
-      }
-    });
+    const WHIRLPOOL_FETCH_BATCH_SIZE = 2;
 
-    await Promise.all(fetches);
+    for (let i = 0; i < uniqueAddresses.length; i += WHIRLPOOL_FETCH_BATCH_SIZE) {
+      const batch = uniqueAddresses.slice(i, i + WHIRLPOOL_FETCH_BATCH_SIZE);
+
+      await Promise.all(batch.map(async (addr) => {
+        try {
+          const whirlpoolAccount = await fetchWhirlpool(rpc, address(addr));
+          results.set(addr, { tickCurrentIndex: whirlpoolAccount.data.tickCurrentIndex });
+        } catch {
+          // Skip failed fetches — positions referencing this pool will be excluded.
+        }
+      }));
+    }
+
     return results;
   }
 }

--- a/packages/adapters/src/outbound/solana-position-reads/SolanaPositionSnapshotReader.ts
+++ b/packages/adapters/src/outbound/solana-position-reads/SolanaPositionSnapshotReader.ts
@@ -1,0 +1,113 @@
+/**
+ * SolanaPositionSnapshotReader
+ *
+ * Fetches a single position snapshot from Solana using @solana/kit and @orca-so/whirlpools-client.
+ * This reader is used for detailed position inspection and is not responsible for
+ * determining breach direction or exit posture - that lives in packages/domain.
+ *
+ * Docs: @solana/kit v6, @orca-so/whirlpools-client
+ */
+import { createSolanaRpc, address } from '@solana/kit';
+import { getPositionAddress, fetchPosition, fetchWhirlpool } from '@orca-so/whirlpools-client';
+
+import type { LiquidityPosition, WalletId, PositionId } from '@clmm/domain';
+import { makePoolId, makeClockTimestamp, evaluateRangeState } from '@clmm/domain';
+
+export class SolanaPositionSnapshotReader {
+  constructor(private readonly rpcUrl: string) {}
+
+  getRpc() {
+    return createSolanaRpc(this.rpcUrl);
+  }
+
+  async fetchSinglePosition(
+    rpc: ReturnType<typeof createSolanaRpc>,
+    positionId: PositionId,
+    walletId: WalletId,
+  ): Promise<LiquidityPosition | null> {
+    try {
+      const positionMint = address(positionId);
+      const [positionAddress] = await getPositionAddress(positionMint);
+      const positionAccount = await fetchPosition(rpc, positionAddress);
+      const position = positionAccount.data;
+
+      const isOwner = await this.verifyOwnership(rpc, walletId, positionId);
+      if (!isOwner) {
+        return null;
+      }
+
+      const whirlpoolAddress = position.whirlpool;
+      const whirlpoolAccount = await fetchWhirlpool(rpc, whirlpoolAddress);
+      const whirlpool = whirlpoolAccount.data;
+
+      const bounds = {
+        lowerBound: position.tickLowerIndex,
+        upperBound: position.tickUpperIndex,
+      };
+
+      const currentTick = whirlpool.tickCurrentIndex;
+      const rangeState = evaluateRangeState(bounds, currentTick);
+
+      return {
+        positionId,
+        walletId,
+        poolId: makePoolId(whirlpoolAddress.toString()),
+        bounds,
+        lastObservedAt: makeClockTimestamp(Date.now()),
+        rangeState,
+        monitoringReadiness: { kind: 'active' },
+      };
+    } catch {
+      return null;
+    }
+  }
+
+  async verifyOwnership(
+    rpc: ReturnType<typeof createSolanaRpc>,
+    walletId: WalletId,
+    positionId: PositionId,
+  ): Promise<boolean> {
+    try {
+      const ownerAddress = address(walletId);
+      const mintAddress = address(positionId);
+
+      const response = await rpc
+        .getTokenAccountsByOwner(
+          ownerAddress,
+          { mint: mintAddress },
+          { encoding: 'jsonParsed' },
+        )
+        .send();
+
+      return response.value.some(
+        (account) => BigInt(account.account.data.parsed.info.tokenAmount.amount) > 0n,
+      );
+    } catch {
+      return false;
+    }
+  }
+
+  async fetchWhirlpoolsBatched(
+    rpc: ReturnType<typeof createSolanaRpc>,
+    whirlpoolAddresses: string[],
+  ): Promise<Map<string, { tickCurrentIndex: number }>> {
+    const uniqueAddresses = [...new Set(whirlpoolAddresses)];
+    const results = new Map<string, { tickCurrentIndex: number }>();
+
+    if (uniqueAddresses.length === 0) {
+      return results;
+    }
+
+    const fetches = uniqueAddresses.map(async (addr) => {
+      try {
+        const whirlpoolAccount = await fetchWhirlpool(rpc, address(addr));
+        results.set(addr, { tickCurrentIndex: whirlpoolAccount.data.tickCurrentIndex });
+      } catch {
+        // Skip failed fetches — positions referencing this pool will be excluded
+      }
+    });
+
+    await Promise.all(fetches);
+    return results;
+  }
+}

--- a/packages/adapters/src/outbound/solana-position-reads/SolanaReadPathEfficiency.integration.test.ts
+++ b/packages/adapters/src/outbound/solana-position-reads/SolanaReadPathEfficiency.integration.test.ts
@@ -51,6 +51,7 @@ describe('Solana read path efficiency integration', () => {
   it('uses the reduced RPC shape for list, detail, and trigger flows', async () => {
     const { fetchPositionsForOwner } = await import('@orca-so/whirlpools');
     const { fetchWhirlpool, getPositionAddress, fetchPosition } = await import('@orca-so/whirlpools-client');
+    const now = Date.now();
 
     // Arrange: wallet scan returns two positions on the same whirlpool
     vi.mocked(fetchPositionsForOwner).mockResolvedValue([
@@ -140,8 +141,8 @@ describe('Solana read path efficiency integration', () => {
             ownershipSelectCalls++;
             return {
               where: async () => [
-                { walletId: MOCK_WALLET, positionId: MOCK_POSITION_MINT, firstSeenAt: 1, lastSeenAt: 1 },
-                { walletId: MOCK_WALLET, positionId: MOCK_POSITION_MINT_2, firstSeenAt: 1, lastSeenAt: 1 },
+                { walletId: MOCK_WALLET, positionId: MOCK_POSITION_MINT, firstSeenAt: now - 1_000, lastSeenAt: now - 1_000 },
+                { walletId: MOCK_WALLET, positionId: MOCK_POSITION_MINT_2, firstSeenAt: now - 1_000, lastSeenAt: now - 1_000 },
               ],
             };
           }

--- a/packages/adapters/src/outbound/solana-position-reads/SolanaReadPathEfficiency.integration.test.ts
+++ b/packages/adapters/src/outbound/solana-position-reads/SolanaReadPathEfficiency.integration.test.ts
@@ -1,18 +1,36 @@
 /**
  * SolanaReadPathEfficiency Integration Test
  *
- * Proves the list flow uses the intended RPC shape with deduplication.
- * (The listActionableTriggers DB-only behavior is tested in OperationalStorageAdapter.test.ts,
- * and getPosition delegation is tested in OrcaPositionReadAdapter.test.ts).
+ * Proves the list -> detail -> triggers flow uses the intended RPC shape:
+ * - listSupportedPositions(): one wallet scan + deduped whirlpool reads
+ * - getPosition(): direct getPositionAddress -> fetchPosition -> fetchWhirlpool path
+ * - listActionableTriggers(): DB-only, zero Solana reads
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { SolanaPositionSnapshotReader } from './SolanaPositionSnapshotReader';
 import { OrcaPositionReadAdapter } from './OrcaPositionReadAdapter';
+import { OperationalStorageAdapter } from '../storage/OperationalStorageAdapter';
 import type { WalletId } from '@clmm/domain';
+import { makePositionId } from '@clmm/domain';
 
 vi.mock('@orca-so/whirlpools', () => ({
   fetchPositionsForOwner: vi.fn(),
 }));
+
+vi.mock('@solana/kit', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@solana/kit')>();
+  return {
+    ...actual,
+    createSolanaRpc: () => ({
+      getTokenAccountsByOwner: () => ({
+        send: () =>
+          Promise.resolve({
+            value: [{ account: { data: { parsed: { info: { tokenAmount: { amount: '1000000' } } } } } }],
+          }),
+      }),
+    }),
+  };
+});
 
 vi.mock('@orca-so/whirlpools-client', () => ({
   getPositionAddress: vi.fn(),
@@ -30,11 +48,11 @@ describe('Solana read path efficiency integration', () => {
     vi.clearAllMocks();
   });
 
-  it('uses batched whirlpool fetching with deduplication in listSupportedPositions', async () => {
+  it('uses the reduced RPC shape for list, detail, and trigger flows', async () => {
     const { fetchPositionsForOwner } = await import('@orca-so/whirlpools');
-    const { fetchWhirlpool } = await import('@orca-so/whirlpools-client');
+    const { fetchWhirlpool, getPositionAddress, fetchPosition } = await import('@orca-so/whirlpools-client');
 
-    // Arrange: wallet scan returns two positions across one shared whirlpool
+    // Arrange: wallet scan returns two positions on the same whirlpool
     vi.mocked(fetchPositionsForOwner).mockResolvedValue([
       {
         address: 'PositionAddress1',
@@ -58,13 +76,98 @@ describe('Solana read path efficiency integration', () => {
       },
     ] as unknown as Awaited<ReturnType<typeof fetchPositionsForOwner>>);
 
-    // Batched whirlpool fetch returns the shared whirlpool once
+    // Batched whirlpool fetch - returns once for shared pool
     vi.mocked(fetchWhirlpool).mockResolvedValue({
       data: { tickCurrentIndex: -18130 },
     } as unknown as Awaited<ReturnType<typeof fetchWhirlpool>>);
 
-    // Arrange: fake DB for scan-time ownership writes
+    // Direct position lookup for getPosition()
+    vi.mocked(getPositionAddress).mockResolvedValue(['PositionPDA1', 0] as unknown as Awaited<ReturnType<typeof getPositionAddress>>);
+    vi.mocked(fetchPosition).mockResolvedValue({
+      data: {
+        whirlpool: MOCK_WHIRLPOOL,
+        tickLowerIndex: -18304,
+        tickUpperIndex: -17956,
+        positionMint: MOCK_POSITION_MINT,
+      },
+    } as unknown as Awaited<ReturnType<typeof fetchPosition>>);
+
+    // DB instrumentation for ownership and trigger queries
+    let ownershipSelectCalls = 0;
+    let triggerSelectCalls = 0;
+
+    function predicateReferencesOpenEpisodeFilter(value: unknown): boolean {
+      const visited = new WeakSet<object>();
+      function walk(node: unknown): boolean {
+        if (node == null) return false;
+        if (typeof node === 'string') {
+          return node === 'open';
+        }
+        if (typeof node !== 'object') return false;
+        if (visited.has(node)) return false;
+        visited.add(node);
+
+        const record = node as Record<string, unknown>;
+        const table = record['table'];
+        const name = record['name'];
+        if (
+          typeof name === 'string' &&
+          name === 'status' &&
+          typeof table === 'object' &&
+          table != null &&
+          (table as { name?: unknown }).name === 'breach_episodes'
+        ) {
+          return true;
+        }
+
+        const queryChunks = record['queryChunks'];
+        if (Array.isArray(queryChunks) && queryChunks.some((chunk) => walk(chunk))) {
+          return true;
+        }
+
+        return Object.values(record).some((entry) => walk(entry));
+      }
+
+      return walk(value);
+    }
+
     const mockDb = {
+      select: () => ({
+        from: (table: unknown) => {
+          const tableName = (table as { name?: string })?.name ??
+            ((table as Record<string | symbol, unknown>)[Symbol.for('drizzle:Name')] as string | undefined) ?? '';
+          if (tableName === 'wallet_position_ownership') {
+            ownershipSelectCalls++;
+            return {
+              where: async () => [
+                { walletId: MOCK_WALLET, positionId: MOCK_POSITION_MINT, firstSeenAt: 1, lastSeenAt: 1 },
+                { walletId: MOCK_WALLET, positionId: MOCK_POSITION_MINT_2, firstSeenAt: 1, lastSeenAt: 1 },
+              ],
+            };
+          }
+          if (tableName === 'exit_triggers') {
+            triggerSelectCalls++;
+            return {
+              innerJoin: () => ({
+                where: async (predicate: unknown) =>
+                  predicateReferencesOpenEpisodeFilter(predicate)
+                    ? [
+                        {
+                          triggerId: 'trigger1',
+                          positionId: MOCK_POSITION_MINT,
+                          episodeId: 'episode1',
+                          directionKind: 'lower-bound-breach',
+                          triggeredAt: 1_000_000,
+                          confirmationEvaluatedAt: 1_000_001,
+                        },
+                      ]
+                    : [],
+              }),
+            };
+          }
+          return { where: async () => [] };
+        },
+      }),
       insert: () => ({
         values: () => ({
           onConflictDoUpdate: () => Promise.resolve(),
@@ -75,16 +178,30 @@ describe('Solana read path efficiency integration', () => {
     const rpcUrl = 'https://api.mainnet-beta.solana.com';
     const snapshotReader = new SolanaPositionSnapshotReader(rpcUrl);
     const positionRead = new OrcaPositionReadAdapter(rpcUrl, snapshotReader, mockDb as never);
+    const storage = new OperationalStorageAdapter(mockDb as never, { generateId: () => 'id' } as never);
 
     // Act
     const listed = await positionRead.listSupportedPositions(MOCK_WALLET);
+    const detail = await positionRead.getPosition(MOCK_WALLET, makePositionId(MOCK_POSITION_MINT));
+    const triggers = await storage.listActionableTriggers(MOCK_WALLET);
 
     // Assert behavior
     expect(listed).toHaveLength(2);
+    expect(detail?.positionId).toBe(MOCK_POSITION_MINT);
+    expect(triggers).toHaveLength(1);
+    expect(triggers[0]?.positionId).toBe(MOCK_POSITION_MINT);
 
-    // Assert call shape: one wallet scan, one deduped whirlpool fetch
-    // 2 positions but only 1 unique whirlpool -> only 1 fetchWhirlpool call
+    // Assert reduced RPC call shape:
+    // - listSupportedPositions: 1 wallet scan + 1 deduped whirlpool fetch
+    // - getPosition: 1 getPositionAddress + 1 fetchPosition + 1 fetchWhirlpool
+    // - listActionableTriggers: 0 Solana calls
     expect(fetchPositionsForOwner).toHaveBeenCalledTimes(1);
-    expect(fetchWhirlpool).toHaveBeenCalledTimes(1); // deduplicated to 1 for shared pool
+    expect(getPositionAddress).toHaveBeenCalledTimes(1);
+    expect(fetchPosition).toHaveBeenCalledTimes(1);
+    expect(fetchWhirlpool).toHaveBeenCalledTimes(2); // 1 from list + 1 from getPosition
+
+    // Assert DB-only trigger listing
+    expect(ownershipSelectCalls).toBe(1);
+    expect(triggerSelectCalls).toBe(1);
   });
 });

--- a/packages/adapters/src/outbound/solana-position-reads/SolanaReadPathEfficiency.integration.test.ts
+++ b/packages/adapters/src/outbound/solana-position-reads/SolanaReadPathEfficiency.integration.test.ts
@@ -1,0 +1,90 @@
+/**
+ * SolanaReadPathEfficiency Integration Test
+ *
+ * Proves the list flow uses the intended RPC shape with deduplication.
+ * (The listActionableTriggers DB-only behavior is tested in OperationalStorageAdapter.test.ts,
+ * and getPosition delegation is tested in OrcaPositionReadAdapter.test.ts).
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { SolanaPositionSnapshotReader } from './SolanaPositionSnapshotReader';
+import { OrcaPositionReadAdapter } from './OrcaPositionReadAdapter';
+import type { WalletId } from '@clmm/domain';
+
+vi.mock('@orca-so/whirlpools', () => ({
+  fetchPositionsForOwner: vi.fn(),
+}));
+
+vi.mock('@orca-so/whirlpools-client', () => ({
+  getPositionAddress: vi.fn(),
+  fetchPosition: vi.fn(),
+  fetchWhirlpool: vi.fn(),
+}));
+
+const MOCK_WALLET = '4Nd1mBQtrMJVYVfKf2PJy9NZUZdTAsp7D4xWLs4gDB4T' as WalletId;
+const MOCK_POSITION_MINT = '2Wgh4mq6rp1q6H1G6K3ZsR3LBdqT5qVJb5KfF3U7Y2hX';
+const MOCK_POSITION_MINT_2 = '3Xhi4mq6rp1q6H1G6K3ZsR3LBdqT5qVJb5KfF3U7Y2hY';
+const MOCK_WHIRLPOOL = '7qbRF6YsyGuLUVs6Y1q64bdVrfe4ZcUUz1JRdoVNUJnm';
+
+describe('Solana read path efficiency integration', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('uses batched whirlpool fetching with deduplication in listSupportedPositions', async () => {
+    const { fetchPositionsForOwner } = await import('@orca-so/whirlpools');
+    const { fetchWhirlpool } = await import('@orca-so/whirlpools-client');
+
+    // Arrange: wallet scan returns two positions across one shared whirlpool
+    vi.mocked(fetchPositionsForOwner).mockResolvedValue([
+      {
+        address: 'PositionAddress1',
+        isPositionBundle: false,
+        data: {
+          whirlpool: MOCK_WHIRLPOOL,
+          tickLowerIndex: -18304,
+          tickUpperIndex: -17956,
+          positionMint: MOCK_POSITION_MINT,
+        },
+      },
+      {
+        address: 'PositionAddress2',
+        isPositionBundle: false,
+        data: {
+          whirlpool: MOCK_WHIRLPOOL,
+          tickLowerIndex: -10000,
+          tickUpperIndex: -5000,
+          positionMint: MOCK_POSITION_MINT_2,
+        },
+      },
+    ] as unknown as Awaited<ReturnType<typeof fetchPositionsForOwner>>);
+
+    // Batched whirlpool fetch returns the shared whirlpool once
+    vi.mocked(fetchWhirlpool).mockResolvedValue({
+      data: { tickCurrentIndex: -18130 },
+    } as unknown as Awaited<ReturnType<typeof fetchWhirlpool>>);
+
+    // Arrange: fake DB for scan-time ownership writes
+    const mockDb = {
+      insert: () => ({
+        values: () => ({
+          onConflictDoUpdate: () => Promise.resolve(),
+        }),
+      }),
+    };
+
+    const rpcUrl = 'https://api.mainnet-beta.solana.com';
+    const snapshotReader = new SolanaPositionSnapshotReader(rpcUrl);
+    const positionRead = new OrcaPositionReadAdapter(rpcUrl, snapshotReader, mockDb as never);
+
+    // Act
+    const listed = await positionRead.listSupportedPositions(MOCK_WALLET);
+
+    // Assert behavior
+    expect(listed).toHaveLength(2);
+
+    // Assert call shape: one wallet scan, one deduped whirlpool fetch
+    // 2 positions but only 1 unique whirlpool -> only 1 fetchWhirlpool call
+    expect(fetchPositionsForOwner).toHaveBeenCalledTimes(1);
+    expect(fetchWhirlpool).toHaveBeenCalledTimes(1); // deduplicated to 1 for shared pool
+  });
+});

--- a/packages/adapters/src/outbound/storage/OperationalStorageAdapter.test.ts
+++ b/packages/adapters/src/outbound/storage/OperationalStorageAdapter.test.ts
@@ -156,14 +156,15 @@ function makeDbForFinalizeQualification(params: {
 
 describe('OperationalStorageAdapter', () => {
   it('scopes actionable triggers to positions owned by the requested wallet via DB lookup', async () => {
+    const now = Date.now();
     const adapter = new OperationalStorageAdapter(
       makeDbWithTriggerRows({
         ownershipRows: [
           {
             walletId: FIXTURE_WALLET_ID,
             positionId: FIXTURE_POSITION_IN_RANGE.positionId,
-            firstSeenAt: 1_000_000,
-            lastSeenAt: 1_000_000,
+            firstSeenAt: now - 1_000,
+            lastSeenAt: now - 1_000,
           },
         ],
         triggerRows: [
@@ -198,14 +199,15 @@ describe('OperationalStorageAdapter', () => {
   });
 
   it('does not return triggers whose breach episode is already closed', async () => {
+    const now = Date.now();
     const adapter = new OperationalStorageAdapter(
       makeDbWithTriggerRows({
         ownershipRows: [
           {
             walletId: FIXTURE_WALLET_ID,
             positionId: FIXTURE_POSITION_IN_RANGE.positionId,
-            firstSeenAt: 1_000_000,
-            lastSeenAt: 1_000_000,
+            firstSeenAt: now - 1_000,
+            lastSeenAt: now - 1_000,
           },
         ],
         triggerRows: [
@@ -226,6 +228,55 @@ describe('OperationalStorageAdapter', () => {
     const triggers = await adapter.listActionableTriggers(FIXTURE_WALLET_ID);
 
     expect(triggers).toHaveLength(0);
+  });
+
+  it('ignores ownership rows older than the freshness window', async () => {
+    const now = Date.now();
+    const adapter = new OperationalStorageAdapter(
+      makeDbWithTriggerRows({
+        ownershipRows: [
+          {
+            walletId: FIXTURE_WALLET_ID,
+            positionId: FIXTURE_POSITION_IN_RANGE.positionId,
+            firstSeenAt: now - 1_000,
+            lastSeenAt: now - 1_000,
+          },
+          {
+            walletId: FIXTURE_WALLET_ID,
+            positionId: leakedPositionId,
+            firstSeenAt: now - 10 * 60_000,
+            lastSeenAt: now - 10 * 60_000,
+          },
+        ],
+        triggerRows: [
+          {
+            triggerId: 'trigger-fresh',
+            positionId: FIXTURE_POSITION_IN_RANGE.positionId,
+            episodeId: 'episode-fresh',
+            directionKind: 'lower-bound-breach',
+            triggeredAt: makeClockTimestamp(now - 1_000),
+            confirmationEvaluatedAt: makeClockTimestamp(now - 900),
+            episodeStatus: 'open',
+          },
+          {
+            triggerId: 'trigger-stale',
+            positionId: leakedPositionId,
+            episodeId: 'episode-stale',
+            directionKind: 'upper-bound-breach',
+            triggeredAt: makeClockTimestamp(now - 10 * 60_000),
+            confirmationEvaluatedAt: makeClockTimestamp(now - 10 * 60_000 + 1),
+            episodeStatus: 'open',
+          },
+        ],
+      }),
+      new FakeIdGeneratorPort('storage'),
+    );
+
+    const triggers = await adapter.listActionableTriggers(FIXTURE_WALLET_ID);
+
+    expect(triggers).toHaveLength(1);
+    expect(triggers[0]?.triggerId).toBe('trigger-fresh');
+    expect(triggers[0]?.positionId).toBe(FIXTURE_POSITION_IN_RANGE.positionId);
   });
 
   it('returns empty array when no ownership rows exist for the wallet', async () => {

--- a/packages/adapters/src/outbound/storage/OperationalStorageAdapter.test.ts
+++ b/packages/adapters/src/outbound/storage/OperationalStorageAdapter.test.ts
@@ -2,36 +2,22 @@ import { describe, it, expect } from 'vitest';
 import { OperationalStorageAdapter } from './OperationalStorageAdapter.js';
 import { FIXTURE_POSITION_IN_RANGE, FIXTURE_WALLET_ID, FakeIdGeneratorPort } from '@clmm/testing';
 import { LOWER_BOUND_BREACH, makeClockTimestamp, makePositionId } from '@clmm/domain';
-import type { SupportedPositionReadPort } from '@clmm/application';
-import type { LiquidityPosition, PositionId, WalletId } from '@clmm/domain';
 import type { Db } from './db.js';
 
 const leakedPositionId = makePositionId('leaked-position');
 
-class WalletScopedPositionReadPort implements SupportedPositionReadPort {
-  receivedWalletId: WalletId | null = null;
-
-  constructor(private readonly positions: LiquidityPosition[]) {}
-
-  async listSupportedPositions(walletId: WalletId): Promise<LiquidityPosition[]> {
-    this.receivedWalletId = walletId;
-    return [...this.positions];
-  }
-
-  async getPosition(_walletId: WalletId, _positionId: PositionId): Promise<LiquidityPosition | null> {
-    return null;
-  }
-}
-
-function makeDbWithTriggerRows(rows: Array<{
-  triggerId: string;
-  positionId: string;
-  episodeId: string;
-  directionKind: string;
-  triggeredAt: number;
-  confirmationEvaluatedAt: number;
-  episodeStatus?: string;
-}>): Db {
+function makeDbWithTriggerRows(params: {
+  ownershipRows: Array<{ walletId: string; positionId: string; firstSeenAt: number; lastSeenAt: number }>;
+  triggerRows: Array<{
+    triggerId: string;
+    positionId: string;
+    episodeId: string;
+    directionKind: string;
+    triggeredAt: number;
+    confirmationEvaluatedAt: number;
+    episodeStatus?: string;
+  }>;
+}): Db {
   function predicateReferencesOpenEpisodeFilter(value: unknown): boolean {
     const visited = new WeakSet<object>();
     function walk(node: unknown): boolean {
@@ -67,16 +53,30 @@ function makeDbWithTriggerRows(rows: Array<{
     return walk(value);
   }
 
+  let selectCallCount = 0;
+
   return {
     select() {
+      selectCallCount++;
       return {
-        from() {
+        from(table: unknown) {
+          const tableName = (table as { name?: string })?.name ??
+            ((table as Record<string | symbol, unknown>)[Symbol.for('drizzle:Name')] as string | undefined) ?? '';
+
+          // First select call in listActionableTriggers queries wallet_position_ownership
+          if (selectCallCount === 1 || tableName === 'wallet_position_ownership') {
+            return {
+              where: async () => params.ownershipRows,
+            };
+          }
+
+          // Second select call queries exit_triggers joined with breach_episodes
           return {
             innerJoin: () => ({
               where: async (predicate: unknown) => (
                 predicateReferencesOpenEpisodeFilter(predicate)
-                  ? rows.filter((row) => row.episodeStatus === 'open')
-                  : rows
+                  ? params.triggerRows.filter((row) => row.episodeStatus === 'open')
+                  : params.triggerRows
               ),
             }),
           };
@@ -155,62 +155,100 @@ function makeDbForFinalizeQualification(params: {
 }
 
 describe('OperationalStorageAdapter', () => {
-  it('scopes actionable triggers to positions owned by the requested wallet', async () => {
-    const positionReadPort = new WalletScopedPositionReadPort([FIXTURE_POSITION_IN_RANGE]);
+  it('scopes actionable triggers to positions owned by the requested wallet via DB lookup', async () => {
     const adapter = new OperationalStorageAdapter(
-      makeDbWithTriggerRows([
-        {
-          triggerId: 'trigger-owned',
-          positionId: FIXTURE_POSITION_IN_RANGE.positionId,
-          episodeId: 'episode-owned',
-          directionKind: 'lower-bound-breach',
-          triggeredAt: makeClockTimestamp(1_000_000),
-          confirmationEvaluatedAt: makeClockTimestamp(1_000_001),
-          episodeStatus: 'open',
-        },
-        {
-          triggerId: 'trigger-leaked',
-          positionId: leakedPositionId,
-          episodeId: 'episode-leaked',
-          directionKind: 'upper-bound-breach',
-          triggeredAt: makeClockTimestamp(1_000_002),
-          confirmationEvaluatedAt: makeClockTimestamp(1_000_003),
-          episodeStatus: 'open',
-        },
-      ]),
+      makeDbWithTriggerRows({
+        ownershipRows: [
+          {
+            walletId: FIXTURE_WALLET_ID,
+            positionId: FIXTURE_POSITION_IN_RANGE.positionId,
+            firstSeenAt: 1_000_000,
+            lastSeenAt: 1_000_000,
+          },
+        ],
+        triggerRows: [
+          {
+            triggerId: 'trigger-owned',
+            positionId: FIXTURE_POSITION_IN_RANGE.positionId,
+            episodeId: 'episode-owned',
+            directionKind: 'lower-bound-breach',
+            triggeredAt: makeClockTimestamp(1_000_000),
+            confirmationEvaluatedAt: makeClockTimestamp(1_000_001),
+            episodeStatus: 'open',
+          },
+          {
+            triggerId: 'trigger-leaked',
+            positionId: leakedPositionId,
+            episodeId: 'episode-leaked',
+            directionKind: 'upper-bound-breach',
+            triggeredAt: makeClockTimestamp(1_000_002),
+            confirmationEvaluatedAt: makeClockTimestamp(1_000_003),
+            episodeStatus: 'open',
+          },
+        ],
+      }),
       new FakeIdGeneratorPort('storage'),
-      positionReadPort,
     );
 
     const triggers = await adapter.listActionableTriggers(FIXTURE_WALLET_ID);
 
-    expect(positionReadPort.receivedWalletId).toBe(FIXTURE_WALLET_ID);
     expect(triggers).toHaveLength(1);
     expect(triggers[0]?.triggerId).toBe('trigger-owned');
     expect(triggers[0]?.positionId).toBe(FIXTURE_POSITION_IN_RANGE.positionId);
   });
 
   it('does not return triggers whose breach episode is already closed', async () => {
-    const positionReadPort = new WalletScopedPositionReadPort([FIXTURE_POSITION_IN_RANGE]);
     const adapter = new OperationalStorageAdapter(
-      makeDbWithTriggerRows([
-        {
-          triggerId: 'trigger-closed',
-          positionId: FIXTURE_POSITION_IN_RANGE.positionId,
-          episodeId: 'episode-closed',
-          directionKind: 'lower-bound-breach',
-          triggeredAt: makeClockTimestamp(1_000_000),
-          confirmationEvaluatedAt: makeClockTimestamp(1_000_001),
-          episodeStatus: 'closed',
-        },
-      ]),
+      makeDbWithTriggerRows({
+        ownershipRows: [
+          {
+            walletId: FIXTURE_WALLET_ID,
+            positionId: FIXTURE_POSITION_IN_RANGE.positionId,
+            firstSeenAt: 1_000_000,
+            lastSeenAt: 1_000_000,
+          },
+        ],
+        triggerRows: [
+          {
+            triggerId: 'trigger-closed',
+            positionId: FIXTURE_POSITION_IN_RANGE.positionId,
+            episodeId: 'episode-closed',
+            directionKind: 'lower-bound-breach',
+            triggeredAt: makeClockTimestamp(1_000_000),
+            confirmationEvaluatedAt: makeClockTimestamp(1_000_001),
+            episodeStatus: 'closed',
+          },
+        ],
+      }),
       new FakeIdGeneratorPort('storage'),
-      positionReadPort,
     );
 
     const triggers = await adapter.listActionableTriggers(FIXTURE_WALLET_ID);
 
-    expect(positionReadPort.receivedWalletId).toBe(FIXTURE_WALLET_ID);
+    expect(triggers).toHaveLength(0);
+  });
+
+  it('returns empty array when no ownership rows exist for the wallet', async () => {
+    const adapter = new OperationalStorageAdapter(
+      makeDbWithTriggerRows({
+        ownershipRows: [],
+        triggerRows: [
+          {
+            triggerId: 'trigger-orphan',
+            positionId: FIXTURE_POSITION_IN_RANGE.positionId,
+            episodeId: 'episode-orphan',
+            directionKind: 'lower-bound-breach',
+            triggeredAt: makeClockTimestamp(1_000_000),
+            confirmationEvaluatedAt: makeClockTimestamp(1_000_001),
+            episodeStatus: 'open',
+          },
+        ],
+      }),
+      new FakeIdGeneratorPort('storage'),
+    );
+
+    const triggers = await adapter.listActionableTriggers(FIXTURE_WALLET_ID);
+
     expect(triggers).toHaveLength(0);
   });
 
@@ -234,7 +272,6 @@ describe('OperationalStorageAdapter', () => {
     const adapter = new OperationalStorageAdapter(
       db,
       new FakeIdGeneratorPort('storage'),
-      new WalletScopedPositionReadPort([FIXTURE_POSITION_IN_RANGE]),
     );
 
     const result = await adapter.finalizeQualification(episodeId as never, {
@@ -273,7 +310,6 @@ describe('OperationalStorageAdapter', () => {
     const adapter = new OperationalStorageAdapter(
       db,
       new FakeIdGeneratorPort('storage'),
-      new WalletScopedPositionReadPort([FIXTURE_POSITION_IN_RANGE]),
     );
 
     await expect(() => adapter.finalizeQualification(episodeId as never, {
@@ -307,7 +343,6 @@ describe('OperationalStorageAdapter', () => {
     const adapter = new OperationalStorageAdapter(
       db,
       new FakeIdGeneratorPort('storage'),
-      new WalletScopedPositionReadPort([FIXTURE_POSITION_IN_RANGE]),
     );
 
     await expect(() => adapter.finalizeQualification(episodeId as never, {

--- a/packages/adapters/src/outbound/storage/OperationalStorageAdapter.test.ts
+++ b/packages/adapters/src/outbound/storage/OperationalStorageAdapter.test.ts
@@ -244,8 +244,8 @@ describe('OperationalStorageAdapter', () => {
           {
             walletId: FIXTURE_WALLET_ID,
             positionId: leakedPositionId,
-            firstSeenAt: now - 10 * 60_000,
-            lastSeenAt: now - 10 * 60_000,
+            firstSeenAt: now - 11 * 60_000,
+            lastSeenAt: now - 11 * 60_000,
           },
         ],
         triggerRows: [
@@ -263,8 +263,8 @@ describe('OperationalStorageAdapter', () => {
             positionId: leakedPositionId,
             episodeId: 'episode-stale',
             directionKind: 'upper-bound-breach',
-            triggeredAt: makeClockTimestamp(now - 10 * 60_000),
-            confirmationEvaluatedAt: makeClockTimestamp(now - 10 * 60_000 + 1),
+            triggeredAt: makeClockTimestamp(now - 11 * 60_000),
+            confirmationEvaluatedAt: makeClockTimestamp(now - 11 * 60_000 + 1),
             episodeStatus: 'open',
           },
         ],

--- a/packages/adapters/src/outbound/storage/OperationalStorageAdapter.ts
+++ b/packages/adapters/src/outbound/storage/OperationalStorageAdapter.ts
@@ -25,6 +25,7 @@ import type {
   BreachDirection,
 } from '@clmm/domain';
 import { LOWER_BOUND_BREACH, UPPER_BOUND_BREACH, makeClockTimestamp } from '@clmm/domain';
+import { BREACH_SCAN_INTERVAL_MS } from '../../inbound/jobs/breach-scan-schedule.js';
 
 function directionFromKind(kind: string) {
   if (kind === 'lower-bound-breach') return LOWER_BOUND_BREACH;
@@ -32,9 +33,9 @@ function directionFromKind(kind: string) {
   throw new Error(`directionFromKind: unknown kind ${kind}`);
 }
 
-// Scan jobs run every 60s; keep two cycles of ownership history hot so
+// Scan jobs run every 5m; keep two cycles of ownership history hot so
 // listActionableTriggers ignores stale ownership rows without dropping history.
-const OWNERSHIP_STALE_AFTER_MS = 2 * 60_000;
+const OWNERSHIP_STALE_AFTER_MS = 2 * BREACH_SCAN_INTERVAL_MS;
 
 export class OperationalStorageAdapter
   implements BreachEpisodeRepository, TriggerRepository, ExecutionRepository, ExecutionSessionRepository

--- a/packages/adapters/src/outbound/storage/OperationalStorageAdapter.ts
+++ b/packages/adapters/src/outbound/storage/OperationalStorageAdapter.ts
@@ -1,6 +1,6 @@
 import { and, eq, inArray } from 'drizzle-orm';
 import type { Db } from './db.js';
-import { breachEpisodes, exitTriggers, executionAttempts, executionSessions, executionPreviews, preparedPayloads } from './schema/index.js';
+import { breachEpisodes, exitTriggers, executionAttempts, executionSessions, executionPreviews, preparedPayloads, walletPositionOwnership } from './schema/index.js';
 import type {
   BreachEpisodeRepository,
   EpisodeTransition,
@@ -9,7 +9,6 @@ import type {
   ExecutionRepository,
   ExecutionSessionRepository,
   IdGeneratorPort,
-  SupportedPositionReadPort,
   StoredExecutionAttempt,
 } from '@clmm/application';
 import type {
@@ -39,7 +38,6 @@ export class OperationalStorageAdapter
   constructor(
     private readonly db: Db,
     private readonly ids: IdGeneratorPort,
-    private readonly positionReadPort: SupportedPositionReadPort,
   ) {}
 
   // --- BreachEpisodeRepository ---
@@ -318,8 +316,12 @@ export class OperationalStorageAdapter
   }
 
   async listActionableTriggers(walletId: WalletId): Promise<ExitTrigger[]> {
-    const positions = await this.positionReadPort.listSupportedPositions(walletId);
-    const positionIds = positions.map((position) => position.positionId);
+    const ownershipRows = await this.db
+      .select()
+      .from(walletPositionOwnership)
+      .where(eq(walletPositionOwnership.walletId, walletId));
+
+    const positionIds = ownershipRows.map((row) => row.positionId);
     if (positionIds.length === 0) {
       return [];
     }

--- a/packages/adapters/src/outbound/storage/OperationalStorageAdapter.ts
+++ b/packages/adapters/src/outbound/storage/OperationalStorageAdapter.ts
@@ -32,6 +32,10 @@ function directionFromKind(kind: string) {
   throw new Error(`directionFromKind: unknown kind ${kind}`);
 }
 
+// Scan jobs run every 60s; keep two cycles of ownership history hot so
+// listActionableTriggers ignores stale ownership rows without dropping history.
+const OWNERSHIP_STALE_AFTER_MS = 2 * 60_000;
+
 export class OperationalStorageAdapter
   implements BreachEpisodeRepository, TriggerRepository, ExecutionRepository, ExecutionSessionRepository
 {
@@ -316,12 +320,17 @@ export class OperationalStorageAdapter
   }
 
   async listActionableTriggers(walletId: WalletId): Promise<ExitTrigger[]> {
+    const now = Date.now();
     const ownershipRows = await this.db
       .select()
       .from(walletPositionOwnership)
       .where(eq(walletPositionOwnership.walletId, walletId));
 
-    const positionIds = ownershipRows.map((row) => row.positionId);
+    const freshOwnershipRows = ownershipRows.filter(
+      (row) => now - row.lastSeenAt <= OWNERSHIP_STALE_AFTER_MS,
+    );
+
+    const positionIds = freshOwnershipRows.map((row) => row.positionId);
     if (positionIds.length === 0) {
       return [];
     }

--- a/packages/adapters/src/outbound/swap-execution/SolanaExecutionPreparationAdapter.test.ts
+++ b/packages/adapters/src/outbound/swap-execution/SolanaExecutionPreparationAdapter.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
 import type { Instruction } from '@solana/kit';
-import type { ExecutionPlan, PoolId, WalletId } from '@clmm/domain';
+import type { ExecutionPlan, PoolId, PositionId, WalletId } from '@clmm/domain';
 import { SolanaExecutionPreparationAdapter } from './SolanaExecutionPreparationAdapter';
 import { SolanaPositionSnapshotReader } from '../solana-position-reads/SolanaPositionSnapshotReader';
 
@@ -77,12 +77,12 @@ describe('SolanaExecutionPreparationAdapter', () => {
 
   it('uses the snapshot reader when preparing execution', async () => {
     const mockReader = new SolanaPositionSnapshotReader('https://api.mainnet-beta.solana.com');
-    vi.mocked(mockReader.fetchSinglePosition).mockResolvedValue({
-      positionId: MOCK_POSITION_ID as any,
+    mockReader.fetchSinglePosition = vi.fn().mockResolvedValue({
+      positionId: MOCK_POSITION_ID,
       walletId: MOCK_WALLET,
       poolId: MOCK_POOL,
       bounds: { lowerBound: -100, upperBound: 100 },
-      lastObservedAt: 1_000_000 as any,
+      lastObservedAt: 1_000_000,
       rangeState: { kind: 'in-range', currentPrice: 50 },
       monitoringReadiness: { kind: 'active' },
     });
@@ -121,13 +121,15 @@ describe('SolanaExecutionPreparationAdapter', () => {
     await expect(adapter.prepareExecution({
       plan: { steps: [] } as unknown as ExecutionPlan,
       walletId: MOCK_WALLET,
-      positionId: MOCK_POSITION_ID as any,
-    })).resolves.toEqual(expect.objectContaining({
-      serializedPayload: expect.any(Uint8Array),
-    }));
+      positionId: MOCK_POSITION_ID as PositionId,
+    })).resolves.toMatchObject({
+      serializedPayload: expect.any(Uint8Array) as Uint8Array,
+    });
 
-    expect(mockReader.fetchSinglePosition).toHaveBeenCalledOnce();
-    expect(mockReader.fetchSinglePosition).toHaveBeenCalledWith(
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    const fetchSinglePosition = mockReader.fetchSinglePosition;
+    expect(fetchSinglePosition).toHaveBeenCalledOnce();
+    expect(fetchSinglePosition).toHaveBeenCalledWith(
       expect.anything(),
       MOCK_POSITION_ID,
       MOCK_WALLET,

--- a/packages/adapters/src/outbound/swap-execution/SolanaExecutionPreparationAdapter.test.ts
+++ b/packages/adapters/src/outbound/swap-execution/SolanaExecutionPreparationAdapter.test.ts
@@ -5,6 +5,7 @@ import { SolanaExecutionPreparationAdapter } from './SolanaExecutionPreparationA
 import { SolanaPositionSnapshotReader } from '../solana-position-reads/SolanaPositionSnapshotReader';
 
 const MOCK_WALLET = '4Nd1mBQtrMJVYVfKf2PJy9NZUZdTAsp7D4xWLs4gDB4T' as WalletId;
+const MOCK_POSITION_ID = '9WzDXwBbmkg8ZTbNMqUxvQRAyrZzDsGYdLVL9zYtAWWM';
 const MOCK_POOL = '7qbRF6YsyGuLUVs6Y1q64bdVrfe4ZcUUz1JRdoVNUJnm' as unknown as PoolId;
 
 const SOL_MINT = 'So11111111111111111111111111111111111111112';
@@ -74,49 +75,62 @@ describe('SolanaExecutionPreparationAdapter', () => {
     expect(result.instructions).toEqual([fallbackInstruction]);
   });
 
-  it('fetchSinglePosition on reader returns the real walletId, not the position mint', async () => {
-    const whirlpoolsClient = await import('@orca-so/whirlpools-client');
-
-    const mockPositionMint = '9WzDXwBbmkg8ZTbNMqUxvQRAyrZzDsGYdLVL9zYtAWWM';
-    const mockWhirlpoolAddress = '7qbRF6YsyGuLUVs6Y1q64bdVrfe4ZcUUz1JRdoVNUJnm';
-    const mockRpc = {} as unknown;
-
-    vi.mocked(whirlpoolsClient.getPositionAddress).mockResolvedValue([
-      'DerivedPositionPDA11111111111111111111111111',
-      0,
-    ] as unknown as Awaited<ReturnType<typeof whirlpoolsClient.getPositionAddress>>);
-
-    vi.mocked(whirlpoolsClient.fetchPosition).mockResolvedValue({
-      address: 'DerivedPositionPDA11111111111111111111111111',
-      data: {
-        whirlpool: mockWhirlpoolAddress,
-        tickLowerIndex: -100,
-        tickUpperIndex: 100,
-        positionMint: mockPositionMint,
-      },
-    } as unknown as Awaited<ReturnType<typeof whirlpoolsClient.fetchPosition>>);
-
-    vi.mocked(whirlpoolsClient.fetchWhirlpool).mockResolvedValue({
-      data: {
-        tickCurrentIndex: 50,
-      },
-    } as unknown as Awaited<ReturnType<typeof whirlpoolsClient.fetchWhirlpool>>);
-
+  it('uses the snapshot reader when preparing execution', async () => {
     const mockReader = new SolanaPositionSnapshotReader('https://api.mainnet-beta.solana.com');
     vi.mocked(mockReader.fetchSinglePosition).mockResolvedValue({
-      positionId: mockPositionMint as any,
+      positionId: MOCK_POSITION_ID as any,
       walletId: MOCK_WALLET,
-      poolId: mockWhirlpoolAddress as any,
+      poolId: MOCK_POOL,
       bounds: { lowerBound: -100, upperBound: 100 },
-      lastObservedAt: { timestamp: Date.now() } as any,
+      lastObservedAt: 1_000_000 as any,
       rangeState: { kind: 'in-range', currentPrice: 50 },
-      monitoringReadiness: { kind: 'active' } as any,
-    } as any);
+      monitoringReadiness: { kind: 'active' },
+    });
 
-    const result = await mockReader.fetchSinglePosition(mockRpc as any, mockPositionMint as any, MOCK_WALLET);
+    const adapter = new SolanaExecutionPreparationAdapter('https://api.mainnet-beta.solana.com', mockReader);
+    const internal = adapter as unknown as {
+      getRpc: () => {
+        getLatestBlockhash: () => { send: () => Promise<{ value: { blockhash: string; lastValidBlockHeight: bigint } }> };
+      };
+      buildOrcaInstructions: (...args: unknown[]) => Promise<{
+        instructions: Instruction[];
+        tokenAmounts: { tokenA: bigint; tokenB: bigint };
+        tokenMintA: string;
+        tokenMintB: string;
+      }>;
+      buildSwapInstructions: (...args: unknown[]) => Promise<{ instructions: Instruction[]; failureReason?: string }>;
+    };
 
-    expect(result).not.toBeNull();
-    expect(result!.walletId).toBe(MOCK_WALLET);
-    expect(result!.walletId).not.toBe(mockPositionMint);
+    vi.spyOn(internal, 'getRpc').mockReturnValue({
+      getLatestBlockhash: () => ({
+        send: async () => ({
+          value: { blockhash: '11111111111111111111111111111111', lastValidBlockHeight: 1n },
+        }),
+      }),
+    } as never);
+
+    vi.spyOn(internal, 'buildOrcaInstructions').mockResolvedValue({
+      instructions: [],
+      tokenAmounts: { tokenA: 0n, tokenB: 0n },
+      tokenMintA: SOL_MINT,
+      tokenMintB: USDC_MINT,
+    });
+
+    vi.spyOn(internal, 'buildSwapInstructions').mockResolvedValue({ instructions: [] });
+
+    await expect(adapter.prepareExecution({
+      plan: { steps: [] } as unknown as ExecutionPlan,
+      walletId: MOCK_WALLET,
+      positionId: MOCK_POSITION_ID as any,
+    })).resolves.toEqual(expect.objectContaining({
+      serializedPayload: expect.any(Uint8Array),
+    }));
+
+    expect(mockReader.fetchSinglePosition).toHaveBeenCalledOnce();
+    expect(mockReader.fetchSinglePosition).toHaveBeenCalledWith(
+      expect.anything(),
+      MOCK_POSITION_ID,
+      MOCK_WALLET,
+    );
   });
 });

--- a/packages/adapters/src/outbound/swap-execution/SolanaExecutionPreparationAdapter.test.ts
+++ b/packages/adapters/src/outbound/swap-execution/SolanaExecutionPreparationAdapter.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi } from 'vitest';
 import type { Instruction } from '@solana/kit';
 import type { ExecutionPlan, PoolId, WalletId } from '@clmm/domain';
 import { SolanaExecutionPreparationAdapter } from './SolanaExecutionPreparationAdapter';
+import { SolanaPositionSnapshotReader } from '../solana-position-reads/SolanaPositionSnapshotReader';
 
 const MOCK_WALLET = '4Nd1mBQtrMJVYVfKf2PJy9NZUZdTAsp7D4xWLs4gDB4T' as WalletId;
 const MOCK_POOL = '7qbRF6YsyGuLUVs6Y1q64bdVrfe4ZcUUz1JRdoVNUJnm' as unknown as PoolId;
@@ -15,11 +16,20 @@ vi.mock('@orca-so/whirlpools-client', () => ({
   fetchWhirlpool: vi.fn(),
 }));
 
+vi.mock('../solana-position-reads/SolanaPositionSnapshotReader', () => ({
+  SolanaPositionSnapshotReader: vi.fn().mockImplementation(() => ({
+    fetchSinglePosition: vi.fn(),
+    fetchWhirlpoolsBatched: vi.fn(),
+    getRpc: vi.fn(() => ({})),
+  })),
+}));
+
 describe('SolanaExecutionPreparationAdapter', () => {
   it('falls back to Orca swap instructions when Jupiter quote is unavailable', async () => {
     vi.spyOn(console, 'error').mockImplementation(() => {});
 
-    const adapter = new SolanaExecutionPreparationAdapter('https://api.mainnet-beta.solana.com');
+    const mockReader = new SolanaPositionSnapshotReader('https://api.mainnet-beta.solana.com');
+    const adapter = new SolanaExecutionPreparationAdapter('https://api.mainnet-beta.solana.com', mockReader);
     const internal = adapter as unknown as {
       getJupiterQuote: (inputMint: string, outputMint: string, amount: string) => Promise<unknown>;
       buildSwapInstructions: (
@@ -64,7 +74,7 @@ describe('SolanaExecutionPreparationAdapter', () => {
     expect(result.instructions).toEqual([fallbackInstruction]);
   });
 
-  it('fetchPositionData returns the real walletId, not the position mint', async () => {
+  it('fetchSinglePosition on reader returns the real walletId, not the position mint', async () => {
     const whirlpoolsClient = await import('@orca-so/whirlpools-client');
 
     const mockPositionMint = '9WzDXwBbmkg8ZTbNMqUxvQRAyrZzDsGYdLVL9zYtAWWM';
@@ -92,16 +102,18 @@ describe('SolanaExecutionPreparationAdapter', () => {
       },
     } as unknown as Awaited<ReturnType<typeof whirlpoolsClient.fetchWhirlpool>>);
 
-    const adapter = new SolanaExecutionPreparationAdapter('https://api.mainnet-beta.solana.com');
-    const internal = adapter as unknown as {
-      fetchPositionData: (
-        rpc: unknown,
-        positionId: string,
-        walletId: WalletId,
-      ) => Promise<{ walletId: string } | null>;
-    };
+    const mockReader = new SolanaPositionSnapshotReader('https://api.mainnet-beta.solana.com');
+    vi.mocked(mockReader.fetchSinglePosition).mockResolvedValue({
+      positionId: mockPositionMint as any,
+      walletId: MOCK_WALLET,
+      poolId: mockWhirlpoolAddress as any,
+      bounds: { lowerBound: -100, upperBound: 100 },
+      lastObservedAt: { timestamp: Date.now() } as any,
+      rangeState: { kind: 'in-range', currentPrice: 50 },
+      monitoringReadiness: { kind: 'active' } as any,
+    } as any);
 
-    const result = await internal.fetchPositionData(mockRpc, mockPositionMint, MOCK_WALLET);
+    const result = await mockReader.fetchSinglePosition(mockRpc as any, mockPositionMint as any, MOCK_WALLET);
 
     expect(result).not.toBeNull();
     expect(result!.walletId).toBe(MOCK_WALLET);

--- a/packages/adapters/src/outbound/swap-execution/SolanaExecutionPreparationAdapter.ts
+++ b/packages/adapters/src/outbound/swap-execution/SolanaExecutionPreparationAdapter.ts
@@ -225,6 +225,7 @@ export class SolanaExecutionPreparationAdapter implements ExecutionPreparationPo
     } catch (jupiterError) {
       const jupiterMessage =
         jupiterError instanceof Error ? jupiterError.message : 'unknown Jupiter swap preparation error';
+      // eslint-disable-next-line no-console
       console.error('Jupiter swap preparation failed, attempting Orca fallback:', jupiterError);
 
       try {
@@ -239,6 +240,7 @@ export class SolanaExecutionPreparationAdapter implements ExecutionPreparationPo
         return { instructions };
       } catch (orcaError) {
         const orcaMessage = orcaError instanceof Error ? orcaError.message : 'unknown Orca fallback error';
+        // eslint-disable-next-line no-console
         console.error('Orca fallback swap preparation failed:', orcaError);
         return {
           instructions: [],

--- a/packages/adapters/src/outbound/swap-execution/SolanaExecutionPreparationAdapter.ts
+++ b/packages/adapters/src/outbound/swap-execution/SolanaExecutionPreparationAdapter.ts
@@ -30,12 +30,13 @@ import {
   setTransactionMessageLifetimeUsingBlockhash,
   prependTransactionMessageInstructions,
 } from '@solana/kit';
-import { fetchPosition, fetchWhirlpool, getPositionAddress } from '@orca-so/whirlpools-client';
+import { fetchWhirlpool } from '@orca-so/whirlpools-client';
 import { closePositionInstructions, swapInstructions, setNativeMintWrappingStrategy } from '@orca-so/whirlpools';
 import type { Instruction } from '@solana/kit';
 import type { ExecutionPreparationPort } from '@clmm/application';
 import type { ExecutionPlan, WalletId, PositionId, PoolId, ClockTimestamp, LiquidityPosition } from '@clmm/domain';
 import { makeClockTimestamp } from '@clmm/domain';
+import { SolanaPositionSnapshotReader } from '../solana-position-reads/SolanaPositionSnapshotReader.js';
 
 const JUPITER_SWAP_API_BASES = [
   'https://lite-api.jup.ag/swap/v1',
@@ -50,7 +51,10 @@ const TOKEN_MINTS: Record<'SOL' | 'USDC', string> = {
 };
 
 export class SolanaExecutionPreparationAdapter implements ExecutionPreparationPort {
-  constructor(private readonly rpcUrl: string) {}
+  constructor(
+    private readonly rpcUrl: string,
+    private readonly snapshotReader: SolanaPositionSnapshotReader,
+  ) {}
 
   private getRpc() {
     return createSolanaRpc(this.rpcUrl);
@@ -74,7 +78,7 @@ export class SolanaExecutionPreparationAdapter implements ExecutionPreparationPo
 
     const { value: latestBlockhash } = await rpc.getLatestBlockhash().send();
 
-    const positionData = await this.fetchPositionData(rpc, positionId, walletId);
+    const positionData = await this.snapshotReader.fetchSinglePosition(rpc, positionId, walletId);
     if (!positionData) {
       throw new Error(`Position not found: ${positionId}`);
     }
@@ -119,53 +123,6 @@ export class SolanaExecutionPreparationAdapter implements ExecutionPreparationPo
       serializedPayload: serializedBytes,
       preparedAt: makeClockTimestamp(Date.now()),
     };
-  }
-
-  private async fetchPositionData(rpc: ReturnType<typeof createSolanaRpc>, positionId: PositionId, walletId: WalletId): Promise<LiquidityPosition | null> {
-    try {
-      const positionMint = address(positionId);
-      const [positionAddress] = await getPositionAddress(positionMint);
-      const positionAccount = await fetchPosition(rpc, positionAddress);
-      const position = positionAccount.data;
-      const whirlpoolAddress = position.whirlpool;
-
-      const whirlpoolAccount = await fetchWhirlpool(rpc, whirlpoolAddress);
-      const whirlpool = whirlpoolAccount.data;
-
-      const bounds = {
-        lowerBound: position.tickLowerIndex,
-        upperBound: position.tickUpperIndex,
-      };
-
-      const currentTick = whirlpool.tickCurrentIndex;
-      const rangeState = this.evaluateRangeState(bounds, currentTick);
-
-      return {
-        positionId,
-        walletId,
-        // boundary: Orca SDK returns Address type; domain uses branded PoolId
-        poolId: whirlpoolAddress.toString() as unknown as PoolId,
-        bounds,
-        lastObservedAt: makeClockTimestamp(Date.now()),
-        rangeState,
-        monitoringReadiness: { kind: 'active' },
-      };
-    } catch {
-      return null;
-    }
-  }
-
-  private evaluateRangeState(
-    bounds: { lowerBound: number; upperBound: number },
-    currentTick: number
-  ): { kind: 'in-range' | 'below-range' | 'above-range'; currentPrice: number } {
-    if (currentTick < bounds.lowerBound) {
-      return { kind: 'below-range', currentPrice: currentTick };
-    }
-    if (currentTick > bounds.upperBound) {
-      return { kind: 'above-range', currentPrice: currentTick };
-    }
-    return { kind: 'in-range', currentPrice: currentTick };
   }
 
   private async buildOrcaInstructions(


### PR DESCRIPTION
## Summary
Reduce redundant Solana RPC work in the read path by sharing a direct snapshot reader across position reads and execution preparation, and by making trigger listing DB-only.

## What changed
- Added `SolanaPositionSnapshotReader` with direct single-position reads and deduped whirlpool batching.
- Rewired `OrcaPositionReadAdapter` and `SolanaExecutionPreparationAdapter` to consume the shared reader.
- Made `OperationalStorageAdapter.listActionableTriggers()` query `wallet_position_ownership` instead of the chain.
- Persisted ownership rows during wallet scans so trigger listing stays current from the database.
- Added adapter and integration coverage for the new read path.

## Verification
- `pnpm exec vitest run`
- `pnpm exec tsc -p tsconfig.typecheck.json --noEmit`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/Codex-GPT_5.4-000000)