### PR TITLE
fix(signing): gate signingState error to awaiting-signature lifecycle

### DIFF
--- a/apps/app/app/signing/[attemptId].tsx
+++ b/apps/app/app/signing/[attemptId].tsx
@@ -341,7 +341,9 @@ export default function SigningRoute() {
             },
           }
         : {})}
-      signingState={signMutation.isError ? 'error' : signMutation.isPending ? 'signing' : 'idle'}
+      signingState={displayedExecution?.lifecycleState.kind === 'awaiting-signature'
+        ? (signMutation.isError ? 'error' : signMutation.isPending ? 'signing' : 'idle')
+        : 'idle'}
       walletConnected={walletAddress != null}
       onSignAndExecute={() => {
         signMutation.mutate();


### PR DESCRIPTION
## Summary

Gates the `signingState` derivation in the signing route so that `signMutation.isError` only maps to `'error'` while `lifecycleState.kind === 'awaiting-signature'`. Once the execution advances past the signing step, `signingState` collapses to `'idle'`.

## Problem

React Query mutations don't reset their error state until `.mutate()` is called again. Without this gate, `signMutation.isError` persists after the lifecycle advances past `awaiting-signature`:

- **Timeout-success scenario**: tx goes through server-side, but the client saw a network error and `signMutation.isError = true`. After `executionQuery.refetch()` returns `submitted` or `confirmed`, the UI shows both a terminal state card ("your swap confirmed") AND the "Signing error / Try Again" block — contradictory and misleading.

## Changes

- `apps/app/app/signing/[attemptId].tsx`: `signingState` now gates on `displayedExecution?.lifecycleState.kind === 'awaiting-signature'`. Past that point, it's `'idle'`, letting the execution state card be the sole source of truth.

## Verification

- `pnpm --filter @clmm/app typecheck` ✅
- `pnpm --filter @clmm/app test` — 70 passing ✅

## Related

- Addresses review comment r3133450353 on PR #23 (the line is no longer in that diff but the concern is live on main)
- Companion to PR #23's `statusError` lifecycle guard on `SigningStatusScreen.tsx`