### PR TITLE
[codex] fix phantom v0 browser signing

### DIFF
--- a/apps/app/src/platform/browserWallet.test.ts
+++ b/apps/app/src/platform/browserWallet.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import { VersionedTransaction } from '@solana/web3.js';
 import {
   connectBrowserWallet,
   disconnectBrowserWallet,
@@ -7,7 +8,8 @@ import {
   signBrowserTransaction,
 } from './browserWallet';
 
-const VALID_SERIALIZED_PAYLOAD = Buffer.from([1, 2, 3, 4]).toString('base64');
+const VALID_SERIALIZED_PAYLOAD =
+  'AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACAAQABA8Ad1mDmJHOT4w9SKImj8qzR0ItAoMpTpj/M0nP1p4YpfC/b4w9Qc3vmYbf/YFgTZoQYCeG3U3QFBeWvvqvS5/YAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQICAAEMAgAAAAEAAAAAAAAAAA==';
 
 describe('browserWallet helpers', () => {
   it('returns null when no browser wallet provider exists', () => {
@@ -105,13 +107,15 @@ describe('browserWallet helpers', () => {
     expect(disconnectCalls).toBe(1);
   });
 
-  it('signBrowserTransaction decodes payload and passes bytes to provider', async () => {
+  it('signBrowserTransaction deserializes payload before passing it to the provider', async () => {
     let received: unknown;
+    let signTransactionCalls = 0;
     const provider = {
       connect: () => Promise.resolve({ publicKey: null }),
       signTransaction: (payload: unknown) => {
+        signTransactionCalls += 1;
         received = payload;
-        return Promise.resolve(new Uint8Array([4, 5, 6]));
+        return Promise.resolve({ serialize: () => new Uint8Array([4, 5, 6]) });
       },
     };
 
@@ -120,11 +124,15 @@ describe('browserWallet helpers', () => {
       serializedPayload: VALID_SERIALIZED_PAYLOAD,
     });
 
-    expect(received).toBeInstanceOf(Uint8Array);
-    expect(Array.from(received as Uint8Array)).toEqual([1, 2, 3, 4]);
+    expect(signTransactionCalls).toBe(1);
+    expect(received).toBeInstanceOf(VersionedTransaction);
+    expect(received).not.toBeInstanceOf(Uint8Array);
+    expect(typeof (received as { serialize?: unknown }).serialize).toBe('function');
+    expect((received as { signatures?: unknown }).signatures).toBeDefined();
+    expect((received as { message?: unknown }).message).toBeDefined();
   });
 
-  it('signBrowserTransaction normalizes serialized result and re-encodes as base64', async () => {
+  it('signBrowserTransaction serializes the signed transaction result and re-encodes as base64', async () => {
     const signedPayload = new Uint8Array([4, 5, 6]);
     const fakeSignedPayload = {
       serialize: () => signedPayload,
@@ -140,46 +148,6 @@ describe('browserWallet helpers', () => {
     });
 
     expect(result).toBe(Buffer.from([4, 5, 6]).toString('base64'));
-  });
-
-  it('signBrowserTransaction throws a clear error when the provider returns an unsupported result shape', async () => {
-    const provider = {
-      connect: () => Promise.resolve({ publicKey: null }),
-      signTransaction: () => Promise.resolve('signed-payload'),
-    };
-
-    await expect(
-      signBrowserTransaction({
-        browserWindow: { solana: provider },
-        serializedPayload: VALID_SERIALIZED_PAYLOAD,
-      }),
-    ).rejects.toThrow('Wallet returned an unsupported signed transaction payload');
-  });
-
-  it('retries with a serializable payload when provider rejects raw bytes', async () => {
-    let callCount = 0;
-    const provider = {
-      connect: () => Promise.resolve({ publicKey: null }),
-      signTransaction: (payload: unknown) => {
-        callCount += 1;
-
-        if (callCount === 1) {
-          expect(payload).toBeInstanceOf(Uint8Array);
-          return Promise.reject(new Error('r.serialize is not a function'));
-        }
-
-        expect(typeof (payload as { serialize?: unknown }).serialize).toBe('function');
-        return Promise.resolve(new Uint8Array([7, 8, 9]));
-      },
-    };
-
-    const result = await signBrowserTransaction({
-      browserWindow: { solana: provider },
-      serializedPayload: VALID_SERIALIZED_PAYLOAD,
-    });
-
-    expect(callCount).toBe(2);
-    expect(result).toBe(Buffer.from([7, 8, 9]).toString('base64'));
   });
 
   it('signBrowserTransaction throws when no browser wallet provider is injected', async () => {

--- a/apps/app/src/platform/browserWallet.ts
+++ b/apps/app/src/platform/browserWallet.ts
@@ -1,5 +1,11 @@
+import { VersionedTransaction } from '@solana/web3.js';
+
 export type BrowserWalletPublicKey = {
   toBase58(): string;
+};
+
+export type BrowserSignedTransaction = {
+  serialize(): Uint8Array;
 };
 
 export type BrowserWalletProvider = {
@@ -7,7 +13,7 @@ export type BrowserWalletProvider = {
   publicKey?: BrowserWalletPublicKey | null;
   connect(): Promise<{ publicKey?: BrowserWalletPublicKey | null } | null | undefined>;
   disconnect?(): Promise<void>;
-  signTransaction?(payload: unknown): Promise<unknown>;
+  signTransaction?(payload: VersionedTransaction): Promise<BrowserSignedTransaction>;
 };
 
 export type BrowserWalletWindow = {
@@ -52,14 +58,6 @@ export async function disconnectBrowserWallet(browserWindow: BrowserWalletWindow
   await provider?.disconnect?.();
 }
 
-function isSerializedTransaction(value: unknown): value is { serialize(): Uint8Array | ArrayBuffer } {
-  if (typeof value !== 'object' || value == null) {
-    return false;
-  }
-
-  return typeof Reflect.get(value, 'serialize') === 'function';
-}
-
 function decodeBase64Payload(value: string): Uint8Array {
   if (typeof globalThis.atob !== 'function') {
     throw new Error('Base64 decoding is not available in this environment');
@@ -88,34 +86,6 @@ function encodeBase64Payload(value: Uint8Array): string {
   return globalThis.btoa(binary);
 }
 
-function normalizeSignedResult(payload: unknown): Uint8Array {
-  if (payload instanceof Uint8Array) {
-    return payload;
-  }
-
-  if (payload instanceof ArrayBuffer) {
-    return new Uint8Array(payload);
-  }
-
-  if (isSerializedTransaction(payload)) {
-    return normalizeSignedResult(payload.serialize());
-  }
-
-  throw new Error('Wallet returned an unsupported signed transaction payload');
-}
-
-function shouldRetryWithSerializablePayload(error: unknown): boolean {
-  return error instanceof Error && error.message.toLowerCase().includes('serialize is not a function');
-}
-
-function buildSerializablePayload(payloadBytes: Uint8Array): { serialize(): Uint8Array } {
-  return {
-    serialize() {
-      return payloadBytes;
-    },
-  };
-}
-
 export async function signBrowserTransaction(params: {
   browserWindow: BrowserWalletWindow | undefined;
   serializedPayload: string;
@@ -131,17 +101,8 @@ export async function signBrowserTransaction(params: {
   }
 
   const payloadBytes = decodeBase64Payload(params.serializedPayload);
-  let signedPayload: unknown;
+  const transaction = VersionedTransaction.deserialize(payloadBytes);
+  const signedPayload = await provider.signTransaction(transaction);
 
-  try {
-    signedPayload = await provider.signTransaction(payloadBytes);
-  } catch (error: unknown) {
-    if (!shouldRetryWithSerializablePayload(error)) {
-      throw error;
-    }
-
-    signedPayload = await provider.signTransaction(buildSerializablePayload(payloadBytes));
-  }
-
-  return encodeBase64Payload(normalizeSignedResult(signedPayload));
+  return encodeBase64Payload(signedPayload.serialize());
 }

--- a/docs/solutions/integration-issues/phantom-injected-v0-signtransaction-requires-versionedtransaction-2026-04-23.md
+++ b/docs/solutions/integration-issues/phantom-injected-v0-signtransaction-requires-versionedtransaction-2026-04-23.md
@@ -1,0 +1,66 @@
+---
+title: Phantom injected signTransaction rejects raw v0 transaction bytes
+date: 2026-04-23
+category: integration-issues
+module: apps/app
+problem_type: integration_issue
+component: wallet_signing
+symptoms:
+  - Signing status page shows "Versioned messages must be deserialized with VersionedMessage.deserialize()"
+  - Out-of-range exit flow fails when user taps Sign & Execute in Phantom browser
+  - Native wallet signing path works for the same prepared transaction payload
+root_cause: wrong_api
+resolution_type: code_fix
+severity: critical
+tags: [phantom, browser-wallet, signing, versioned-transaction, v0-transaction]
+---
+
+# Phantom injected signTransaction rejects raw v0 transaction bytes
+
+## Problem
+
+The server prepares exit execution payloads as serialized Solana v0 transactions. The browser signing path decoded the base64 payload to raw bytes and passed the `Uint8Array` directly to Phantom's injected `window.solana.signTransaction`.
+
+Phantom's injected provider expects a transaction object for this API. Passing raw v0 wire bytes causes Phantom to attempt legacy message deserialization internally, which fails with:
+
+```text
+Versioned messages must be deserialized with VersionedMessage.deserialize()
+```
+
+## Symptoms
+
+- The signing page enters the error state immediately after attempting browser wallet signing
+- Error text contains `Versioned messages must be deserialized with VersionedMessage.deserialize()`
+- The same execution path can work through native MWA because the native adapter decodes bytes with `@solana/kit` before calling the wallet
+
+## What Didn't Work
+
+- Retrying with an object that only exposes `serialize()` around the raw bytes. Phantom's injected provider reads transaction object fields such as `message`, `signatures`, and versioned transaction shape. A fake serializable wrapper is not a real transaction object.
+- Treating browser `signTransaction` as a bytes-in/bytes-out API. That shape is valid for the app's internal port, but the injected Phantom boundary is web3.js-shaped.
+
+## Solution
+
+At the `apps/app` Phantom-injected-provider boundary, deserialize the prepared wire bytes to a `VersionedTransaction`, hand that object to `provider.signTransaction`, then serialize the signed result back to base64 for submission.
+
+```typescript
+import { VersionedTransaction } from '@solana/web3.js';
+
+const payloadBytes = decodeBase64Payload(serializedPayload);
+const transaction = VersionedTransaction.deserialize(payloadBytes);
+const signedPayload = await provider.signTransaction(transaction);
+
+return encodeBase64Payload(signedPayload.serialize());
+```
+
+This keeps `@solana/web3.js` usage at the browser wallet interop edge. Do not move this into domain, application, UI package code, or general Solana implementation logic. Do not introduce `Connection`, `PublicKey`, or legacy `Transaction` for this flow.
+
+## Prevention
+
+- Test browser signing with a real serialized v0 transaction fixture, not arbitrary bytes.
+- Assert `provider.signTransaction` is called exactly once with a `VersionedTransaction`-shaped object and not a `Uint8Array`.
+- Do not reintroduce the fake `serialize()` wrapper fallback. It validates the wrong contract and hides the actual provider API mismatch.
+- If browser signing is later migrated to Wallet Standard or `@solana/react`, keep the bytes-in/bytes-out adapter at that new boundary and remove this Phantom injected-provider-specific conversion.
+
+## Related Issues
+
+- Adjacent signing pipeline issue: `docs/solutions/integration-issues/signing-payload-version-missing-from-submit-2026-04-23.md`


### PR DESCRIPTION
## Summary

Fixes Phantom injected browser signing for v0 Solana transactions on the signing status page.

## Root Cause

The server prepares exit execution payloads as serialized v0 transactions, but the browser wallet path passed the raw decoded `Uint8Array` directly to `window.solana.signTransaction`. Phantom's injected provider expects a transaction object for this API, so it attempted legacy message deserialization internally and failed with `Versioned messages must be deserialized with VersionedMessage.deserialize()`.

## Changes

- Deserialize browser signing payloads with `VersionedTransaction.deserialize(...)` before calling Phantom.
- Serialize Phantom's signed transaction result directly for submission.
- Remove the raw-byte retry path and fake `serialize()` wrapper fallback.
- Update browser wallet tests to use a real serialized v0 transaction fixture and assert Phantom receives a `VersionedTransaction`, not raw bytes.
- Add a Compound Engineering solution note for this integration pitfall.

## Validation

- `pnpm --filter @clmm/app test -- src/platform/browserWallet.test.ts` passed.
- `pnpm --filter @clmm/app exec eslint src/platform/browserWallet.ts src/platform/browserWallet.test.ts --ext .ts` passed.

## Known Existing Check Blockers

- `pnpm --filter @clmm/app typecheck` is currently blocked by unrelated existing errors in `payloadVersion`, `srLevels`, and AsyncStorage typings.
- Full `pnpm --filter @clmm/app lint` is currently blocked by unrelated existing errors outside the touched files.