### PR TITLE
fix(execution): pass payloadVersion through signing pipeline

### DIFF
--- a/apps/app/app/signing/[attemptId].tsx
+++ b/apps/app/app/signing/[attemptId].tsx
@@ -194,7 +194,7 @@ export default function SigningRoute() {
                 walletId: walletAddress,
               });
 
-        await submitExecution(attemptId, signedPayload);
+        await submitExecution(attemptId, signedPayload, signingPayload.payloadVersion);
         await executionQuery.refetch();
         navigateRoute({
           router,
@@ -341,7 +341,7 @@ export default function SigningRoute() {
             },
           }
         : {})}
-      signingState={signMutation.isPending ? 'signing' : 'idle'}
+      signingState={signMutation.isError ? 'error' : signMutation.isPending ? 'signing' : 'idle'}
       walletConnected={walletAddress != null}
       onSignAndExecute={() => {
         signMutation.mutate();

--- a/apps/app/src/api/executions.test.ts
+++ b/apps/app/src/api/executions.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { approveExecutionPreview } from './executions';
+import { approveExecutionPreview, fetchExecutionSigningPayload, submitExecution } from './executions';
 
 type ExpoPublicEnv = NodeJS.ProcessEnv & {
   EXPO_PUBLIC_BFF_BASE_URL?: string;
@@ -59,6 +59,77 @@ describe('approveExecutionPreview', () => {
           episodeId: 'episode-1',
         }),
       }),
+    );
+  });
+});
+
+describe('submitExecution', () => {
+  afterEach(() => {
+    globalThis.fetch = ORIGINAL_FETCH;
+    restoreBffBaseUrl();
+  });
+
+  it('includes payloadVersion in the request body when provided', async () => {
+    env.EXPO_PUBLIC_BFF_BASE_URL = 'https://bff.example.test';
+
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ result: 'confirmed' }),
+    });
+    globalThis.fetch = fetchMock as typeof fetch;
+
+    await submitExecution('attempt-1', 'signed-payload-base64', 'v1');
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://bff.example.test/executions/attempt-1/submit',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({ signedPayload: 'signed-payload-base64', payloadVersion: 'v1' }),
+      }),
+    );
+  });
+
+  it('omits payloadVersion from the request body when not provided', async () => {
+    env.EXPO_PUBLIC_BFF_BASE_URL = 'https://bff.example.test';
+
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ result: 'confirmed' }),
+    });
+    globalThis.fetch = fetchMock as typeof fetch;
+
+    await submitExecution('attempt-1', 'signed-payload-base64');
+
+    const call = fetchMock.mock.calls[0] as [string, RequestInit];
+    const body = JSON.parse(call[1].body as string) as Record<string, unknown>;
+    expect(body).not.toHaveProperty('payloadVersion');
+  });
+});
+
+describe('fetchExecutionSigningPayload', () => {
+  afterEach(() => {
+    globalThis.fetch = ORIGINAL_FETCH;
+    restoreBffBaseUrl();
+  });
+
+  it('rejects signing payload DTOs missing payloadVersion', async () => {
+    env.EXPO_PUBLIC_BFF_BASE_URL = 'https://bff.example.test';
+
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          signingPayload: {
+            attemptId: 'attempt-1',
+            serializedPayload: 'base64-payload',
+            lifecycleState: { kind: 'awaiting-signature' },
+          },
+        }),
+    });
+    globalThis.fetch = fetchMock as typeof fetch;
+
+    await expect(fetchExecutionSigningPayload('attempt-1')).rejects.toThrow(
+      'Malformed execution signing payload response',
     );
   });
 });

--- a/apps/app/src/api/executions.ts
+++ b/apps/app/src/api/executions.ts
@@ -114,6 +114,7 @@ function isExecutionSigningPayloadDto(value: unknown): value is ExecutionSigning
     typeof value['attemptId'] === 'string' &&
     typeof value['serializedPayload'] === 'string' &&
     value['serializedPayload'].length > 0 &&
+    typeof value['payloadVersion'] === 'string' &&
     isExecutionLifecycleState(value['lifecycleState']) &&
     (value['signingExpiresAt'] == null || typeof value['signingExpiresAt'] === 'number')
   );

--- a/docs/solutions/integration-issues/signing-payload-version-missing-from-submit-2026-04-23.md
+++ b/docs/solutions/integration-issues/signing-payload-version-missing-from-submit-2026-04-23.md
@@ -1,0 +1,82 @@
+---
+title: Signing payload pipeline omits payloadVersion, submit rejects with 409
+date: 2026-04-23
+category: integration-issues
+module: execution
+problem_type: integration_issue
+component: service_object
+symptoms:
+  - Execution stuck at awaiting-signature after user signs in Phantom wallet
+  - POST /executions/:attemptId/submit returns 409 "has a prepared payload; payloadVersion is required"
+  - Signing page shows no error after wallet confirmation
+root_cause: missing_workflow_step
+resolution_type: code_fix
+severity: critical
+tags: [signing, payload-version, phantom, execution-pipeline, silent-failure]
+---
+
+# Signing payload pipeline omits payloadVersion, submit rejects with 409
+
+## Problem
+
+After a user signs a transaction in Phantom wallet, the execution stays stuck at `awaiting-signature` indefinitely. The submit endpoint rejects the request with 409 because `payloadVersion` is required but never sent, and the error is silently swallowed by the UI.
+
+## Symptoms
+
+- User signs in Phantom, Phantom closes, page remains unchanged at "Awaiting Signature"
+- `GET /executions/:attemptId` returns `lifecycleState.kind: "awaiting-signature"` permanently
+- Server logs show 409: "Attempt has a prepared payload; payloadVersion is required"
+- No error is visible to the user
+
+## What Didn't Work
+
+- Initially assumed the wallet signing itself was failing — but Phantom returns successfully
+- Checking only the execution endpoint data — the 409 from submit was invisible because `signingState` never mapped to `'error'`
+
+## Solution
+
+The fix threads `payloadVersion` through the entire signing pipeline:
+
+1. **`GetAwaitingSignaturePayload.ts`**: Added `payloadVersion` to the `'found'` result, sourced from `preparedPayload.payloadVersion`
+2. **`ExecutionSigningPayloadDto`**: Added `payloadVersion: string` field
+3. **`ExecutionController.getSigningPayload`**: Included `payloadVersion` in the HTTP response
+4. **`isExecutionSigningPayloadDto`**: Added `typeof value['payloadVersion'] === 'string'` validation
+5. **`signing/[attemptId].tsx`**: Passed `signingPayload.payloadVersion` to `submitExecution(attemptId, signedPayload, payloadVersion)`
+6. **`signing/[attemptId].tsx`**: Mapped `signMutation.isError` to `signingState: 'error'` so submit failures surface in the UI
+
+Key code change in the signing page:
+
+```typescript
+// Before: version not sent
+await submitExecution(attemptId, signedPayload);
+
+// After: version threaded through
+await submitExecution(attemptId, signedPayload, signingPayload.payloadVersion);
+```
+
+And the signingState fix:
+
+```typescript
+// Before: error state invisible
+signingState={signMutation.isPending ? 'signing' : 'idle'}
+
+// After: error surfaces through existing error banner
+signingState={signMutation.isError ? 'error' : signMutation.isPending ? 'signing' : 'idle'}
+```
+
+## Why This Works
+
+The server's submit endpoint requires `payloadVersion` as a consistency check against the prepared payload. The use case (`GetAwaitingSignaturePayload`) had access to `preparedPayload.payloadVersion` but excluded it from the result type, so the version was never returned to the client and never sent back. The fix ensures the version travels the full round-trip: server stores it → server returns it → client sends it back.
+
+The `signingState` fix addresses the secondary issue: even when the 409 was returned, the error was caught by the mutation but never displayed because `SigningStatusScreen` only renders `signingError` when `signingState === 'error'`.
+
+## Prevention
+
+- **Regression test on the client call site**: Added test in `executions.test.ts` asserting `submitExecution('a', 'b', 'v1')` includes `payloadVersion: 'v1'` in the request body. Since `payloadVersion` is optional on the function signature, a future refactor could drop it silently — this test catches that.
+- **DTO validator test**: Added test asserting `fetchExecutionSigningPayload` rejects payloads missing `payloadVersion`.
+- **Pattern to watch**: When a server endpoint requires a field that originates from an earlier endpoint response, verify the full round-trip in both the DTO and the client call site. Optional parameters on client functions are easy to silently drop.
+
+## Related Issues
+
+- PR #22: The fix for this bug
+- PR #23: The adjacent UI rendering trap (statusError invisible when lifecycleState is present)

--- a/packages/adapters/src/inbound/http/ExecutionController.test.ts
+++ b/packages/adapters/src/inbound/http/ExecutionController.test.ts
@@ -220,6 +220,7 @@ describe('ExecutionController', () => {
       signingPayload: {
         attemptId: 'attempt-signing-payload',
         serializedPayload: Buffer.from([9, 8, 7]).toString('base64'),
+        payloadVersion: 'v1',
         lifecycleState: { kind: 'awaiting-signature' },
         signingExpiresAt: makeClockTimestamp(1_060_000),
       },

--- a/packages/adapters/src/inbound/http/ExecutionController.ts
+++ b/packages/adapters/src/inbound/http/ExecutionController.ts
@@ -235,6 +235,7 @@ export class ExecutionController {
       signingPayload: {
         attemptId: result.attemptId,
         serializedPayload: Buffer.from(result.serializedPayload).toString('base64'),
+        payloadVersion: result.payloadVersion,
         lifecycleState: result.lifecycleState,
         ...(result.signingExpiresAt ? { signingExpiresAt: result.signingExpiresAt } : {}),
       },

--- a/packages/application/src/dto/index.ts
+++ b/packages/application/src/dto/index.ts
@@ -91,6 +91,7 @@ export type ExecutionApprovalDto = {
 export type ExecutionSigningPayloadDto = {
   readonly attemptId: string;
   readonly serializedPayload: string;
+  readonly payloadVersion: string;
   readonly lifecycleState: ExecutionLifecycleState;
   readonly signingExpiresAt?: ClockTimestamp;
 };

--- a/packages/application/src/use-cases/execution/GetAwaitingSignaturePayload.test.ts
+++ b/packages/application/src/use-cases/execution/GetAwaitingSignaturePayload.test.ts
@@ -41,6 +41,7 @@ describe('GetAwaitingSignaturePayload', () => {
       kind: 'found',
       attemptId: 'attempt-1',
       serializedPayload: new Uint8Array([9, 8, 7]),
+      payloadVersion: 'v1',
       lifecycleState: { kind: 'awaiting-signature' },
       signingExpiresAt: makeClockTimestamp(1_060_000),
     });

--- a/packages/application/src/use-cases/execution/GetAwaitingSignaturePayload.ts
+++ b/packages/application/src/use-cases/execution/GetAwaitingSignaturePayload.ts
@@ -19,6 +19,7 @@ export type GetAwaitingSignaturePayloadResult =
       readonly kind: 'found';
       readonly attemptId: string;
       readonly serializedPayload: Uint8Array;
+      readonly payloadVersion: string;
       readonly lifecycleState: { readonly kind: 'awaiting-signature' };
       readonly signingExpiresAt?: ClockTimestamp;
     }
@@ -71,6 +72,7 @@ export async function getAwaitingSignaturePayload(
     kind: 'found',
     attemptId: input.attemptId,
     serializedPayload: preparedPayload.unsignedPayload,
+    payloadVersion: preparedPayload.payloadVersion,
     lifecycleState: { kind: 'awaiting-signature' },
     signingExpiresAt: preparedPayload.expiresAt,
   };


### PR DESCRIPTION
## Summary

Fixes a bug where signing a transaction in Phantom wallet had no effect — the execution stayed stuck at `awaiting-signature` indefinitely.

The signing payload endpoint (`GET /executions/:attemptId/signing-payload`) was not returning `payloadVersion`, but the submit endpoint (`POST /executions/:attemptId/submit`) required it. After the user signed in Phantom, the submit call was rejected with a 409 that was silently swallowed by the UI.

## Root Cause

`GetAwaitingSignaturePayload` had access to `preparedPayload.payloadVersion` but excluded it from its result type. This propagated through the DTO, controller response, client validator, and signing page — the version was never sent back to the server.

## Changes

- `GetAwaitingSignaturePayload.ts` — return `payloadVersion` from `preparedPayload` in the `found` result
- `dto/index.ts` — add `payloadVersion: string` to `ExecutionSigningPayloadDto`
- `ExecutionController.ts` — include `payloadVersion` in signing-payload response
- `executions.ts` (app) — validate `payloadVersion` in DTO type guard
- `signing/[attemptId].tsx` — pass `payloadVersion` to `submitExecution`; map `isError` to `'error'` signing state so submit failures surface in the UI

## Verification

typecheck, lint, boundaries (0 violations), all 342 tests pass.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![OpenCode](https://img.shields.io/badge/OpenCode-GLM_5.1-6366f1?logo=claude&logoColor=white)