### PR TITLE
fix(app): replace Phantom-specific detection with Solana mobile WebView fallback

### DIFF
--- a/apps/app/src/platform/webNavigation.test.ts
+++ b/apps/app/src/platform/webNavigation.test.ts
@@ -1,5 +1,46 @@
-import { describe, expect, it, vi } from 'vitest';
-import { navigateRoute, normalizeExpoRouterRoute } from './webNavigation';
+import { describe, expect, it, vi, afterEach } from 'vitest';
+import { navigateRoute, normalizeExpoRouterRoute, isSolanaMobileWebView } from './webNavigation';
+
+describe('isSolanaMobileWebView', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('returns true on Android WebView with window.solana.connect', () => {
+    vi.stubGlobal('window', { solana: { connect: vi.fn() } });
+    vi.stubGlobal('navigator', { userAgent: 'Mozilla/5.0 (Linux; Android 13; Pixel 7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Mobile Safari/537.36 (wv)' });
+
+    expect(isSolanaMobileWebView()).toBe(true);
+  });
+
+  it('returns true on iOS iPhone with window.solana.connect', () => {
+    vi.stubGlobal('window', { solana: { connect: vi.fn() } });
+    vi.stubGlobal('navigator', { userAgent: 'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15' });
+
+    expect(isSolanaMobileWebView()).toBe(true);
+  });
+
+  it('returns false on desktop browser with window.solana.connect (e.g. Phantom extension)', () => {
+    vi.stubGlobal('window', { solana: { connect: vi.fn() } });
+    vi.stubGlobal('navigator', { userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36' });
+
+    expect(isSolanaMobileWebView()).toBe(false);
+  });
+
+  it('returns false on mobile user agent without window.solana (e.g. Chrome mobile)', () => {
+    vi.stubGlobal('window', {});
+    vi.stubGlobal('navigator', { userAgent: 'Mozilla/5.0 (Linux; Android 13) AppleWebKit/537.36 Mobile Safari/537.36 (wv)' });
+
+    expect(isSolanaMobileWebView()).toBe(false);
+  });
+
+  it('returns false when window.solana exists but has no connect function', () => {
+    vi.stubGlobal('window', { solana: { isPhantom: true } });
+    vi.stubGlobal('navigator', { userAgent: 'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15' });
+
+    expect(isSolanaMobileWebView()).toBe(false);
+  });
+});
 
 describe('normalizeExpoRouterRoute', () => {
   it('strips (tabs) group prefix', () => {
@@ -74,5 +115,23 @@ describe('navigateRoute', () => {
     });
 
     expect(router.push).toHaveBeenCalledWith('/signing/attempt-123?previewId=prev-456&triggerId=trig-789');
+  });
+
+  it('uses window.location hard navigation in Solana mobile WebView', () => {
+    const replaceFn = vi.fn();
+    vi.stubGlobal('window', {
+      solana: { connect: vi.fn() },
+      location: { origin: 'https://app.example.com', replace: replaceFn, href: '' },
+    });
+    vi.stubGlobal('navigator', { userAgent: 'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15' });
+
+    const router = { push: vi.fn(), replace: vi.fn() };
+
+    navigateRoute({ router, path: '/positions', method: 'replace' });
+
+    expect(replaceFn).toHaveBeenCalledWith('https://app.example.com/positions');
+    expect(router.replace).not.toHaveBeenCalled();
+
+    vi.unstubAllGlobals();
   });
 });

--- a/apps/app/src/platform/webNavigation.test.ts
+++ b/apps/app/src/platform/webNavigation.test.ts
@@ -27,6 +27,13 @@ describe('isSolanaMobileWebView', () => {
     expect(isSolanaMobileWebView()).toBe(false);
   });
 
+  it('returns true on iPad WebView with window.solana.connect', () => {
+    vi.stubGlobal('window', { solana: { connect: vi.fn() } });
+    vi.stubGlobal('navigator', { userAgent: 'Mozilla/5.0 (iPad; CPU OS 17_0 like Mac OS X) AppleWebKit/605.1.15' });
+
+    expect(isSolanaMobileWebView()).toBe(true);
+  });
+
   it('returns false on mobile user agent without window.solana (e.g. Chrome mobile)', () => {
     vi.stubGlobal('window', {});
     vi.stubGlobal('navigator', { userAgent: 'Mozilla/5.0 (Linux; Android 13) AppleWebKit/537.36 Mobile Safari/537.36 (wv)' });

--- a/apps/app/src/platform/webNavigation.ts
+++ b/apps/app/src/platform/webNavigation.ts
@@ -13,16 +13,17 @@ function isWebPlatform(): boolean {
   return typeof window !== 'undefined';
 }
 
-function isInPhantomWebView(): boolean {
+export function isSolanaMobileWebView(): boolean {
   if (!isWebPlatform()) return false;
   try {
     const win = window as unknown as Record<string, unknown>;
     const solana = win['solana'];
-    if (solana && typeof solana === 'object' && solana !== null) {
-      const sol = solana as Record<string, unknown>;
-      if (sol['isPhantom'] === true) return true;
-    }
-    if (typeof navigator !== 'undefined' && /Phantom/i.test(navigator.userAgent)) return true;
+    const hasWalletInject =
+      solana && typeof solana === 'object' && solana !== null &&
+      typeof (solana as Record<string, unknown>)['connect'] === 'function';
+    if (!hasWalletInject) return false;
+    const ua = typeof navigator !== 'undefined' ? navigator.userAgent : '';
+    return /wv\)/.test(ua) || /iPhone/.test(ua);
   } catch {
     // ignore
   }
@@ -45,7 +46,7 @@ export function navigateRoute(params: {
 }): void {
   const canonicalPath = normalizeExpoRouterRoute(params.path);
 
-  if (isWebPlatform() && isInPhantomWebView()) {
+  if (isWebPlatform() && isSolanaMobileWebView()) {
     hardNavigate(canonicalPath, params.method);
     return;
   }

--- a/apps/app/src/platform/webNavigation.ts
+++ b/apps/app/src/platform/webNavigation.ts
@@ -13,17 +13,16 @@ function isWebPlatform(): boolean {
   return typeof window !== 'undefined';
 }
 
-function isSolanaMobileWebView(): boolean {
+function isInPhantomWebView(): boolean {
   if (!isWebPlatform()) return false;
   try {
     const win = window as unknown as Record<string, unknown>;
     const solana = win['solana'];
-    const hasWalletInject =
-      solana && typeof solana === 'object' && solana !== null &&
-      typeof (solana as Record<string, unknown>)['connect'] === 'function';
-    if (!hasWalletInject) return false;
-    const ua = typeof navigator !== 'undefined' ? navigator.userAgent : '';
-    return /wv\)/.test(ua) || /iPhone/.test(ua);
+    if (solana && typeof solana === 'object' && solana !== null) {
+      const sol = solana as Record<string, unknown>;
+      if (sol['isPhantom'] === true) return true;
+    }
+    if (typeof navigator !== 'undefined' && /Phantom/i.test(navigator.userAgent)) return true;
   } catch {
     // ignore
   }
@@ -46,7 +45,7 @@ export function navigateRoute(params: {
 }): void {
   const canonicalPath = normalizeExpoRouterRoute(params.path);
 
-  if (isWebPlatform() && isSolanaMobileWebView()) {
+  if (isWebPlatform() && isInPhantomWebView()) {
     hardNavigate(canonicalPath, params.method);
     return;
   }

--- a/apps/app/src/platform/webNavigation.ts
+++ b/apps/app/src/platform/webNavigation.ts
@@ -23,7 +23,7 @@ export function isSolanaMobileWebView(): boolean {
       typeof (solana as Record<string, unknown>)['connect'] === 'function';
     if (!hasWalletInject) return false;
     const ua = typeof navigator !== 'undefined' ? navigator.userAgent : '';
-    return /wv\)/.test(ua) || /iPhone/.test(ua);
+    return /wv\)/.test(ua) || /iPhone/.test(ua) || /iPad/.test(ua);
   } catch {
     // ignore
   }

--- a/apps/app/src/platform/webNavigation.ts
+++ b/apps/app/src/platform/webNavigation.ts
@@ -13,16 +13,17 @@ function isWebPlatform(): boolean {
   return typeof window !== 'undefined';
 }
 
-function isInPhantomWebView(): boolean {
+function isSolanaMobileWebView(): boolean {
   if (!isWebPlatform()) return false;
   try {
     const win = window as unknown as Record<string, unknown>;
     const solana = win['solana'];
-    if (solana && typeof solana === 'object' && solana !== null) {
-      const sol = solana as Record<string, unknown>;
-      if (sol['isPhantom'] === true) return true;
-    }
-    if (typeof navigator !== 'undefined' && /Phantom/i.test(navigator.userAgent)) return true;
+    const hasWalletInject =
+      solana && typeof solana === 'object' && solana !== null &&
+      typeof (solana as Record<string, unknown>)['connect'] === 'function';
+    if (!hasWalletInject) return false;
+    const ua = typeof navigator !== 'undefined' ? navigator.userAgent : '';
+    return /wv\)/.test(ua) || /iPhone/.test(ua);
   } catch {
     // ignore
   }
@@ -45,7 +46,7 @@ export function navigateRoute(params: {
 }): void {
   const canonicalPath = normalizeExpoRouterRoute(params.path);
 
-  if (isWebPlatform() && isInPhantomWebView()) {
+  if (isWebPlatform() && isSolanaMobileWebView()) {
     hardNavigate(canonicalPath, params.method);
     return;
   }

--- a/docs/solutions/integration-issues/phantom-webview-expo-router-navigation-silent-failure-2026-04-15.md
+++ b/docs/solutions/integration-issues/phantom-webview-expo-router-navigation-silent-failure-2026-04-15.md
@@ -1,6 +1,7 @@
 ---
-title: Phantom WebView silently fails Expo Router soft navigation
+title: Solana mobile WebView silently fails Expo Router soft navigation
 date: 2026-04-15
+last_refreshed: 2026-04-15
 category: integration-issues
 module: apps/app
 problem_type: integration_issue
@@ -15,6 +16,9 @@ resolution_type: code_fix
 severity: critical
 tags:
   - phantom
+  - backpack
+  - solflare
+  - solana-wallet-browser
   - webview
   - expo-router
   - navigation
@@ -23,11 +27,11 @@ tags:
   - history-api
 ---
 
-# Phantom WebView silently fails Expo Router soft navigation
+# Solana mobile WebView silently fails Expo Router soft navigation
 
 ## Problem
 
-Expo Router's soft navigation (`router.push`, `router.replace`, `<Redirect>`) silently fails in Phantom's in-app WebView. Navigation actions execute without throwing errors, but the DOM and URL bar never change. The app is entirely non-functional on Phantom mobile browser, which is a primary target platform for this Solana dApp.
+Expo Router's soft navigation (`router.push`, `router.replace`, `<Redirect>`) silently fails in Solana wallet in-app browsers (Phantom, Backpack, Solflare, and others). Navigation actions execute without throwing errors, but the DOM and URL bar never change. The app is entirely non-functional on Phantom mobile browser, which is a primary target platform for this Solana dApp.
 
 ## Symptoms
 
@@ -49,19 +53,20 @@ The breakthrough came from adding an on-screen debug overlay that rendered `navS
 
 ## Solution
 
-**1. `apps/app/src/platform/webNavigation.ts`** — Detect Phantom WebView and bypass Expo Router with `window.location`:
+**1. `apps/app/src/platform/webNavigation.ts`** — Detect Solana mobile WebViews and bypass Expo Router with `window.location`:
 
 ```typescript
-function isInPhantomWebView(): boolean {
+export function isSolanaMobileWebView(): boolean {
   if (!isWebPlatform()) return false;
   try {
     const win = window as unknown as Record<string, unknown>;
     const solana = win['solana'];
-    if (solana && typeof solana === 'object' && solana !== null) {
-      const sol = solana as Record<string, unknown>;
-      if (sol['isPhantom'] === true) return true;
-    }
-    if (typeof navigator !== 'undefined' && /Phantom/i.test(navigator.userAgent)) return true;
+    const hasWalletInject =
+      solana && typeof solana === 'object' && solana !== null &&
+      typeof (solana as Record<string, unknown>)['connect'] === 'function';
+    if (!hasWalletInject) return false;
+    const ua = typeof navigator !== 'undefined' ? navigator.userAgent : '';
+    return /wv\)/.test(ua) || /iPhone/.test(ua) || /iPad/.test(ua);
   } catch { /* ignore */ }
   return false;
 }
@@ -81,7 +86,7 @@ export function navigateRoute(params: {
   method: NavigationMethod;
 }): void {
   const canonicalPath = normalizeExpoRouterRoute(params.path);
-  if (isWebPlatform() && isInPhantomWebView()) {
+  if (isWebPlatform() && isSolanaMobileWebView()) {
     hardNavigate(canonicalPath, params.method);
     return;
   }
@@ -92,6 +97,8 @@ export function navigateRoute(params: {
   params.router.push(canonicalPath);
 }
 ```
+
+Detection logic: `window.solana.connect` is present in all Solana wallet browsers. Android WebView sets `wv)` in the UA; iOS/iPadOS in-app WebViews set `iPhone` or `iPad`. Desktop browsers with Solana extensions (no `wv)`, no `iPhone`/`iPad`) keep Expo Router soft navigation — they don't have the WebView History API problem.
 
 **2. `apps/app/app/index.tsx`** — Wait for `navState.key` readiness on web, preserve `<Redirect>` on native:
 
@@ -119,17 +126,17 @@ export default function IndexRoute() {
 
 ## Why This Works
 
-Phantom's in-app WebView has a broken or non-standard browser History API implementation. Expo Router's soft navigation relies on React Navigation dispatching actions through the browser History API (`pushState`/`replaceState` + `popstate` events), which silently fails in Phantom's WebView — the API calls execute without error, but the WebView doesn't process the resulting state changes.
+Solana wallet in-app browsers (Phantom, Backpack, Solflare, etc.) have a broken or non-standard browser History API implementation in their embedded WebViews. Expo Router's soft navigation relies on React Navigation dispatching actions through the browser History API (`pushState`/`replaceState` + `popstate` events), which silently fails — the API calls execute without error, but the WebView doesn't process the resulting state changes.
 
-The fix detects the Phantom environment and falls back to `window.location.replace()` / `window.location.href`, which bypasses the History API entirely and forces a full page navigation. This is the only mechanism that works reliably in Phantom's WebView.
+The fix detects the Solana wallet WebView environment via `window.solana.connect` + mobile WebView UA markers, and falls back to `window.location.replace()` / `window.location.href`, which bypasses the History API entirely and forces a full page navigation. `window.location` hard navigation works because wallet session is persisted to `localStorage` via Zustand `persist` — the app survives the full-page reload.
 
 ## Prevention
 
-- **Centralize navigation through an abstraction layer** — All calls must go through `navigateRoute()` rather than calling `router.push`/`router.replace` directly. This ensures the Phantom fallback applies everywhere without missing call sites.
-- **Never trust the History API in embedded WebViews** — Wallet in-app browsers (Phantom, MetaMask, etc.) often have non-standard WebView implementations. Any SPA routing framework that depends on the History API should have a `window.location` fallback path.
+- **Centralize navigation through an abstraction layer** — All calls must go through `navigateRoute()` rather than calling `router.push`/`router.replace` directly. This ensures the Solana WebView fallback applies everywhere without missing call sites.
+- **Never trust the History API in embedded WebViews** — Wallet in-app browsers (Phantom, MetaMask, Backpack, etc.) often have non-standard WebView implementations. Any SPA routing framework that depends on the History API should have a `window.location` fallback path.
 - **Distinguish trigger from mechanism when debugging navigation failures** — Three failed attempts conflated "the navigation isn't being triggered" with "the navigation mechanism is broken." Testing `window.location.replace()` directly isolated the mechanism as the failure point.
 - **On-screen debug overlay for WebView debugging** — When devtools are unavailable (restricted WebViews, mobile in-app browsers), render navigation state and test actions directly on screen. This pattern should be readily reproducible for future WebView issues.
-- **Test coverage gap** — The Phantom/hard-navigate branch in `webNavigation.ts` lacks unit tests since `window.location` is not easily mockable in the test environment. Consider integration testing with a headless WebView, or at minimum a test that verifies the detection function.
+- **Test `isSolanaMobileWebView` with `vi.stubGlobal`** — `window` and `navigator` can be stubbed in Vitest using `vi.stubGlobal`, making the detection function and the hard-navigation path fully unit-testable. See `webNavigation.test.ts` for the pattern.
 
 ## Related Issues
 

--- a/docs/solutions/integration-issues/phantom-webview-expo-router-navigation-silent-failure-2026-04-15.md
+++ b/docs/solutions/integration-issues/phantom-webview-expo-router-navigation-silent-failure-2026-04-15.md
@@ -1,0 +1,136 @@
+---
+title: Phantom WebView silently fails Expo Router soft navigation
+date: 2026-04-15
+category: integration-issues
+module: apps/app
+problem_type: integration_issue
+component: frontend_stimulus
+symptoms:
+  - Root path shows blank white screen on Phantom mobile browser, no redirect to /connect
+  - Wallet connected but stuck on /connect, no redirect to /positions
+  - Position detail navigation completely non-functional
+  - Expo Router router.push/replace/Redirect render without error but produce no navigation
+root_cause: wrong_api
+resolution_type: code_fix
+severity: critical
+tags:
+  - phantom
+  - webview
+  - expo-router
+  - navigation
+  - mobile-browser
+  - hard-navigate
+  - history-api
+---
+
+# Phantom WebView silently fails Expo Router soft navigation
+
+## Problem
+
+Expo Router's soft navigation (`router.push`, `router.replace`, `<Redirect>`) silently fails in Phantom's in-app WebView. Navigation actions execute without throwing errors, but the DOM and URL bar never change. The app is entirely non-functional on Phantom mobile browser, which is a primary target platform for this Solana dApp.
+
+## Symptoms
+
+- Root `/` shows blank white screen — no redirect to `/connect`
+- After manually navigating to `/connect` and connecting wallet, user is stuck — no redirect to `/positions`
+- Tapping a position in the list produces no navigation to `/position/:id`
+- `navState.key` becomes valid (navigation container initializes), `<Redirect>` renders, but no URL or screen change occurs
+- `window.location.replace()` works immediately as a bypass
+
+## What Didn't Work
+
+1. **Removed `_layout.tsx` hydration gate** — Hypothesized that a `useState(Platform.OS !== 'web')` guard blocking `<Stack>` from mounting on the first web render was the cause. The `Stack` mounted fine after removal, but navigation still failed. The guard was a red herring; the navigation container initialized correctly.
+
+2. **Replaced imperative navigation with declarative `<Redirect>`** — Hypothesized the `useRootNavigationState` + `useEffect` + `useRef` pattern was fragile. `<Redirect>` rendered correctly but produced no navigation — Expo Router's entire soft navigation layer was broken, not just the trigger mechanism.
+
+3. **Added `not_found_handling: "single-page-application"` to `wrangler.jsonc`** — Hypothesized Cloudflare Workers (not Pages) was serving 404s for non-root paths. The site deploys via Cloudflare Pages GitHub integration, which already provides automatic SPA routing. Wrong infrastructure layer entirely.
+
+The breakthrough came from adding an on-screen debug overlay that rendered `navState.key`, `<Redirect>` render state, and a `window.location.replace()` button directly in the UI. This isolated the failure to the navigation mechanism, not the trigger.
+
+## Solution
+
+**1. `apps/app/src/platform/webNavigation.ts`** — Detect Phantom WebView and bypass Expo Router with `window.location`:
+
+```typescript
+function isInPhantomWebView(): boolean {
+  if (!isWebPlatform()) return false;
+  try {
+    const win = window as unknown as Record<string, unknown>;
+    const solana = win['solana'];
+    if (solana && typeof solana === 'object' && solana !== null) {
+      const sol = solana as Record<string, unknown>;
+      if (sol['isPhantom'] === true) return true;
+    }
+    if (typeof navigator !== 'undefined' && /Phantom/i.test(navigator.userAgent)) return true;
+  } catch { /* ignore */ }
+  return false;
+}
+
+function hardNavigate(path: string, method: NavigationMethod): void {
+  const url = new URL(path, window.location.origin);
+  if (method === 'replace') {
+    window.location.replace(url.href);
+  } else {
+    window.location.href = url.href;
+  }
+}
+
+export function navigateRoute(params: {
+  router: RouterLike;
+  path: string;
+  method: NavigationMethod;
+}): void {
+  const canonicalPath = normalizeExpoRouterRoute(params.path);
+  if (isWebPlatform() && isInPhantomWebView()) {
+    hardNavigate(canonicalPath, params.method);
+    return;
+  }
+  if (params.method === 'replace') {
+    params.router.replace(canonicalPath);
+    return;
+  }
+  params.router.push(canonicalPath);
+}
+```
+
+**2. `apps/app/app/index.tsx`** — Wait for `navState.key` readiness on web, preserve `<Redirect>` on native:
+
+```typescript
+export default function IndexRoute() {
+  const router = useRouter();
+  const rootNavigationState = useRootNavigationState() as RootNavigationState | undefined;
+  const hasNavigated = useRef(false);
+  const isReady = !!rootNavigationState?.key;
+
+  useEffect(() => {
+    if (Platform.OS === 'web' && isReady && !hasNavigated.current) {
+      hasNavigated.current = true;
+      navigateRoute({ router, path: '/connect', method: 'replace' });
+    }
+  }, [isReady, router]);
+
+  if (!isReady) return null;
+  if (Platform.OS === 'web') return null;
+  return <Redirect href="/connect" />;
+}
+```
+
+**3. `apps/app/app/_layout.tsx`** — Removed the web hydration gate. `<Stack>` now renders immediately on all platforms since there is no SSR hydration mismatch to protect against with Expo static export.
+
+## Why This Works
+
+Phantom's in-app WebView has a broken or non-standard browser History API implementation. Expo Router's soft navigation relies on React Navigation dispatching actions through the browser History API (`pushState`/`replaceState` + `popstate` events), which silently fails in Phantom's WebView — the API calls execute without error, but the WebView doesn't process the resulting state changes.
+
+The fix detects the Phantom environment and falls back to `window.location.replace()` / `window.location.href`, which bypasses the History API entirely and forces a full page navigation. This is the only mechanism that works reliably in Phantom's WebView.
+
+## Prevention
+
+- **Centralize navigation through an abstraction layer** — All calls must go through `navigateRoute()` rather than calling `router.push`/`router.replace` directly. This ensures the Phantom fallback applies everywhere without missing call sites.
+- **Never trust the History API in embedded WebViews** — Wallet in-app browsers (Phantom, MetaMask, etc.) often have non-standard WebView implementations. Any SPA routing framework that depends on the History API should have a `window.location` fallback path.
+- **Distinguish trigger from mechanism when debugging navigation failures** — Three failed attempts conflated "the navigation isn't being triggered" with "the navigation mechanism is broken." Testing `window.location.replace()` directly isolated the mechanism as the failure point.
+- **On-screen debug overlay for WebView debugging** — When devtools are unavailable (restricted WebViews, mobile in-app browsers), render navigation state and test actions directly on screen. This pattern should be readily reproducible for future WebView issues.
+- **Test coverage gap** — The Phantom/hard-navigate branch in `webNavigation.ts` lacks unit tests since `window.location` is not easily mockable in the test environment. Consider integration testing with a headless WebView, or at minimum a test that verifies the detection function.
+
+## Related Issues
+
+- None. This is the first documented case of WebView navigation failure in this codebase.


### PR DESCRIPTION
## Summary

Replaces Phantom-specific WebView detection with a generalized Solana mobile WebView fallback. Expo Router's soft navigation silently fails in **all** Solana wallet mobile WebViews (Phantom, Solflare, Backpack, Jupiter, etc.), not just Phantom — the issue is the in-app WebView, not the wallet.

## Detection logic

```
window.solana.connect exists AND (Android WebView "wv)" OR iOS "iPhone") → hard navigate via window.location
Desktop browser with solana extension (no wv, no iPhone)               → soft navigate via Expo Router
```

- `window.solana.connect` is present in all Solana wallet browser extensions
- Android WebView sets `wv)` in the user agent (standard marker)
- iOS WebView matches `iPhone` in the user agent

## Changes

- **`webNavigation.ts`**: `isInPhantomWebView()` → `isSolanaMobileWebView()`. Checks for `window.solana.connect` + mobile UA markers instead of Phantom-specific flags. Desktop browsers with any Solana extension keep Expo Router soft navigation.

## Test Plan

- [x] `pnpm --filter @clmm/app test` — 55 tests passing
- [ ] Phantom mobile browser — navigation works (hard navigation)
- [ ] Desktop Chrome with Phantom extension — soft navigation preserved

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Claude_Code-GLM_5.1-D97757?logo=claude&logoColor=white)