### PR TITLE
fix(app): resolve Phantom mobile browser routing failures

### DIFF
--- a/apps/app/app/(tabs)/alerts.tsx
+++ b/apps/app/app/(tabs)/alerts.tsx
@@ -4,6 +4,7 @@ import { AlertsListScreen } from '@clmm/ui';
 import { useStore } from 'zustand';
 import { fetchAlerts } from '../../src/api/alerts';
 import { walletSessionStore } from '../../src/state/walletSessionStore';
+import { navigateRoute } from '../../src/platform/webNavigation';
 
 export default function AlertsRoute() {
   const router = useRouter();
@@ -24,7 +25,11 @@ export default function AlertsRoute() {
       alertsError={alertsQuery.error instanceof Error ? alertsQuery.error.message : null}
       platformCapabilities={platformCapabilities}
       onSelectAlert={(triggerId: string, positionId: string) => {
-        router.push({ pathname: '/position/[id]', params: { id: positionId, triggerId } });
+        navigateRoute({
+          router,
+          path: `/position/${positionId}?triggerId=${encodeURIComponent(triggerId)}`,
+          method: 'push',
+        });
       }}
     />
   );

--- a/apps/app/app/(tabs)/positions.tsx
+++ b/apps/app/app/(tabs)/positions.tsx
@@ -5,6 +5,7 @@ import { useStore } from 'zustand';
 import { fetchSupportedPositions } from '../../src/api/positions';
 import { walletSessionStore } from '../../src/state/walletSessionStore';
 import type { PositionListItemViewModel } from '@clmm/ui';
+import { navigateRoute } from '../../src/platform/webNavigation';
 
 export default function PositionsRoute() {
   const router = useRouter();
@@ -24,8 +25,20 @@ export default function PositionsRoute() {
       positionsLoading={positionsQuery.isLoading}
       positionsError={positionsQuery.isError && !hasLoadedPositions ? 'Could not load supported positions for this wallet.' : null}
       platformCapabilities={platformCapabilities}
-      onConnectWallet={() => router.push('/connect')}
-      onSelectPosition={(positionId: PositionListItemViewModel['positionId']) => router.push(`/position/${positionId}`)}
+      onConnectWallet={() =>
+        navigateRoute({
+          router,
+          path: '/connect',
+          method: 'push',
+        })
+      }
+      onSelectPosition={(positionId: PositionListItemViewModel['positionId']) =>
+        navigateRoute({
+          router,
+          path: `/position/${positionId}`,
+          method: 'push',
+        })
+      }
     />
   );
 }

--- a/apps/app/app/(tabs)/wallet.tsx
+++ b/apps/app/app/(tabs)/wallet.tsx
@@ -2,6 +2,7 @@ import { useRouter } from 'expo-router';
 import { WalletSettingsScreen } from '@clmm/ui';
 import { useStore } from 'zustand';
 import { disconnectBrowserWallet } from '../../src/platform/browserWallet';
+import { navigateRoute } from '../../src/platform/webNavigation';
 import { walletSessionStore } from '../../src/state/walletSessionStore';
 
 export default function WalletRoute() {
@@ -14,12 +15,12 @@ export default function WalletRoute() {
 
   function handleReconnect() {
     clearOutcome();
-    router.push('/connect');
+    navigateRoute({ router, path: '/connect', method: 'push' });
   }
 
   function handleSwitchWallet() {
     disconnect();
-    router.push('/connect');
+    navigateRoute({ router, path: '/connect', method: 'push' });
   }
 
   async function handleDisconnect() {

--- a/apps/app/app/_layout.tsx
+++ b/apps/app/app/_layout.tsx
@@ -3,6 +3,7 @@ import { QueryClientProvider } from '@tanstack/react-query';
 import { Stack, useRouter } from 'expo-router';
 import { Platform } from 'react-native';
 import { queryClient } from '../src/composition/queryClient';
+import { navigateRoute } from '../src/platform/webNavigation';
 
 export default function RootLayout() {
   const router = useRouter();
@@ -22,11 +23,11 @@ export default function RootLayout() {
           triggerId?: string;
         };
         if (data.route) {
-          router.push(data.route);
+          navigateRoute({ router, path: data.route, method: 'push' });
         } else if (data.triggerId) {
-          router.push(`/preview/${data.triggerId}`);
+          navigateRoute({ router, path: `/preview/${data.triggerId}`, method: 'push' });
         } else if (data.positionId) {
-          router.push(`/position/${data.positionId}`);
+          navigateRoute({ router, path: `/position/${data.positionId}`, method: 'push' });
         }
       });
     };

--- a/apps/app/app/connect.tsx
+++ b/apps/app/app/connect.tsx
@@ -6,6 +6,7 @@ import type { PlatformCapabilityState } from '@clmm/application/public';
 import { platformCapabilityAdapter, walletPlatform } from '../src/composition/index';
 import { connectBrowserWallet } from '../src/platform/browserWallet';
 import { mapWalletErrorToOutcome } from '../src/platform/walletConnection';
+import { navigateRoute } from '../src/platform/webNavigation';
 import { walletSessionStore } from '../src/state/walletSessionStore';
 import { enrollWalletForMonitoring } from '../src/api/wallets';
 
@@ -76,11 +77,14 @@ export default function ConnectRoute() {
           : await walletPlatform.connectNativeWallet();
 
       markConnected({ walletAddress, connectionKind: kind });
-      // Best-effort enrollment -- non-blocking
       enrollWalletForMonitoring(walletAddress).catch((err) => {
         console.warn('Wallet enrollment failed (will retry on next connect):', err);
       });
-      router.replace('/(tabs)/positions');
+      navigateRoute({
+        router,
+        path: '/(tabs)/positions',
+        method: 'replace',
+      });
     } catch (error) {
       handleConnectionError(error);
     }

--- a/apps/app/app/execution/[attemptId].tsx
+++ b/apps/app/app/execution/[attemptId].tsx
@@ -2,6 +2,7 @@ import { useRouter, useLocalSearchParams } from 'expo-router';
 import { useQuery } from '@tanstack/react-query';
 import { ExecutionResultScreen } from '@clmm/ui';
 import { fetchExecution } from '../../src/api/executions';
+import { navigateRoute } from '../../src/platform/webNavigation';
 
 function readAttemptId(value: string | string[] | undefined): string | null {
   return typeof value === 'string' && value.length > 0 ? value : null;
@@ -32,7 +33,13 @@ export default function ExecutionRoute() {
         : {})}
       resultLoading={executionQuery.isLoading}
       resultError={executionQuery.error instanceof Error ? executionQuery.error.message : null}
-      onViewHistory={() => router.push('/(tabs)/history')}
+      onViewHistory={() => {
+        navigateRoute({
+          router,
+          path: '/(tabs)/history',
+          method: 'push',
+        });
+      }}
     />
   );
 }

--- a/apps/app/app/index.tsx
+++ b/apps/app/app/index.tsx
@@ -1,5 +1,6 @@
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import { useRootNavigationState, useRouter } from 'expo-router';
+import { navigateRoute } from '../src/platform/webNavigation';
 
 type RootNavigationState = {
   key?: string;
@@ -8,13 +9,19 @@ type RootNavigationState = {
 export default function IndexRoute() {
   const router = useRouter();
   const rootNavigationState = useRootNavigationState() as RootNavigationState | undefined;
+  const hasNavigated = useRef(false);
 
   useEffect(() => {
+    if (hasNavigated.current) {
+      return;
+    }
+
     if (!rootNavigationState?.key) {
       return;
     }
 
-    router.replace('/connect');
+    hasNavigated.current = true;
+    navigateRoute({ router, path: '/connect', method: 'replace' });
   }, [rootNavigationState?.key, router]);
 
   return null;

--- a/apps/app/app/position/[id].tsx
+++ b/apps/app/app/position/[id].tsx
@@ -4,6 +4,7 @@ import { PositionDetailScreen } from '@clmm/ui';
 import { Text, View } from 'react-native';
 import { useStore } from 'zustand';
 import { fetchPositionDetail } from '../../src/api/positions';
+import { navigateRoute } from '../../src/platform/webNavigation';
 import { walletSessionStore } from '../../src/state/walletSessionStore';
 
 export default function PositionDetailRoute() {
@@ -18,7 +19,7 @@ export default function PositionDetailRoute() {
 
   // Only redirect if we have a valid positionId, no wallet address, AND hydration is complete
   if (hasValidPositionId && !hasWalletAddress && hasHydrated) {
-    router.push('/connect');
+    navigateRoute({ router, path: '/connect', method: 'push' });
     return null;
   }
 
@@ -50,7 +51,11 @@ export default function PositionDetailRoute() {
     <PositionDetailScreen
       {...(position ? { position } : {})}
       onViewPreview={(resolvedTriggerId: string) =>
-        router.push(`/preview/${alertTriggerId ?? resolvedTriggerId}`)
+        navigateRoute({
+          router,
+          path: `/preview/${alertTriggerId ?? resolvedTriggerId}`,
+          method: 'push',
+        })
       }
     />
   );

--- a/apps/app/app/preview/[triggerId].tsx
+++ b/apps/app/app/preview/[triggerId].tsx
@@ -4,6 +4,7 @@ import { useMutation } from '@tanstack/react-query';
 import { ExecutionPreviewScreen } from '@clmm/ui';
 import { useStore } from 'zustand';
 import { createPreview, refreshPreview } from '../../src/api/previews';
+import { navigateRoute } from '../../src/platform/webNavigation';
 import { walletSessionStore } from '../../src/state/walletSessionStore';
 
 function readTriggerId(value: string | string[] | undefined): string | null {
@@ -18,7 +19,7 @@ export default function PreviewRoute() {
   const hasHydrated = useStore(walletSessionStore, (s) => s.hasHydrated);
 
   if (triggerId != null && walletAddress == null && hasHydrated) {
-    router.push('/connect');
+    navigateRoute({ router, path: '/connect', method: 'push' });
     return null;
   }
 
@@ -73,9 +74,20 @@ export default function PreviewRoute() {
                 signingParams.episodeId = preview.episodeId;
               }
 
-              router.push({
-                pathname: '/signing/[attemptId]',
-                params: signingParams,
+              navigateRoute({
+                router,
+                path: `/signing/${signingParams.attemptId}?previewId=${encodeURIComponent(
+                  signingParams.previewId,
+                )}${
+                  signingParams.triggerId != null
+                    ? `&triggerId=${encodeURIComponent(signingParams.triggerId)}`
+                    : ''
+                }${
+                  signingParams.episodeId != null
+                    ? `&episodeId=${encodeURIComponent(signingParams.episodeId)}`
+                    : ''
+                }`,
+                method: 'push',
               });
             },
           }

--- a/apps/app/app/signing/[attemptId].tsx
+++ b/apps/app/app/signing/[attemptId].tsx
@@ -14,6 +14,7 @@ import {
 import { signBrowserTransaction } from '../../src/platform/browserWallet';
 import { signNativeTransaction } from '../../src/platform/nativeWallet';
 import { mapWalletErrorToOutcome } from '../../src/platform/walletConnection';
+import { navigateRoute } from '../../src/platform/webNavigation';
 import { walletSessionStore } from '../../src/state/walletSessionStore';
 import type { ExecutionAttemptDto } from '@clmm/application/public';
 
@@ -79,7 +80,7 @@ export default function SigningRoute() {
 
   useEffect(() => {
     if (attemptId == null && walletAddress == null && hasHydrated) {
-      router.push('/connect');
+      navigateRoute({ router, path: '/connect', method: 'push' });
     }
   }, [attemptId, walletAddress, hasHydrated, router]);
 
@@ -110,9 +111,10 @@ export default function SigningRoute() {
       },
       {
         onSuccess: (approval) => {
-          router.replace({
-            pathname: '/signing/[attemptId]',
-            params: { attemptId: approval.attemptId },
+          navigateRoute({
+            router,
+            path: `/signing/${approval.attemptId}`,
+            method: 'replace',
           });
         },
       },
@@ -194,7 +196,11 @@ export default function SigningRoute() {
 
         await submitExecution(attemptId, signedPayload);
         await executionQuery.refetch();
-        router.replace(`/execution/${attemptId}`);
+        navigateRoute({
+          router,
+          path: `/execution/${attemptId}`,
+          method: 'replace',
+        });
       } catch (error: unknown) {
         const outcome = mapWalletErrorToOutcome(error);
 
@@ -288,14 +294,22 @@ export default function SigningRoute() {
       }
       statusNotice={statusNotice}
       onGoHome={() => {
-        router.replace('/(tabs)/positions');
+        navigateRoute({
+          router,
+          path: '/(tabs)/positions',
+          method: 'replace',
+        });
       }}
       {...(isPendingApprovalMode
         ? {
             ...(triggerId != null
               ? {
                   onRefreshQuote: () => {
-                    router.replace(`/preview/${triggerId}`);
+                    navigateRoute({
+                      router,
+                      path: `/preview/${triggerId}`,
+                      method: 'replace',
+                    });
                   },
                 }
               : {}),
@@ -316,7 +330,17 @@ export default function SigningRoute() {
               : {}),
           }
         : {})}
-      {...(attemptId != null ? { onViewResult: () => router.push(`/execution/${attemptId}`) } : {})}
+      {...(attemptId != null
+        ? {
+            onViewResult: () => {
+              navigateRoute({
+                router,
+                path: `/execution/${attemptId}`,
+                method: 'push',
+              });
+            },
+          }
+        : {})}
       signingState={signMutation.isPending ? 'signing' : 'idle'}
       walletConnected={walletAddress != null}
       onSignAndExecute={() => {

--- a/apps/app/src/appShellDependencies.test.ts
+++ b/apps/app/src/appShellDependencies.test.ts
@@ -52,6 +52,7 @@ describe('app shell wallet dependency guard', () => {
     const routeSource = readText('../app/(tabs)/positions.tsx');
 
     expect(routeSource).toContain('onSelectPosition');
-    expect(routeSource).toContain("router.push(`/position/");
+    expect(routeSource).toContain('navigateRoute');
+    expect(routeSource).toContain('/position/${');
   });
 });

--- a/apps/app/src/platform/webNavigation.test.ts
+++ b/apps/app/src/platform/webNavigation.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it, vi } from 'vitest';
+import { navigateRoute, normalizeExpoRouterRoute } from './webNavigation';
+
+describe('normalizeExpoRouterRoute', () => {
+  it('strips (tabs) group prefix', () => {
+    expect(normalizeExpoRouterRoute('/(tabs)/positions')).toBe('/positions');
+    expect(normalizeExpoRouterRoute('/(tabs)/history')).toBe('/history');
+  });
+
+  it('leaves non-group paths unchanged', () => {
+    expect(normalizeExpoRouterRoute('/position/abc')).toBe('/position/abc');
+    expect(normalizeExpoRouterRoute('/connect')).toBe('/connect');
+  });
+});
+
+describe('navigateRoute', () => {
+  it('uses router.push for push method', () => {
+    const router = {
+      push: vi.fn(),
+      replace: vi.fn(),
+    };
+
+    navigateRoute({
+      router,
+      path: '/position/abc',
+      method: 'push',
+    });
+
+    expect(router.push).toHaveBeenCalledWith('/position/abc');
+    expect(router.replace).not.toHaveBeenCalled();
+  });
+
+  it('uses router.replace for replace method', () => {
+    const router = {
+      push: vi.fn(),
+      replace: vi.fn(),
+    };
+
+    navigateRoute({
+      router,
+      path: '/connect',
+      method: 'replace',
+    });
+
+    expect(router.replace).toHaveBeenCalledWith('/connect');
+    expect(router.push).not.toHaveBeenCalled();
+  });
+
+  it('normalizes group paths to canonical form before routing', () => {
+    const router = {
+      push: vi.fn(),
+      replace: vi.fn(),
+    };
+
+    navigateRoute({
+      router,
+      path: '/(tabs)/positions',
+      method: 'replace',
+    });
+
+    expect(router.replace).toHaveBeenCalledWith('/positions');
+  });
+
+  it('preserves dynamic route params', () => {
+    const router = {
+      push: vi.fn(),
+      replace: vi.fn(),
+    };
+
+    navigateRoute({
+      router,
+      path: '/signing/attempt-123?previewId=prev-456&triggerId=trig-789',
+      method: 'push',
+    });
+
+    expect(router.push).toHaveBeenCalledWith('/signing/attempt-123?previewId=prev-456&triggerId=trig-789');
+  });
+});

--- a/apps/app/src/platform/webNavigation.ts
+++ b/apps/app/src/platform/webNavigation.ts
@@ -1,0 +1,25 @@
+type RouterLike = {
+  push: (path: string) => void;
+  replace: (path: string) => void;
+};
+
+type NavigationMethod = 'push' | 'replace';
+
+export function normalizeExpoRouterRoute(path: string): string {
+  return path.startsWith('/(tabs)/') ? path.replace('/(tabs)', '') : path;
+}
+
+export function navigateRoute(params: {
+  router: RouterLike;
+  path: string;
+  method: NavigationMethod;
+}): void {
+  const canonicalPath = normalizeExpoRouterRoute(params.path);
+
+  if (params.method === 'replace') {
+    params.router.replace(canonicalPath);
+    return;
+  }
+
+  params.router.push(canonicalPath);
+}

--- a/packages/ui/src/screens/AlertsListScreen.tsx
+++ b/packages/ui/src/screens/AlertsListScreen.tsx
@@ -82,6 +82,7 @@ export function AlertsListScreen({ alerts, alertsLoading, alertsError, onSelectA
             data={alertItems}
             keyExtractor={(item) => item.triggerId}
             style={{ marginTop: 12 }}
+            removeClippedSubviews={false}
             renderItem={({ item }) => (
               <TouchableOpacity
                 onPress={() => onSelectAlert?.(item.triggerId, item.positionId)}

--- a/packages/ui/src/screens/PositionsListScreen.tsx
+++ b/packages/ui/src/screens/PositionsListScreen.tsx
@@ -131,6 +131,7 @@ function ConnectedPositionsList({
       data={viewModel.items}
       keyExtractor={(item) => item.positionId}
       style={{ marginTop: 12 }}
+      removeClippedSubviews={false}
       renderItem={({ item }) => (
         <TouchableOpacity
           onPress={() => onSelectPosition?.(item.positionId)}


### PR DESCRIPTION
## Summary

- **FlatList touch events broken** (`removeClippedSubviews` default clips handlers on mobile web): `removeClippedSubviews={false}` added to `PositionsListScreen` and `AlertsListScreen` — fixes position/alert taps not responding
- **Route-group URL in History API** (`/(tabs)/positions` survived into `history.replaceState`): new `navigateRoute()` helper strips `/(tabs)/` prefix before delegating to `router.replace/push` — fixes connect→positions redirect
- **Object-form `router.push`** in alerts and preview routes converted to string URLs for consistent WebView behaviour

Also adds a `hasNavigated` ref in `index.tsx` to prevent duplicate navigation when `rootNavigationState` re-triggers the effect.

## Root causes traced from

Three separate code paths, three separate causes:

| Issue | Cause | Fix |
|-------|-------|-----|
| Position taps silent | `removeClippedSubviews` drops touch handlers off-screen | `removeClippedSubviews={false}` |
| connect→positions broken | `/(tabs)/positions` path literal in History API | `navigateRoute()` normalizes to `/positions` |
| Object-form push | `{ pathname, params }` form inconsistent in WebViews | String URL form everywhere |

## Test plan

- [ ] Open app in Phantom mobile browser — navigating to `/` should redirect to `/connect`
- [ ] Connect wallet on `/connect` — should redirect to `/positions`
- [ ] Tap a position on `/positions` — should navigate to position detail
- [ ] All existing tests pass (`pnpm test --filter @clmm/app`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)