### PR TITLE
[codex] fix phantom mobile wallet connect

### DIFF
--- a/apps/app/app/(tabs)/wallet.tsx
+++ b/apps/app/app/(tabs)/wallet.tsx
@@ -1,7 +1,7 @@
 import { useRouter } from 'expo-router';
 import { WalletSettingsScreen } from '@clmm/ui';
 import { useStore } from 'zustand';
-import { disconnectBrowserWallet } from '../../src/platform/browserWallet';
+import { disconnectBrowserWallet, readInjectedBrowserWalletWindow } from '../../src/platform/browserWallet';
 import { navigateRoute } from '../../src/platform/webNavigation';
 import { walletSessionStore } from '../../src/state/walletSessionStore';
 
@@ -26,7 +26,7 @@ export default function WalletRoute() {
   async function handleDisconnect() {
     if (connectionKind === 'browser' && typeof window !== 'undefined') {
       try {
-        await disconnectBrowserWallet({ solana: Reflect.get(window, 'solana') });
+        await disconnectBrowserWallet(readInjectedBrowserWalletWindow());
       } catch {
         // Browser wallet disconnect is best-effort; always clear local session.
       }

--- a/apps/app/app/connect.tsx
+++ b/apps/app/app/connect.tsx
@@ -4,7 +4,7 @@ import { WalletConnectScreen } from '@clmm/ui';
 import { useStore } from 'zustand';
 import type { PlatformCapabilityState } from '@clmm/application/public';
 import { platformCapabilityAdapter, walletPlatform } from '../src/composition/index';
-import { connectBrowserWallet } from '../src/platform/browserWallet';
+import { connectBrowserWallet, readInjectedBrowserWalletWindow } from '../src/platform/browserWallet';
 import { mapWalletErrorToOutcome } from '../src/platform/walletConnection';
 import { navigateRoute } from '../src/platform/webNavigation';
 import { walletSessionStore } from '../src/state/walletSessionStore';
@@ -69,11 +69,9 @@ export default function ConnectRoute() {
     beginConnection();
 
     try {
-      const browserWalletWindow =
-        typeof window === 'undefined' ? undefined : { solana: Reflect.get(window, 'solana') as unknown };
       const walletAddress =
         kind === 'browser'
-          ? await connectBrowserWallet(browserWalletWindow)
+          ? await connectBrowserWallet(readInjectedBrowserWalletWindow())
           : await walletPlatform.connectNativeWallet();
 
       markConnected({ walletAddress, connectionKind: kind });

--- a/apps/app/app/signing/[attemptId].tsx
+++ b/apps/app/app/signing/[attemptId].tsx
@@ -11,7 +11,7 @@ import {
   recordSignatureInterruption,
   submitExecution,
 } from '../../src/api/executions';
-import { signBrowserTransaction } from '../../src/platform/browserWallet';
+import { readInjectedBrowserWalletWindow, signBrowserTransaction } from '../../src/platform/browserWallet';
 import { signNativeTransaction } from '../../src/platform/nativeWallet';
 import { mapWalletErrorToOutcome } from '../../src/platform/walletConnection';
 import { navigateRoute } from '../../src/platform/webNavigation';
@@ -186,7 +186,7 @@ export default function SigningRoute() {
         const signedPayload =
           connectionKind === 'browser'
             ? await signBrowserTransaction({
-                browserWindow: typeof window === 'undefined' ? undefined : { solana: Reflect.get(window, 'solana') },
+                browserWindow: readInjectedBrowserWalletWindow(),
                 serializedPayload: signingPayload.serializedPayload,
               })
             : await signNativeTransaction({

--- a/apps/app/src/platform/browserWallet.test.ts
+++ b/apps/app/src/platform/browserWallet.test.ts
@@ -1,10 +1,11 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { VersionedTransaction } from '@solana/web3.js';
 import {
   connectBrowserWallet,
   disconnectBrowserWallet,
   getInjectedBrowserProvider,
   normalizeBrowserWalletAddress,
+  readInjectedBrowserWalletWindow,
   signBrowserTransaction,
 } from './browserWallet';
 
@@ -23,6 +24,42 @@ describe('browserWallet helpers', () => {
     };
 
     expect(getInjectedBrowserProvider({ solana: provider })).toBe(provider);
+  });
+
+  it('prefers the Phantom-scoped Solana provider over the legacy global provider', () => {
+    const phantomProvider = {
+      isPhantom: true,
+      connect: () => Promise.resolve({ publicKey: { toBase58: () => 'phantom' } }),
+    };
+    const legacyProvider = {
+      connect: () => Promise.resolve({ publicKey: { toBase58: () => 'legacy' } }),
+    };
+
+    expect(
+      getInjectedBrowserProvider({
+        phantom: { solana: phantomProvider },
+        solana: legacyProvider,
+      }),
+    ).toBe(phantomProvider);
+  });
+
+  it('reads both Phantom-scoped and legacy global providers from the browser window', () => {
+    const phantomProvider = {
+      isPhantom: true,
+      connect: () => Promise.resolve({ publicKey: { toBase58: () => 'phantom' } }),
+    };
+    const legacyProvider = {
+      connect: () => Promise.resolve({ publicKey: { toBase58: () => 'legacy' } }),
+    };
+    vi.stubGlobal('window', {
+      phantom: { solana: phantomProvider },
+      solana: legacyProvider,
+    });
+
+    expect(readInjectedBrowserWalletWindow()).toEqual({
+      phantom: { solana: phantomProvider },
+      solana: legacyProvider,
+    });
   });
 
   it('returns null when injected solana does not expose a connect function', () => {
@@ -51,6 +88,22 @@ describe('browserWallet helpers', () => {
     await expect(connectBrowserWallet({ solana: provider })).resolves.toBe(
       'ConnectResult111111111111111111111111111111111',
     );
+  });
+
+  it('connectBrowserWallet returns existing provider publicKey without calling connect', async () => {
+    const connect = vi.fn(() => Promise.reject(new Error('connect should not be called')));
+    const provider = {
+      isConnected: true,
+      publicKey: {
+        toBase58: () => 'AlreadyConnected111111111111111111111111111111',
+      },
+      connect,
+    };
+
+    await expect(connectBrowserWallet({ solana: provider })).resolves.toBe(
+      'AlreadyConnected111111111111111111111111111111',
+    );
+    expect(connect).not.toHaveBeenCalled();
   });
 
   it('connectBrowserWallet throws controlled error when no provider is injected', async () => {
@@ -86,6 +139,35 @@ describe('browserWallet helpers', () => {
     await expect(connectBrowserWallet({ solana: provider })).rejects.toThrow(
       'Wallet provider did not return a public key',
     );
+  });
+
+  it('connectBrowserWallet rejects Phantom unauthorized errors immediately for manual retry', async () => {
+    const unauthorizedError = Object.assign(
+      new Error('The requested method and/or account has not been authorized by the user'),
+      { code: 4100 },
+    );
+    const provider = {
+      connect: vi.fn(() => Promise.reject(unauthorizedError)),
+      on: vi.fn(),
+    };
+
+    await expect(connectBrowserWallet({ solana: provider })).rejects.toBe(unauthorizedError);
+    expect(provider.on).not.toHaveBeenCalled();
+  });
+
+  it('connectBrowserWallet rejects user-denied Phantom errors immediately', async () => {
+    vi.useFakeTimers();
+    try {
+      const rejectedError = Object.assign(new Error('User rejected the request'), { code: 4001 });
+      const provider = {
+        connect: vi.fn(() => Promise.reject(rejectedError)),
+        on: vi.fn(),
+      };
+
+      await expect(connectBrowserWallet({ solana: provider })).rejects.toBe(rejectedError);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it('disconnectBrowserWallet is safe when provider is missing', async () => {

--- a/apps/app/src/platform/browserWallet.ts
+++ b/apps/app/src/platform/browserWallet.ts
@@ -10,6 +10,7 @@ export type BrowserSignedTransaction = {
 
 export type BrowserWalletProvider = {
   isPhantom?: boolean;
+  isConnected?: boolean;
   publicKey?: BrowserWalletPublicKey | null;
   connect(): Promise<{ publicKey?: BrowserWalletPublicKey | null } | null | undefined>;
   disconnect?(): Promise<void>;
@@ -17,6 +18,9 @@ export type BrowserWalletProvider = {
 };
 
 export type BrowserWalletWindow = {
+  phantom?: {
+    solana?: unknown;
+  } | null | undefined;
   solana?: unknown;
 };
 
@@ -31,7 +35,27 @@ function isBrowserWalletProvider(value: unknown): value is BrowserWalletProvider
 export function getInjectedBrowserProvider(
   browserWindow: BrowserWalletWindow | undefined,
 ): BrowserWalletProvider | null {
+  const phantomSolana = browserWindow?.phantom?.solana;
+  if (isBrowserWalletProvider(phantomSolana)) {
+    return phantomSolana;
+  }
+
   return isBrowserWalletProvider(browserWindow?.solana) ? browserWindow.solana : null;
+}
+
+export function readInjectedBrowserWalletWindow(): BrowserWalletWindow | undefined {
+  if (typeof window === 'undefined') {
+    return undefined;
+  }
+
+  return {
+    phantom: Reflect.get(window, 'phantom') as { solana?: unknown } | null | undefined,
+    solana: Reflect.get(window, 'solana') as unknown,
+  };
+}
+
+export function hasInjectedBrowserWalletProvider(browserWindow: BrowserWalletWindow | undefined): boolean {
+  return getInjectedBrowserProvider(browserWindow) !== null;
 }
 
 export function normalizeBrowserWalletAddress(publicKey: BrowserWalletPublicKey | null | undefined): string {
@@ -47,6 +71,10 @@ export async function connectBrowserWallet(browserWindow: BrowserWalletWindow | 
 
   if (!provider) {
     throw new Error('No supported browser wallet detected on this device');
+  }
+
+  if (provider.publicKey) {
+    return normalizeBrowserWalletAddress(provider.publicKey);
   }
 
   const result = await provider.connect();

--- a/apps/app/src/platform/walletConnection.test.ts
+++ b/apps/app/src/platform/walletConnection.test.ts
@@ -25,6 +25,15 @@ describe('walletConnection helpers', () => {
     });
   });
 
+  it('maps Phantom unauthorized errors to retry guidance outcome', () => {
+    const error = Object.assign(
+      new Error('The requested method and/or account has not been authorized by the user'),
+      { code: 4100 },
+    );
+
+    expect(mapWalletErrorToOutcome(error)).toEqual({ kind: 'needs-wallet-retry' });
+  });
+
   it('maps non-Error unknown inputs to failed with string reason', () => {
     expect(mapWalletErrorToOutcome({ code: 'WALLET_DOWN' })).toEqual({
       kind: 'failed',

--- a/apps/app/src/platform/walletConnection.ts
+++ b/apps/app/src/platform/walletConnection.ts
@@ -3,17 +3,29 @@ import type { WalletConnectionKind } from '../state/walletSessionStore';
 
 const CANCELLATION_MATCHERS = ['user rejected', 'declined', 'cancelled', 'canceled'] as const;
 const INTERRUPTION_MATCHERS = ['interrupted', 'timeout', 'closed'] as const;
+const RETRY_AUTHORIZATION_MATCHERS = ['not been authorized'] as const;
 
 function includesAny(value: string, matchers: readonly string[]): boolean {
   return matchers.some((matcher) => value.includes(matcher));
 }
 
+function getWalletErrorCode(error: unknown): unknown {
+  return typeof error === 'object' && error !== null
+    ? (error as { code?: unknown }).code
+    : undefined;
+}
+
 export function mapWalletErrorToOutcome(error: unknown): ConnectionOutcome {
   const message = error instanceof Error ? error.message : String(error);
   const normalizedMessage = message.toLowerCase();
+  const code = getWalletErrorCode(error);
 
   if (includesAny(normalizedMessage, CANCELLATION_MATCHERS)) {
     return { kind: 'cancelled' };
+  }
+
+  if (code === 4100 || code === '4100' || includesAny(normalizedMessage, RETRY_AUTHORIZATION_MATCHERS)) {
+    return { kind: 'needs-wallet-retry' };
   }
 
   if (includesAny(normalizedMessage, INTERRUPTION_MATCHERS)) {

--- a/apps/app/src/platform/webNavigation.test.ts
+++ b/apps/app/src/platform/webNavigation.test.ts
@@ -13,6 +13,13 @@ describe('isSolanaMobileWebView', () => {
     expect(isSolanaMobileWebView()).toBe(true);
   });
 
+  it('returns true on mobile WebView with only window.phantom.solana.connect', () => {
+    vi.stubGlobal('window', { phantom: { solana: { connect: vi.fn() } } });
+    vi.stubGlobal('navigator', { userAgent: 'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15' });
+
+    expect(isSolanaMobileWebView()).toBe(true);
+  });
+
   it('returns true on iOS iPhone with window.solana.connect', () => {
     vi.stubGlobal('window', { solana: { connect: vi.fn() } });
     vi.stubGlobal('navigator', { userAgent: 'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15' });
@@ -128,6 +135,24 @@ describe('navigateRoute', () => {
     const replaceFn = vi.fn();
     vi.stubGlobal('window', {
       solana: { connect: vi.fn() },
+      location: { origin: 'https://app.example.com', replace: replaceFn, href: '' },
+    });
+    vi.stubGlobal('navigator', { userAgent: 'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15' });
+
+    const router = { push: vi.fn(), replace: vi.fn() };
+
+    navigateRoute({ router, path: '/positions', method: 'replace' });
+
+    expect(replaceFn).toHaveBeenCalledWith('https://app.example.com/positions');
+    expect(router.replace).not.toHaveBeenCalled();
+
+    vi.unstubAllGlobals();
+  });
+
+  it('uses window.location hard navigation when only Phantom scoped provider is injected', () => {
+    const replaceFn = vi.fn();
+    vi.stubGlobal('window', {
+      phantom: { solana: { connect: vi.fn() } },
       location: { origin: 'https://app.example.com', replace: replaceFn, href: '' },
     });
     vi.stubGlobal('navigator', { userAgent: 'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15' });

--- a/apps/app/src/platform/webNavigation.ts
+++ b/apps/app/src/platform/webNavigation.ts
@@ -1,3 +1,5 @@
+import { hasInjectedBrowserWalletProvider, readInjectedBrowserWalletWindow } from './browserWallet';
+
 type RouterLike = {
   push: (path: string) => void;
   replace: (path: string) => void;
@@ -16,12 +18,7 @@ function isWebPlatform(): boolean {
 export function isSolanaMobileWebView(): boolean {
   if (!isWebPlatform()) return false;
   try {
-    const win = window as unknown as Record<string, unknown>;
-    const solana = win['solana'];
-    const hasWalletInject =
-      solana && typeof solana === 'object' && solana !== null &&
-      typeof (solana as Record<string, unknown>)['connect'] === 'function';
-    if (!hasWalletInject) return false;
+    if (!hasInjectedBrowserWalletProvider(readInjectedBrowserWalletWindow())) return false;
     const ua = typeof navigator !== 'undefined' ? navigator.userAgent : '';
     return /wv\)/.test(ua) || /iPhone/.test(ua) || /iPad/.test(ua);
   } catch {

--- a/docs/solutions/integration-issues/phantom-mobile-connect-prefers-scoped-solana-provider-2026-04-24.md
+++ b/docs/solutions/integration-issues/phantom-mobile-connect-prefers-scoped-solana-provider-2026-04-24.md
@@ -1,0 +1,64 @@
+---
+title: Phantom mobile connect should prefer window.phantom.solana
+date: 2026-04-24
+category: integration-issues
+module: apps/app
+problem_type: integration_issue
+component: wallet_connect
+symptoms:
+  - Phantom mobile browser shows "Connection Failed"
+  - Error detail says "The requested method and/or account has not been authorized by the user"
+  - User tapped the explicit browser wallet connect button on /connect
+root_cause: wrong_provider_boundary
+resolution_type: code_fix
+severity: high
+tags:
+  - phantom
+  - mobile-browser
+  - browser-wallet
+  - wallet-connect
+  - injected-provider
+---
+
+# Phantom mobile connect should prefer window.phantom.solana
+
+## Problem
+
+Phantom documents the Solana provider as `window.phantom.solana`, with `window.solana` retained for legacy integrations. The app's browser wallet connect path only passed `window.solana` into the wallet helper.
+
+In Phantom mobile browser, this can surface as an authorization failure when the user taps the explicit connect button:
+
+```text
+The requested method and/or account has not been authorized by the user.
+```
+
+## Solution
+
+At the app browser-wallet boundary, read both injected shapes in one helper and prefer the Phantom-scoped Solana provider:
+
+```typescript
+readInjectedBrowserWalletWindow();
+```
+
+Provider selection should check `phantom.solana` first, then fall back to `solana` for other Solana wallet injections and legacy integrations. Every browser wallet lifecycle call must use the same helper:
+
+- connect
+- sign transaction
+- disconnect
+
+If connect uses the scoped Phantom provider but signing or disconnect reconstructs only `{ solana: window.solana }`, the app can switch provider surfaces mid-session and hit authorization failures after the wallet popup has already appeared.
+
+The connect helper also needs Phantom-specific completion handling:
+
+- If `provider.publicKey` is already populated, return it without calling `connect()`.
+- If `connect()` rejects with Phantom unauthorized code `4100` while the wallet approval sheet still opens, do not wait in a spinner. Stop connecting, show explicit guidance to approve CLMM V2 in Phantom, and keep the Connect button available so the user can tap it again after approval.
+- If the user rejects with code `4001`, fail immediately instead of waiting.
+
+Capability and mobile WebView detection must also check `window.phantom.solana`, not only `window.solana`; otherwise scoped-only Phantom injection can hide the connect button or skip hard navigation.
+
+## Prevention
+
+- Keep Phantom-specific provider selection in `apps/app/src/platform/browserWallet.ts`.
+- Do not use `window.solana` as the only Phantom detection path.
+- Do not reconstruct the injected browser wallet window inline at route call sites.
+- Add or preserve unit tests for already-connected `publicKey`, immediate `4100` retry guidance, scoped provider detection, and `window.phantom.solana` winning when both providers are present.

--- a/packages/adapters/src/outbound/capabilities/WebPlatformCapabilityAdapter.test.ts
+++ b/packages/adapters/src/outbound/capabilities/WebPlatformCapabilityAdapter.test.ts
@@ -1,0 +1,24 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { WebPlatformCapabilityAdapter } from './WebPlatformCapabilityAdapter';
+
+describe('WebPlatformCapabilityAdapter', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('detects a browser wallet from Phantom scoped Solana provider', async () => {
+    vi.stubGlobal('navigator', {
+      userAgent: 'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15',
+    });
+    vi.stubGlobal('phantom', {
+      solana: { connect: vi.fn() },
+    });
+
+    const adapter = new WebPlatformCapabilityAdapter();
+
+    await expect(adapter.getCapabilities()).resolves.toMatchObject({
+      browserWalletAvailable: true,
+      isMobileWeb: true,
+    });
+  });
+});

--- a/packages/adapters/src/outbound/capabilities/WebPlatformCapabilityAdapter.ts
+++ b/packages/adapters/src/outbound/capabilities/WebPlatformCapabilityAdapter.ts
@@ -12,6 +12,16 @@ export class WebPlatformCapabilityAdapter implements PlatformCapabilityPort {
     const injectedBrowserWallet = ((): boolean => {
       try {
         const win = globalThis as unknown as Record<string, unknown>;
+        const phantom = win['phantom'];
+        const phantomSolana =
+          typeof phantom === 'object' && phantom !== null
+            ? (phantom as Record<string, unknown>)['solana']
+            : undefined;
+        if (typeof phantomSolana === 'object' && phantomSolana !== null) {
+          const phantomSolanaRecord = phantomSolana as Record<string, unknown>;
+          if (typeof phantomSolanaRecord['connect'] === 'function') return true;
+        }
+
         const solana = win['solana'];
         if (typeof solana !== 'object' || solana === null) return false;
         const solanaRecord = solana as Record<string, unknown>;

--- a/packages/ui/src/components/WalletConnection.test.ts
+++ b/packages/ui/src/components/WalletConnection.test.ts
@@ -91,6 +91,14 @@ describe('getConnectionOutcomeDisplay', () => {
     expect(display.severity).toBe('warning');
     expect(display.detail).toContain('returned');
   });
+
+  it('maps wallet retry outcome to Phantom approval guidance', () => {
+    const display = getConnectionOutcomeDisplay({ kind: 'needs-wallet-retry' });
+    expect(display.title).toBe('Wallet Approval Needed');
+    expect(display.severity).toBe('warning');
+    expect(display.detail).toContain('Approve CLMM V2 in Phantom');
+    expect(display.detail).toContain('tap Connect again');
+  });
 });
 
 describe('buildConnectedWalletSummary', () => {

--- a/packages/ui/src/components/WalletConnectionUtils.ts
+++ b/packages/ui/src/components/WalletConnectionUtils.ts
@@ -39,7 +39,8 @@ export type ConnectionOutcome =
   | { kind: 'connected' }
   | { kind: 'failed'; reason: string }
   | { kind: 'cancelled' }
-  | { kind: 'interrupted' };
+  | { kind: 'interrupted' }
+  | { kind: 'needs-wallet-retry' };
 
 export type ConnectionOutcomeDisplay = {
   title: string;
@@ -71,6 +72,12 @@ export function getConnectionOutcomeDisplay(outcome: ConnectionOutcome): Connect
       return {
         title: 'Connection Interrupted',
         detail: 'The connection was interrupted before completing. You have returned to the app — please try connecting again.',
+        severity: 'warning',
+      };
+    case 'needs-wallet-retry':
+      return {
+        title: 'Wallet Approval Needed',
+        detail: 'Approve CLMM V2 in Phantom, then tap Connect again.',
         severity: 'warning',
       };
     default: {

--- a/packages/ui/src/view-models/WalletConnectionViewModel.test.ts
+++ b/packages/ui/src/view-models/WalletConnectionViewModel.test.ts
@@ -61,6 +61,19 @@ describe('buildWalletConnectViewModel', () => {
     expect(vm.outcomeDisplay!.title).toBe('Connection Failed');
   });
 
+  it('shows retry guidance without staying in connecting state', () => {
+    const vm = buildWalletConnectViewModel({
+      capabilities: makeCaps({ browserWalletAvailable: true }),
+      connectionOutcome: { kind: 'needs-wallet-retry' },
+      isConnecting: false,
+    });
+
+    expect(vm.isConnecting).toBe(false);
+    expect(vm.walletOptions.map((option) => option.kind)).toEqual(['browser']);
+    expect(vm.outcomeDisplay!.title).toBe('Wallet Approval Needed');
+    expect(vm.outcomeDisplay!.severity).toBe('warning');
+  });
+
   it('passes through isConnecting state', () => {
     const vm = buildWalletConnectViewModel({
       capabilities: makeCaps({ nativeWalletAvailable: true }),


### PR DESCRIPTION
## What changed

- Prefer Phantom's scoped Solana provider (`window.phantom.solana`) before falling back to legacy `window.solana`.
- Centralize injected browser wallet reads and keep connect, browser signing, and browser disconnect on the same provider shape.
- Keep the safe already-connected path: if `provider.publicKey` exists, return it without calling `connect()`.
- Remove the 60s late-connect waiter. Phantom `4100` now fails fast into a dedicated retry outcome instead of leaving the app on a spinner.
- Add user-facing retry guidance: "Approve CLMM V2 in Phantom, then tap Connect again."
- Detect browser wallet capability and Solana mobile WebView hard-navigation support from scoped-only `window.phantom.solana` injection.
- Document the Phantom mobile browser provider-selection and retry gotchas in `docs/solutions/`.

## Why

Testing in Phantom mobile showed the wallet approval popup can appear, but the app remains stuck in the connecting spinner for the late-wait timeout. The safer next behavior is deterministic: stop loading immediately on Phantom unauthorized `4100`, keep the Connect button available, and tell the user to approve in Phantom and tap Connect again. If that second tap also returns `4100`, the manual retry hypothesis is falsified and the next step should be a Wallet Standard / official adapter integration rather than more injected-provider patching.

## Validation

- `pnpm --filter @clmm/app test -- src/platform/browserWallet.test.ts src/platform/walletConnection.test.ts src/platform/webNavigation.test.ts` passes: 43/43 tests.
- `pnpm --filter @clmm/ui test -- src/components/WalletConnection.test.ts src/view-models/WalletConnectionViewModel.test.ts` passes: 27/27 tests.
- `pnpm --filter @clmm/adapters test -- src/outbound/capabilities/WebPlatformCapabilityAdapter.test.ts` passes: 1/1 test.
- `pnpm --filter @clmm/app exec eslint src/platform/browserWallet.ts src/platform/browserWallet.test.ts src/platform/walletConnection.ts src/platform/walletConnection.test.ts src/platform/webNavigation.ts src/platform/webNavigation.test.ts --ext .ts` passes.
- `pnpm --filter @clmm/ui exec eslint src/components/WalletConnectionUtils.ts src/components/WalletConnection.test.ts src/view-models/WalletConnectionViewModel.ts src/view-models/WalletConnectionViewModel.test.ts --ext .ts,.tsx` passes.
- `git diff --check` passes.

Known unrelated blocker: `pnpm --filter @clmm/app typecheck` still fails on existing `payloadVersion`, `srLevels`, and `@react-native-async-storage/async-storage` type/import issues outside this change.