### PR TITLE
fix(wallet): browser-wallet hard-nav recovery boot status

### DIFF
--- a/apps/app/app/connect.tsx
+++ b/apps/app/app/connect.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState } from 'react';
 import { View, Text, TouchableOpacity, ScrollView, Linking, Platform, ActivityIndicator, Image } from 'react-native';
-import { useRouter } from 'expo-router';
+import { useRouter, useLocalSearchParams } from 'expo-router';
 import { useStore } from 'zustand';
 import type { PlatformCapabilityState } from '@clmm/application/public';
 import type { BrowserWalletOption } from '../src/platform/browserWallet/browserWalletTypes';
@@ -14,6 +14,7 @@ import {
 } from '../src/platform/browserWallet/walletDeepLinks';
 import { mapWalletErrorToOutcome } from '../src/platform/walletConnection';
 import { navigateRoute } from '../src/platform/webNavigation';
+import { parseReturnTo } from '../src/wallet-boot/parseReturnTo';
 import { walletSessionStore } from '../src/state/walletSessionStore';
 import { getConnectionOutcomeDisplay } from '@clmm/ui';
 import { enrollWalletForMonitoring } from '../src/api/wallets';
@@ -60,6 +61,8 @@ const FALLBACK_PLATFORM_CAPABILITIES: PlatformCapabilityState = {
 
 export default function ConnectRoute() {
   const router = useRouter();
+  const params = useLocalSearchParams<{ returnTo?: string | string[] }>();
+  const returnTo = useMemo(() => parseReturnTo(params.returnTo), [params.returnTo]);
   const platformCapabilities = useStore(walletSessionStore, (state) => state.platformCapabilities);
   const connectionOutcome = useStore(walletSessionStore, (state) => state.connectionOutcome);
   const isConnecting = useStore(walletSessionStore, (state) => state.isConnecting);
@@ -137,7 +140,7 @@ export default function ConnectRoute() {
       enrollWalletForMonitoring(address).catch((err) => {
         console.warn('Wallet enrollment failed:', err);
       });
-      navigateRoute({ router, path: '/(tabs)/positions', method: 'replace' });
+      navigateRoute({ router, path: returnTo, method: 'replace' });
     } catch (error) {
       handleConnectionError(error);
     }
@@ -152,7 +155,7 @@ export default function ConnectRoute() {
       enrollWalletForMonitoring(address).catch((err) => {
         console.warn('Wallet enrollment failed:', err);
       });
-      navigateRoute({ router, path: '/(tabs)/positions', method: 'replace' });
+      navigateRoute({ router, path: returnTo, method: 'replace' });
     } catch (error) {
       handleConnectionError(error);
     }
@@ -167,7 +170,7 @@ export default function ConnectRoute() {
       enrollWalletForMonitoring(walletAddress).catch((err) => {
         console.warn('Wallet enrollment failed:', err);
       });
-      navigateRoute({ router, path: '/(tabs)/positions', method: 'replace' });
+      navigateRoute({ router, path: returnTo, method: 'replace' });
     } catch (error) {
       handleConnectionError(error);
     }

--- a/apps/app/app/execution/[attemptId].tsx
+++ b/apps/app/app/execution/[attemptId].tsx
@@ -3,12 +3,21 @@ import { useQuery } from '@tanstack/react-query';
 import { ExecutionResultScreen } from '@clmm/ui';
 import { fetchExecution } from '../../src/api/executions';
 import { navigateRoute } from '../../src/platform/webNavigation';
+import { RequireWallet } from '../../src/wallet-boot/RequireWallet';
 
 function readAttemptId(value: string | string[] | undefined): string | null {
   return typeof value === 'string' && value.length > 0 ? value : null;
 }
 
 export default function ExecutionRoute() {
+  return (
+    <RequireWallet>
+      <ExecutionRouteBody />
+    </RequireWallet>
+  );
+}
+
+function ExecutionRouteBody() {
   const router = useRouter();
   const params = useLocalSearchParams<{ attemptId?: string | string[] }>();
   const attemptId = readAttemptId(params.attemptId);

--- a/apps/app/app/position/[id].tsx
+++ b/apps/app/app/position/[id].tsx
@@ -1,4 +1,5 @@
-import { useLocalSearchParams, useRouter } from 'expo-router';
+import { useLocalSearchParams } from 'expo-router';
+import { useRouter } from 'expo-router';
 import { useQuery } from '@tanstack/react-query';
 import { PositionDetailScreen } from '@clmm/ui';
 import { Text, View } from 'react-native';
@@ -6,27 +7,31 @@ import { useStore } from 'zustand';
 import { fetchPositionDetail } from '../../src/api/positions';
 import { navigateRoute } from '../../src/platform/webNavigation';
 import { walletSessionStore } from '../../src/state/walletSessionStore';
+import { RequireWallet } from '../../src/wallet-boot/RequireWallet';
 
 export default function PositionDetailRoute() {
-  const { id, triggerId } = useLocalSearchParams<{ id?: string | string[]; triggerId?: string | string[] }>();
+  return (
+    <RequireWallet>
+      <PositionDetailRouteBody />
+    </RequireWallet>
+  );
+}
+
+function PositionDetailRouteBody() {
+  const { id, triggerId } = useLocalSearchParams<{
+    id?: string | string[];
+    triggerId?: string | string[];
+  }>();
   const router = useRouter();
   const walletAddress = useStore(walletSessionStore, (state) => state.walletAddress);
-  const hasHydrated = useStore(walletSessionStore, (s) => s.hasHydrated);
   const positionId = typeof id === 'string' ? id : undefined;
   const alertTriggerId = typeof triggerId === 'string' && triggerId.length > 0 ? triggerId : undefined;
   const hasValidPositionId = positionId != null && positionId.length > 0;
-  const hasWalletAddress = walletAddress != null && walletAddress.length > 0;
-
-  // Only redirect if we have a valid positionId, no wallet address, AND hydration is complete
-  if (hasValidPositionId && !hasWalletAddress && hasHydrated) {
-    navigateRoute({ router, path: '/connect', method: 'push' });
-    return null;
-  }
 
   const positionQuery = useQuery({
     queryKey: ['position-detail', walletAddress, positionId],
     queryFn: () => fetchPositionDetail(walletAddress!, positionId!),
-    enabled: hasWalletAddress && hasValidPositionId,
+    enabled: walletAddress != null && hasValidPositionId,
   });
 
   if (!hasValidPositionId) {

--- a/apps/app/app/preview/[triggerId].tsx
+++ b/apps/app/app/preview/[triggerId].tsx
@@ -6,22 +6,25 @@ import { useStore } from 'zustand';
 import { createPreview, refreshPreview } from '../../src/api/previews';
 import { navigateRoute } from '../../src/platform/webNavigation';
 import { walletSessionStore } from '../../src/state/walletSessionStore';
+import { RequireWallet } from '../../src/wallet-boot/RequireWallet';
 
 function readTriggerId(value: string | string[] | undefined): string | null {
   return typeof value === 'string' && value.length > 0 ? value : null;
 }
 
 export default function PreviewRoute() {
+  return (
+    <RequireWallet>
+      <PreviewRouteBody />
+    </RequireWallet>
+  );
+}
+
+function PreviewRouteBody() {
   const router = useRouter();
   const params = useLocalSearchParams<{ triggerId?: string | string[] }>();
   const triggerId = readTriggerId(params.triggerId);
   const walletAddress = useStore(walletSessionStore, (state) => state.walletAddress);
-  const hasHydrated = useStore(walletSessionStore, (s) => s.hasHydrated);
-
-  if (triggerId != null && walletAddress == null && hasHydrated) {
-    navigateRoute({ router, path: '/connect', method: 'push' });
-    return null;
-  }
 
   const createMutation = useMutation({
     mutationFn: createPreview,
@@ -37,7 +40,6 @@ export default function PreviewRoute() {
     if (triggerId == null) {
       return;
     }
-
     createMutation.mutate(triggerId);
     // Intentionally depend only on triggerId to avoid mutation-object re-render loops.
   }, [triggerId]);

--- a/apps/app/app/signing/[attemptId].tsx
+++ b/apps/app/app/signing/[attemptId].tsx
@@ -16,6 +16,7 @@ import { signNativeTransaction } from '../../src/platform/nativeWallet';
 import { mapWalletErrorToOutcome } from '../../src/platform/walletConnection';
 import { navigateRoute } from '../../src/platform/webNavigation';
 import { walletSessionStore } from '../../src/state/walletSessionStore';
+import { RequireWallet } from '../../src/wallet-boot/RequireWallet';
 import type { ExecutionAttemptDto } from '@clmm/application/public';
 
 function readAttemptId(value: string | string[] | undefined): string | null {
@@ -58,7 +59,7 @@ async function recordSigningOutcome(params: {
   }
 }
 
-export default function SigningRoute() {
+function SigningRouteBody() {
   const router = useRouter();
   const params = useLocalSearchParams<{
     attemptId?: string | string[];
@@ -72,18 +73,11 @@ export default function SigningRoute() {
   const episodeId = readEpisodeId(params.episodeId);
   const hasPendingAttemptPlaceholder = isPendingAttemptPlaceholder(params.attemptId);
   const walletAddress = useStore(walletSessionStore, (state) => state.walletAddress);
-  const hasHydrated = useStore(walletSessionStore, (s) => s.hasHydrated);
   const connectionKind = useStore(walletSessionStore, (state) => state.connectionKind);
   const browserSigner = useBrowserWalletSign();
 
   const [statusNotice, setStatusNotice] = useState<string | null>(null);
   const [hasStartedPendingApproval, setHasStartedPendingApproval] = useState(false);
-
-  useEffect(() => {
-    if (attemptId == null && walletAddress == null && hasHydrated) {
-      navigateRoute({ router, path: '/connect', method: 'push' });
-    }
-  }, [attemptId, walletAddress, hasHydrated, router]);
 
   const approveMutation = useMutation({
     mutationFn: approveExecutionPreview,
@@ -244,10 +238,6 @@ export default function SigningRoute() {
     },
   });
 
-  if (attemptId == null && walletAddress == null) {
-    return null;
-  }
-
   return (
     <SigningStatusScreen
       {...(displayedExecution != null
@@ -347,6 +337,14 @@ export default function SigningRoute() {
         signMutation.mutate();
       }}
       {...(signMutation.error instanceof Error ? { signingError: signMutation.error.message } : {})}
-    />
+     />
+  );
+}
+
+export default function SigningRoute() {
+  return (
+    <RequireWallet>
+      <SigningRouteBody />
+    </RequireWallet>
   );
 }

--- a/apps/app/src/platform/browserWallet/BrowserWalletProvider.native.tsx
+++ b/apps/app/src/platform/browserWallet/BrowserWalletProvider.native.tsx
@@ -1,5 +1,6 @@
 import type { ReactNode } from 'react';
+import { WalletBootProvider } from '../../wallet-boot/WalletBootProvider.native';
 
 export function BrowserWalletProvider({ children }: { children: ReactNode }) {
-  return <>{children}</>;
+  return <WalletBootProvider>{children}</WalletBootProvider>;
 }

--- a/apps/app/src/platform/browserWallet/BrowserWalletProvider.web.tsx
+++ b/apps/app/src/platform/browserWallet/BrowserWalletProvider.web.tsx
@@ -2,6 +2,7 @@ import type { ReactNode } from 'react';
 import { useEffect } from 'react';
 import { AppProvider, getDefaultConfig, getDefaultMobileConfig, useConnector } from '@solana/connector';
 import { walletSessionStore } from '../../state/walletSessionStore';
+import { WalletBootProvider } from '../../wallet-boot/WalletBootProvider.web';
 
 const connectorConfig = getDefaultConfig({
   appName: 'CLMM V2',
@@ -21,13 +22,10 @@ function BrowserWalletSessionSync() {
   const { isConnected, account } = useConnector();
 
   useEffect(() => {
-    const store = walletSessionStore.getState();
-
     if (isConnected && account) {
+      const store = walletSessionStore.getState();
       if (store.walletAddress === account && store.connectionKind === 'browser') return;
       store.markConnected({ walletAddress: account, connectionKind: 'browser' });
-    } else if (store.connectionKind === 'browser' && store.walletAddress) {
-      store.disconnect();
     }
   }, [isConnected, account]);
 
@@ -38,7 +36,7 @@ export function BrowserWalletProvider({ children }: { children: ReactNode }) {
   return (
     <AppProvider connectorConfig={connectorConfig} mobile={mobileConfig}>
       <BrowserWalletSessionSync />
-      {children}
+      <WalletBootProvider>{children}</WalletBootProvider>
     </AppProvider>
   );
 }

--- a/apps/app/src/state/deriveWalletBootStatus.test.ts
+++ b/apps/app/src/state/deriveWalletBootStatus.test.ts
@@ -12,6 +12,7 @@ function input(partial: Partial<DeriveWalletBootStatusInput>): DeriveWalletBootS
     hasHydrated: true,
     connectionKind: null,
     walletAddress: null,
+    browserRestoreAddress: null,
     connectorStatus: { status: 'disconnected' },
     connectorAccount: null,
     hasSeenConnectorInflight: false,
@@ -27,6 +28,7 @@ describe('deriveWalletBootStatus', () => {
         hasHydrated: false,
         connectionKind: 'browser',
         walletAddress: ADDR,
+        browserRestoreAddress: ADDR,
         connectorStatus: { status: 'connected', session: {} as never },
         connectorAccount: ADDR,
         hasSeenConnectorInflight: true,
@@ -57,7 +59,7 @@ describe('deriveWalletBootStatus', () => {
       deriveWalletBootStatus(
         input({
           connectionKind: 'browser',
-          walletAddress: ADDR,
+          browserRestoreAddress: ADDR,
           connectorStatus: { status: 'disconnected' },
           hasSeenConnectorInflight: false,
           restoreTimedOut: false,
@@ -71,7 +73,7 @@ describe('deriveWalletBootStatus', () => {
       deriveWalletBootStatus(
         input({
           connectionKind: 'browser',
-          walletAddress: ADDR,
+          browserRestoreAddress: ADDR,
           connectorStatus: { status: 'connecting', connectorId: 'phantom' as never },
           hasSeenConnectorInflight: true,
           restoreTimedOut: false,
@@ -85,7 +87,7 @@ describe('deriveWalletBootStatus', () => {
       deriveWalletBootStatus(
         input({
           connectionKind: 'browser',
-          walletAddress: ADDR,
+          browserRestoreAddress: ADDR,
           connectorStatus: { status: 'connected', session: {} as never },
           connectorAccount: ADDR,
           hasSeenConnectorInflight: true,
@@ -99,7 +101,7 @@ describe('deriveWalletBootStatus', () => {
       deriveWalletBootStatus(
         input({
           connectionKind: 'browser',
-          walletAddress: ADDR,
+          browserRestoreAddress: ADDR,
           connectorStatus: { status: 'connected', session: {} as never },
           connectorAccount: null,
           hasSeenConnectorInflight: true,
@@ -108,12 +110,12 @@ describe('deriveWalletBootStatus', () => {
     ).toBe('checking-browser-wallet');
   });
 
-  it('returns disconnected when connector account does not match persisted wallet address', () => {
+  it('returns disconnected when connector account does not match persisted browser restore address', () => {
     expect(
       deriveWalletBootStatus(
         input({
           connectionKind: 'browser',
-          walletAddress: ADDR,
+          browserRestoreAddress: ADDR,
           connectorStatus: { status: 'connected', session: {} as never },
           connectorAccount: 'AnotherWallet1111111111111111111111111111111',
           hasSeenConnectorInflight: true,
@@ -127,7 +129,7 @@ describe('deriveWalletBootStatus', () => {
       deriveWalletBootStatus(
         input({
           connectionKind: 'browser',
-          walletAddress: ADDR,
+          browserRestoreAddress: ADDR,
           connectorStatus: { status: 'error', error: new Error('x'), recoverable: false },
           hasSeenConnectorInflight: true,
         }),
@@ -140,7 +142,7 @@ describe('deriveWalletBootStatus', () => {
       deriveWalletBootStatus(
         input({
           connectionKind: 'browser',
-          walletAddress: ADDR,
+          browserRestoreAddress: ADDR,
           connectorStatus: { status: 'disconnected' },
           hasSeenConnectorInflight: true,
         }),
@@ -153,7 +155,7 @@ describe('deriveWalletBootStatus', () => {
       deriveWalletBootStatus(
         input({
           connectionKind: 'browser',
-          walletAddress: ADDR,
+          browserRestoreAddress: ADDR,
           connectorStatus: { status: 'connecting', connectorId: 'phantom' as never },
           hasSeenConnectorInflight: true,
           restoreTimedOut: true,
@@ -165,15 +167,15 @@ describe('deriveWalletBootStatus', () => {
   it('returns disconnected when there is no restore candidate and no native session', () => {
     expect(
       deriveWalletBootStatus(
-        input({ connectionKind: null, walletAddress: null }),
+        input({ connectionKind: null, walletAddress: null, browserRestoreAddress: null }),
       ),
     ).toBe('disconnected');
   });
 
-  it('returns disconnected when browser kind has no walletAddress (no candidate)', () => {
+  it('returns disconnected when browser kind has no browserRestoreAddress (no candidate)', () => {
     expect(
       deriveWalletBootStatus(
-        input({ connectionKind: 'browser', walletAddress: null }),
+        input({ connectionKind: 'browser', browserRestoreAddress: null }),
       ),
     ).toBe('disconnected');
   });

--- a/apps/app/src/state/deriveWalletBootStatus.test.ts
+++ b/apps/app/src/state/deriveWalletBootStatus.test.ts
@@ -108,6 +108,20 @@ describe('deriveWalletBootStatus', () => {
     ).toBe('checking-browser-wallet');
   });
 
+  it('returns disconnected when connector account does not match persisted wallet address', () => {
+    expect(
+      deriveWalletBootStatus(
+        input({
+          connectionKind: 'browser',
+          walletAddress: ADDR,
+          connectorStatus: { status: 'connected', session: {} as never },
+          connectorAccount: 'AnotherWallet1111111111111111111111111111111',
+          hasSeenConnectorInflight: true,
+        }),
+      ),
+    ).toBe('disconnected');
+  });
+
   it('returns disconnected when connector reaches error state', () => {
     expect(
       deriveWalletBootStatus(

--- a/apps/app/src/state/deriveWalletBootStatus.test.ts
+++ b/apps/app/src/state/deriveWalletBootStatus.test.ts
@@ -1,0 +1,166 @@
+import { describe, expect, it } from 'vitest';
+import {
+  deriveWalletBootStatus,
+  type DeriveWalletBootStatusInput,
+  type WalletBootStatus,
+} from './deriveWalletBootStatus';
+
+const ADDR = 'DemoWallet1111111111111111111111111111111111';
+
+function input(partial: Partial<DeriveWalletBootStatusInput>): DeriveWalletBootStatusInput {
+  return {
+    hasHydrated: true,
+    connectionKind: null,
+    walletAddress: null,
+    connectorStatus: { status: 'disconnected' },
+    connectorAccount: null,
+    hasSeenConnectorInflight: false,
+    restoreTimedOut: false,
+    ...partial,
+  };
+}
+
+describe('deriveWalletBootStatus', () => {
+  it('returns hydrating-storage when storage has not hydrated, regardless of other inputs', () => {
+    const out: WalletBootStatus = deriveWalletBootStatus(
+      input({
+        hasHydrated: false,
+        connectionKind: 'browser',
+        walletAddress: ADDR,
+        connectorStatus: { status: 'connected', session: {} as never },
+        connectorAccount: ADDR,
+        hasSeenConnectorInflight: true,
+        restoreTimedOut: true,
+      }),
+    );
+    expect(out).toBe('hydrating-storage');
+  });
+
+  it('returns connected immediately for a persisted native session', () => {
+    expect(
+      deriveWalletBootStatus(
+        input({ connectionKind: 'native', walletAddress: ADDR }),
+      ),
+    ).toBe('connected');
+  });
+
+  it('returns disconnected for native kind with null address', () => {
+    expect(
+      deriveWalletBootStatus(
+        input({ connectionKind: 'native', walletAddress: null }),
+      ),
+    ).toBe('disconnected');
+  });
+
+  it('returns checking-browser-wallet for a browser candidate while connector is initial-disconnected', () => {
+    expect(
+      deriveWalletBootStatus(
+        input({
+          connectionKind: 'browser',
+          walletAddress: ADDR,
+          connectorStatus: { status: 'disconnected' },
+          hasSeenConnectorInflight: false,
+          restoreTimedOut: false,
+        }),
+      ),
+    ).toBe('checking-browser-wallet');
+  });
+
+  it('returns checking-browser-wallet for a browser candidate while connector is connecting', () => {
+    expect(
+      deriveWalletBootStatus(
+        input({
+          connectionKind: 'browser',
+          walletAddress: ADDR,
+          connectorStatus: { status: 'connecting', connectorId: 'phantom' as never },
+          hasSeenConnectorInflight: true,
+          restoreTimedOut: false,
+        }),
+      ),
+    ).toBe('checking-browser-wallet');
+  });
+
+  it('returns connected for browser candidate when connector reports connected with matching account', () => {
+    expect(
+      deriveWalletBootStatus(
+        input({
+          connectionKind: 'browser',
+          walletAddress: ADDR,
+          connectorStatus: { status: 'connected', session: {} as never },
+          connectorAccount: ADDR,
+          hasSeenConnectorInflight: true,
+        }),
+      ),
+    ).toBe('connected');
+  });
+
+  it('keeps checking-browser-wallet when connector says connected but account is null (defensive)', () => {
+    expect(
+      deriveWalletBootStatus(
+        input({
+          connectionKind: 'browser',
+          walletAddress: ADDR,
+          connectorStatus: { status: 'connected', session: {} as never },
+          connectorAccount: null,
+          hasSeenConnectorInflight: true,
+        }),
+      ),
+    ).toBe('checking-browser-wallet');
+  });
+
+  it('returns disconnected when connector reaches error state', () => {
+    expect(
+      deriveWalletBootStatus(
+        input({
+          connectionKind: 'browser',
+          walletAddress: ADDR,
+          connectorStatus: { status: 'error', error: new Error('x'), recoverable: false },
+          hasSeenConnectorInflight: true,
+        }),
+      ),
+    ).toBe('disconnected');
+  });
+
+  it('returns disconnected when connector returns to disconnected after being inflight', () => {
+    expect(
+      deriveWalletBootStatus(
+        input({
+          connectionKind: 'browser',
+          walletAddress: ADDR,
+          connectorStatus: { status: 'disconnected' },
+          hasSeenConnectorInflight: true,
+        }),
+      ),
+    ).toBe('disconnected');
+  });
+
+  it('returns disconnected when watchdog fires regardless of connector state', () => {
+    expect(
+      deriveWalletBootStatus(
+        input({
+          connectionKind: 'browser',
+          walletAddress: ADDR,
+          connectorStatus: { status: 'connecting', connectorId: 'phantom' as never },
+          hasSeenConnectorInflight: true,
+          restoreTimedOut: true,
+        }),
+      ),
+    ).toBe('disconnected');
+  });
+
+  it('returns disconnected when there is no restore candidate and no native session', () => {
+    expect(
+      deriveWalletBootStatus(
+        input({ connectionKind: null, walletAddress: null }),
+      ),
+    ).toBe('disconnected');
+  });
+
+  it('returns disconnected when browser kind has no walletAddress (no candidate)', () => {
+    expect(
+      deriveWalletBootStatus(
+        input({ connectionKind: 'browser', walletAddress: null }),
+      ),
+    ).toBe('disconnected');
+  });
+});

--- a/apps/app/src/state/deriveWalletBootStatus.ts
+++ b/apps/app/src/state/deriveWalletBootStatus.ts
@@ -11,6 +11,7 @@ export type DeriveWalletBootStatusInput = {
   hasHydrated: boolean;
   connectionKind: WalletConnectionKind | null;
   walletAddress: string | null;
+  browserRestoreAddress: string | null;
   connectorStatus: WalletStatus;
   connectorAccount: string | null;
   hasSeenConnectorInflight: boolean;
@@ -25,19 +26,19 @@ export function deriveWalletBootStatus(input: DeriveWalletBootStatusInput): Wall
   }
 
   const hasBrowserRestoreCandidate =
-    input.connectionKind === 'browser' && input.walletAddress != null;
+    input.connectionKind === 'browser' && input.browserRestoreAddress != null;
 
   if (hasBrowserRestoreCandidate) {
     if (
       input.connectorStatus.status === 'connected' &&
-      input.connectorAccount === input.walletAddress
+      input.connectorAccount === input.browserRestoreAddress
     ) {
       return 'connected';
     }
     if (
       input.connectorStatus.status === 'connected' &&
       input.connectorAccount != null &&
-      input.connectorAccount !== input.walletAddress
+      input.connectorAccount !== input.browserRestoreAddress
     ) {
       return 'disconnected';
     }

--- a/apps/app/src/state/deriveWalletBootStatus.ts
+++ b/apps/app/src/state/deriveWalletBootStatus.ts
@@ -1,0 +1,48 @@
+import type { WalletStatus } from '@solana/connector';
+import type { WalletConnectionKind } from './walletSessionStore';
+
+export type WalletBootStatus =
+  | 'hydrating-storage'
+  | 'checking-browser-wallet'
+  | 'connected'
+  | 'disconnected';
+
+export type DeriveWalletBootStatusInput = {
+  hasHydrated: boolean;
+  connectionKind: WalletConnectionKind | null;
+  walletAddress: string | null;
+  connectorStatus: WalletStatus;
+  connectorAccount: string | null;
+  hasSeenConnectorInflight: boolean;
+  restoreTimedOut: boolean;
+};
+
+export function deriveWalletBootStatus(input: DeriveWalletBootStatusInput): WalletBootStatus {
+  if (!input.hasHydrated) return 'hydrating-storage';
+
+  if (input.connectionKind === 'native' && input.walletAddress != null) {
+    return 'connected';
+  }
+
+  const hasBrowserRestoreCandidate =
+    input.connectionKind === 'browser' && input.walletAddress != null;
+
+  if (hasBrowserRestoreCandidate) {
+    if (
+      input.connectorStatus.status === 'connected' &&
+      input.connectorAccount != null
+    ) {
+      return 'connected';
+    }
+    if (input.connectorStatus.status === 'error') {
+      return 'disconnected';
+    }
+    if (input.connectorStatus.status === 'disconnected' && input.hasSeenConnectorInflight) {
+      return 'disconnected';
+    }
+    if (input.restoreTimedOut) return 'disconnected';
+    return 'checking-browser-wallet';
+  }
+
+  return 'disconnected';
+}

--- a/apps/app/src/state/deriveWalletBootStatus.ts
+++ b/apps/app/src/state/deriveWalletBootStatus.ts
@@ -30,9 +30,16 @@ export function deriveWalletBootStatus(input: DeriveWalletBootStatusInput): Wall
   if (hasBrowserRestoreCandidate) {
     if (
       input.connectorStatus.status === 'connected' &&
-      input.connectorAccount != null
+      input.connectorAccount === input.walletAddress
     ) {
       return 'connected';
+    }
+    if (
+      input.connectorStatus.status === 'connected' &&
+      input.connectorAccount != null &&
+      input.connectorAccount !== input.walletAddress
+    ) {
+      return 'disconnected';
     }
     if (input.connectorStatus.status === 'error') {
       return 'disconnected';

--- a/apps/app/src/state/walletSessionStore.test.ts
+++ b/apps/app/src/state/walletSessionStore.test.ts
@@ -61,8 +61,22 @@ describe('walletSessionStore', () => {
 
     expect(store.getState().walletAddress).toBe('DemoWallet1111111111111111111111111111111111');
     expect(store.getState().connectionKind).toBe('browser');
+    expect(store.getState().browserRestoreAddress).toBe('DemoWallet1111111111111111111111111111111111');
     expect(store.getState().connectionOutcome).toEqual({ kind: 'connected' });
     expect(store.getState().isConnecting).toBe(false);
+  });
+
+  it('marks a native connection without setting browserRestoreAddress', () => {
+    const store = createWalletSessionStore();
+
+    store.getState().markConnected({
+      walletAddress: 'DemoWallet1111111111111111111111111111111111',
+      connectionKind: 'native',
+    });
+
+    expect(store.getState().walletAddress).toBe('DemoWallet1111111111111111111111111111111111');
+    expect(store.getState().connectionKind).toBe('native');
+    expect(store.getState().browserRestoreAddress).toBeNull();
   });
 
   it('beginConnection clears stale session fields and stale outcome', () => {
@@ -71,6 +85,7 @@ describe('walletSessionStore', () => {
     store.setState({
       walletAddress: 'DemoWallet1111111111111111111111111111111111',
       connectionKind: 'browser' satisfies WalletConnectionKind,
+      browserRestoreAddress: 'DemoWallet1111111111111111111111111111111111',
       connectionOutcome: { kind: 'failed', reason: 'stale' },
     });
 
@@ -79,6 +94,7 @@ describe('walletSessionStore', () => {
     expect(store.getState().isConnecting).toBe(true);
     expect(store.getState().walletAddress).toBeNull();
     expect(store.getState().connectionKind).toBeNull();
+    expect(store.getState().browserRestoreAddress).toBeNull();
     expect(store.getState().connectionOutcome).toBeNull();
   });
 
@@ -102,7 +118,7 @@ describe('walletSessionStore', () => {
     expect(store.getState().connectionKind).toBeNull();
   });
 
-  it('disconnect clears address, kind, and connecting state, and clears persisted storage', async () => {
+  it('disconnect clears address, kind, browserRestoreAddress, and connecting state, and clears persisted storage', async () => {
     const store = createWalletSessionStore();
 
     store.getState().markConnected({
@@ -120,10 +136,11 @@ describe('walletSessionStore', () => {
 
     expect(store.getState().walletAddress).toBeNull();
     expect(store.getState().connectionKind).toBeNull();
+    expect(store.getState().browserRestoreAddress).toBeNull();
     expect(store.getState().isConnecting).toBe(false);
   });
 
-  it('persists browser wallet sessions across rehydration', async () => {
+  it('persists browser wallet sessions across rehydration but keeps walletAddress null until boot confirms', async () => {
     const store1 = createWalletSessionStore();
 
     store1.getState().setPlatformCapabilities(caps);
@@ -138,8 +155,9 @@ describe('walletSessionStore', () => {
     const store2 = createWalletSessionStore();
     await store2.persist.rehydrate();
 
-    expect(store2.getState().walletAddress).toBe('DemoWallet1111111111111111111111111111111111');
+    expect(store2.getState().walletAddress).toBeNull();
     expect(store2.getState().connectionKind).toBe('browser');
+    expect(store2.getState().browserRestoreAddress).toBe('DemoWallet1111111111111111111111111111111111');
     expect(store2.getState().platformCapabilities).toEqual(caps);
   });
 

--- a/apps/app/src/state/walletSessionStore.test.ts
+++ b/apps/app/src/state/walletSessionStore.test.ts
@@ -123,7 +123,7 @@ describe('walletSessionStore', () => {
     expect(store.getState().isConnecting).toBe(false);
   });
 
-  it('does not persist browser wallet sessions across rehydration', async () => {
+  it('persists browser wallet sessions across rehydration', async () => {
     const store1 = createWalletSessionStore();
 
     store1.getState().setPlatformCapabilities(caps);
@@ -138,9 +138,50 @@ describe('walletSessionStore', () => {
     const store2 = createWalletSessionStore();
     await store2.persist.rehydrate();
 
-    expect(store2.getState().walletAddress).toBeNull();
-    expect(store2.getState().connectionKind).toBeNull();
+    expect(store2.getState().walletAddress).toBe('DemoWallet1111111111111111111111111111111111');
+    expect(store2.getState().connectionKind).toBe('browser');
     expect(store2.getState().platformCapabilities).toEqual(caps);
+  });
+
+  it('records lastConnectedAt when markConnected is called', () => {
+    const store = createWalletSessionStore();
+    const before = Date.now();
+
+    store.getState().markConnected({
+      walletAddress: 'DemoWallet1111111111111111111111111111111111',
+      connectionKind: 'browser',
+    });
+
+    const after = Date.now();
+    const ts = store.getState().lastConnectedAt;
+    expect(ts).not.toBeNull();
+    expect(ts!).toBeGreaterThanOrEqual(before);
+    expect(ts!).toBeLessThanOrEqual(after);
+  });
+
+  it('persists lastConnectedAt across rehydration', async () => {
+    const store1 = createWalletSessionStore();
+    store1.getState().markConnected({
+      walletAddress: 'DemoWallet1111111111111111111111111111111111',
+      connectionKind: 'browser',
+    });
+    const ts = store1.getState().lastConnectedAt;
+    await Promise.resolve();
+
+    const store2 = createWalletSessionStore();
+    await store2.persist.rehydrate();
+    expect(store2.getState().lastConnectedAt).toBe(ts);
+  });
+
+  it('clears lastConnectedAt on disconnect', () => {
+    const store = createWalletSessionStore();
+    store.getState().markConnected({
+      walletAddress: 'DemoWallet1111111111111111111111111111111111',
+      connectionKind: 'browser',
+    });
+    expect(store.getState().lastConnectedAt).not.toBeNull();
+    store.getState().disconnect();
+    expect(store.getState().lastConnectedAt).toBeNull();
   });
 
   it('persists native wallet sessions across rehydration', async () => {

--- a/apps/app/src/state/walletSessionStore.ts
+++ b/apps/app/src/state/walletSessionStore.ts
@@ -23,6 +23,7 @@ type NonSuccessConnectionOutcome = Exclude<ConnectionOutcome, { kind: 'connected
 export type WalletSessionState = {
   walletAddress: string | null;
   connectionKind: WalletConnectionKind | null;
+  browserRestoreAddress: string | null;
   connectionOutcome: ConnectionOutcome | null;
   platformCapabilities: PlatformCapabilityState | null;
   isConnecting: boolean;
@@ -45,6 +46,7 @@ export function createWalletSessionStore() {
       (set, _get, store) => ({
         walletAddress: null,
         connectionKind: null,
+        browserRestoreAddress: null,
         connectionOutcome: null,
         platformCapabilities: null,
         isConnecting: false,
@@ -57,11 +59,13 @@ export function createWalletSessionStore() {
             connectionOutcome: null,
             walletAddress: null,
             connectionKind: null,
+            browserRestoreAddress: null,
           }),
         markConnected: ({ walletAddress, connectionKind }) =>
           set({
             walletAddress,
             connectionKind,
+            browserRestoreAddress: connectionKind === 'browser' ? walletAddress : null,
             connectionOutcome: { kind: 'connected' },
             isConnecting: false,
             lastConnectedAt: Date.now(),
@@ -72,11 +76,13 @@ export function createWalletSessionStore() {
             isConnecting: false,
             walletAddress: null,
             connectionKind: null,
+            browserRestoreAddress: null,
           }),
         disconnect: () => {
           set({
             walletAddress: null,
             connectionKind: null,
+            browserRestoreAddress: null,
             connectionOutcome: null,
             isConnecting: false,
             lastConnectedAt: null,
@@ -88,12 +94,24 @@ export function createWalletSessionStore() {
       {
         name: 'wallet-session',
         storage: safeStorageFactory(),
-        partialize: (state) => ({
-          walletAddress: state.walletAddress,
-          connectionKind: state.connectionKind,
-          platformCapabilities: state.platformCapabilities,
-          lastConnectedAt: state.lastConnectedAt,
-        }),
+        partialize: (state) => {
+          if (state.connectionKind === 'browser') {
+            return {
+              walletAddress: null,
+              connectionKind: state.connectionKind,
+              browserRestoreAddress: state.browserRestoreAddress,
+              platformCapabilities: state.platformCapabilities,
+              lastConnectedAt: state.lastConnectedAt,
+            };
+          }
+          return {
+            walletAddress: state.walletAddress,
+            connectionKind: state.connectionKind,
+            browserRestoreAddress: null,
+            platformCapabilities: state.platformCapabilities,
+            lastConnectedAt: state.lastConnectedAt,
+          };
+        },
         onRehydrateStorage: () => (_state, _error) => {
           if (typeof window !== 'undefined') {
             store.setState({ hasHydrated: true });

--- a/apps/app/src/state/walletSessionStore.ts
+++ b/apps/app/src/state/walletSessionStore.ts
@@ -27,6 +27,7 @@ export type WalletSessionState = {
   platformCapabilities: PlatformCapabilityState | null;
   isConnecting: boolean;
   hasHydrated: boolean;
+  lastConnectedAt: number | null;
   setPlatformCapabilities: (capabilities: PlatformCapabilityState) => void;
   beginConnection: () => void;
   markConnected: (params: {
@@ -48,6 +49,7 @@ export function createWalletSessionStore() {
         platformCapabilities: null,
         isConnecting: false,
         hasHydrated: false,
+        lastConnectedAt: null,
         setPlatformCapabilities: (platformCapabilities) => set({ platformCapabilities }),
         beginConnection: () =>
           set({
@@ -62,6 +64,7 @@ export function createWalletSessionStore() {
             connectionKind,
             connectionOutcome: { kind: 'connected' },
             isConnecting: false,
+            lastConnectedAt: Date.now(),
           }),
         markOutcome: (connectionOutcome) =>
           set({
@@ -76,8 +79,8 @@ export function createWalletSessionStore() {
             connectionKind: null,
             connectionOutcome: null,
             isConnecting: false,
+            lastConnectedAt: null,
           });
-          // Also clear persisted storage so nothing survives across sessions
           store.persist.clearStorage();
         },
         clearOutcome: () => set({ connectionOutcome: null }),
@@ -85,20 +88,12 @@ export function createWalletSessionStore() {
       {
         name: 'wallet-session',
         storage: safeStorageFactory(),
-        partialize: (state) => {
-          if (state.connectionKind === 'browser') {
-            return {
-              walletAddress: null,
-              connectionKind: null,
-              platformCapabilities: state.platformCapabilities,
-            };
-          }
-          return {
-            walletAddress: state.walletAddress,
-            connectionKind: state.connectionKind,
-            platformCapabilities: state.platformCapabilities,
-          };
-        },
+        partialize: (state) => ({
+          walletAddress: state.walletAddress,
+          connectionKind: state.connectionKind,
+          platformCapabilities: state.platformCapabilities,
+          lastConnectedAt: state.lastConnectedAt,
+        }),
         onRehydrateStorage: () => (_state, _error) => {
           if (typeof window !== 'undefined') {
             store.setState({ hasHydrated: true });

--- a/apps/app/src/wallet-boot/BootScreen.tsx
+++ b/apps/app/src/wallet-boot/BootScreen.tsx
@@ -1,0 +1,30 @@
+import { ActivityIndicator, Text, View } from 'react-native';
+import type { WalletBootStatus } from '../state/deriveWalletBootStatus';
+
+type BootScreenProps = {
+  status: Extract<WalletBootStatus, 'hydrating-storage' | 'checking-browser-wallet'>;
+};
+
+const COPY: Record<BootScreenProps['status'], string> = {
+  'hydrating-storage': 'Loading\u2026',
+  'checking-browser-wallet': 'Restoring wallet session\u2026',
+};
+
+export function BootScreen({ status }: BootScreenProps) {
+  return (
+    <View
+      style={{
+        flex: 1,
+        backgroundColor: '#0a0a0a',
+        justifyContent: 'center',
+        alignItems: 'center',
+        gap: 12,
+      }}
+      accessibilityRole="alert"
+      accessibilityLabel={COPY[status]}
+    >
+      <ActivityIndicator size="small" color="#a1a1aa" />
+      <Text style={{ color: '#a1a1aa', fontSize: 14 }}>{COPY[status]}</Text>
+    </View>
+  );
+}

--- a/apps/app/src/wallet-boot/RequireWallet.test.tsx
+++ b/apps/app/src/wallet-boot/RequireWallet.test.tsx
@@ -1,0 +1,100 @@
+import { act, cleanup, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useState } from 'react';
+import type { WalletBootStatus } from '../state/deriveWalletBootStatus';
+import { WalletBootContext } from './walletBootContext';
+
+const navigateMock = vi.fn();
+vi.mock('../platform/webNavigation', () => ({
+  navigateRoute: (...args: unknown[]) => navigateMock(...args),
+}));
+
+vi.mock('react-native', () => ({
+  ActivityIndicator: ({ size, color }: { size: string; color: string }) => {
+    const React = require('react');
+    return React.createElement('ActivityIndicator', { size, color });
+  },
+  Text: ({ children, style }: { children: React.ReactNode; style?: unknown }) => {
+    const React = require('react');
+    return React.createElement('span', { style }, children);
+  },
+  View: ({ children, style }: { children: React.ReactNode; style?: unknown }) => {
+    const React = require('react');
+    return React.createElement('div', { style }, children);
+  },
+}));
+
+vi.mock('expo-router', () => ({
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn() }),
+  usePathname: () => mockPathname,
+  useGlobalSearchParams: () => mockSearch,
+}));
+
+let mockPathname = '/positions/abc';
+let mockSearch: Record<string, string | string[] | undefined> = {};
+
+import { RequireWallet } from './RequireWallet';
+
+function Harness({ initial }: { initial: WalletBootStatus }) {
+  const [status, setStatus] = useState<WalletBootStatus>(initial);
+  return (
+    <WalletBootContext.Provider value={status}>
+      <RequireWallet>
+        <span data-testid="children">child content</span>
+      </RequireWallet>
+      <button data-testid="set-connected" onClick={() => setStatus('connected')}>c</button>
+      <button data-testid="set-disconnected" onClick={() => setStatus('disconnected')}>d</button>
+    </WalletBootContext.Provider>
+  );
+}
+
+beforeEach(() => {
+  navigateMock.mockReset();
+  mockPathname = '/positions/abc';
+  mockSearch = {};
+});
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe('RequireWallet', () => {
+  it('renders BootScreen when status is hydrating-storage', () => {
+    render(<Harness initial="hydrating-storage" />);
+    expect(screen.getByText('Loading\u2026')).toBeTruthy();
+    expect(screen.queryByTestId('children')).toBeNull();
+    expect(navigateMock).not.toHaveBeenCalled();
+  });
+
+  it('renders BootScreen when status is checking-browser-wallet', () => {
+    render(<Harness initial="checking-browser-wallet" />);
+    expect(screen.getByText('Restoring wallet session\u2026')).toBeTruthy();
+    expect(navigateMock).not.toHaveBeenCalled();
+  });
+
+  it('renders children when status is connected', () => {
+    render(<Harness initial="connected" />);
+    expect(screen.getByTestId('children')).toBeTruthy();
+    expect(navigateMock).not.toHaveBeenCalled();
+  });
+
+  it('navigates to /connect with encoded returnTo when status is disconnected', () => {
+    mockPathname = '/preview/abc';
+    mockSearch = { triggerId: 'xyz' };
+    render(<Harness initial="disconnected" />);
+    expect(navigateMock).toHaveBeenCalledTimes(1);
+    const call = navigateMock.mock.calls[0]![0] as { path: string; method: string };
+    expect(call.method).toBe('push');
+    expect(call.path).toBe('/connect?returnTo=' + encodeURIComponent('/preview/abc?triggerId=xyz'));
+    expect(screen.queryByTestId('children')).toBeNull();
+  });
+
+  it('does not call navigate again if status flips back to connected', () => {
+    render(<Harness initial="disconnected" />);
+    expect(navigateMock).toHaveBeenCalledTimes(1);
+    act(() => { screen.getByTestId('set-connected').click(); });
+    expect(navigateMock).toHaveBeenCalledTimes(1);
+    expect(screen.getByTestId('children')).toBeTruthy();
+  });
+});

--- a/apps/app/src/wallet-boot/RequireWallet.test.tsx
+++ b/apps/app/src/wallet-boot/RequireWallet.test.tsx
@@ -80,9 +80,9 @@ describe('RequireWallet', () => {
     mockSearch = { triggerId: 'xyz' };
     render(<Harness initial="disconnected" />);
     expect(navigateMock).toHaveBeenCalledTimes(1);
-    const call = navigateMock.mock.calls[0] as Array<{ path: string; method: string }>;
-    expect(call[0].method).toBe('push');
-    expect(call[0].path).toBe('/connect?returnTo=' + encodeURIComponent('/preview/abc?triggerId=xyz'));
+    const call = navigateMock.mock.calls[0]![0]! as { path: string; method: string };
+    expect(call.method).toBe('push');
+    expect(call.path).toBe('/connect?returnTo=' + encodeURIComponent('/preview/abc?triggerId=xyz'));
     expect(screen.queryByTestId('children')).toBeNull();
   });
 

--- a/apps/app/src/wallet-boot/RequireWallet.test.tsx
+++ b/apps/app/src/wallet-boot/RequireWallet.test.tsx
@@ -86,6 +86,15 @@ describe('RequireWallet', () => {
     expect(screen.queryByTestId('children')).toBeNull();
   });
 
+  it('excludes path params from returnTo query string', () => {
+    mockPathname = '/signing/mypass';
+    mockSearch = { attemptId: 'mypass', tab: 'details' };
+    render(<Harness initial="disconnected" />);
+    expect(navigateMock).toHaveBeenCalledTimes(1);
+    const call = navigateMock.mock.calls[0]![0]! as { path: string; method: string };
+    expect(call.path).toBe('/connect?returnTo=' + encodeURIComponent('/signing/mypass?tab=details'));
+  });
+
   it('does not call navigate again if status flips back to connected', () => {
     render(<Harness initial="disconnected" />);
     expect(navigateMock).toHaveBeenCalledTimes(1);

--- a/apps/app/src/wallet-boot/RequireWallet.test.tsx
+++ b/apps/app/src/wallet-boot/RequireWallet.test.tsx
@@ -6,23 +6,19 @@ import { WalletBootContext } from './walletBootContext';
 
 const navigateMock = vi.fn();
 vi.mock('../platform/webNavigation', () => ({
-  navigateRoute: (...args: unknown[]) => navigateMock(...args),
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-argument
+  navigateRoute: (...args: any[]) => navigateMock(...args),
 }));
 
-vi.mock('react-native', () => ({
-  ActivityIndicator: ({ size, color }: { size: string; color: string }) => {
-    const React = require('react');
-    return React.createElement('ActivityIndicator', { size, color });
-  },
-  Text: ({ children, style }: { children: React.ReactNode; style?: unknown }) => {
-    const React = require('react');
-    return React.createElement('span', { style }, children);
-  },
-  View: ({ children, style }: { children: React.ReactNode; style?: unknown }) => {
-    const React = require('react');
-    return React.createElement('div', { style }, children);
-  },
-}));
+/* eslint-disable @typescript-eslint/no-var-requires, @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-explicit-any */
+vi.mock('react-native', () => {
+  const R = require('react');
+  return {
+    ActivityIndicator: (_props: any) => R.createElement('span', { 'data-testid': 'activity-indicator' }),
+    Text: (props: any) => R.createElement('span', null, props.children),
+    View: (props: any) => R.createElement('div', null, props.children),
+  };
+});
 
 vi.mock('expo-router', () => ({
   useRouter: () => ({ push: vi.fn(), replace: vi.fn() }),
@@ -84,9 +80,9 @@ describe('RequireWallet', () => {
     mockSearch = { triggerId: 'xyz' };
     render(<Harness initial="disconnected" />);
     expect(navigateMock).toHaveBeenCalledTimes(1);
-    const call = navigateMock.mock.calls[0]![0] as { path: string; method: string };
-    expect(call.method).toBe('push');
-    expect(call.path).toBe('/connect?returnTo=' + encodeURIComponent('/preview/abc?triggerId=xyz'));
+    const call = navigateMock.mock.calls[0] as Array<{ path: string; method: string }>;
+    expect(call[0].method).toBe('push');
+    expect(call[0].path).toBe('/connect?returnTo=' + encodeURIComponent('/preview/abc?triggerId=xyz'));
     expect(screen.queryByTestId('children')).toBeNull();
   });
 

--- a/apps/app/src/wallet-boot/RequireWallet.tsx
+++ b/apps/app/src/wallet-boot/RequireWallet.tsx
@@ -1,0 +1,30 @@
+import { useEffect, type ReactNode } from 'react';
+import { useGlobalSearchParams, usePathname, useRouter } from 'expo-router';
+import { navigateRoute } from '../platform/webNavigation';
+import { BootScreen } from './BootScreen';
+import { buildReturnToPath, type SearchParamRecord } from './buildReturnToPath';
+import { useWalletBootStatus } from './walletBootContext';
+
+export function RequireWallet({ children }: { children: ReactNode }) {
+  const status = useWalletBootStatus();
+  const router = useRouter();
+  const pathname = usePathname();
+  const search = useGlobalSearchParams() as SearchParamRecord;
+
+  useEffect(() => {
+    if (status !== 'disconnected') return;
+    const fullPath = buildReturnToPath(pathname, search);
+    const target = `/connect?returnTo=${encodeURIComponent(fullPath)}`;
+    navigateRoute({ router, path: target, method: 'push' });
+  }, [status]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  if (status === 'hydrating-storage' || status === 'checking-browser-wallet') {
+    return <BootScreen status={status} />;
+  }
+
+  if (status === 'disconnected') {
+    return null;
+  }
+
+  return <>{children}</>;
+}

--- a/apps/app/src/wallet-boot/RequireWallet.tsx
+++ b/apps/app/src/wallet-boot/RequireWallet.tsx
@@ -1,9 +1,20 @@
-import { useEffect, type ReactNode } from 'react';
+import { useEffect, useMemo, type ReactNode } from 'react';
 import { useGlobalSearchParams, usePathname, useRouter } from 'expo-router';
 import { navigateRoute } from '../platform/webNavigation';
 import { BootScreen } from './BootScreen';
 import { buildReturnToPath, type SearchParamRecord } from './buildReturnToPath';
 import { useWalletBootStatus } from './walletBootContext';
+
+function extractPathParamKeys(pathname: string, search: SearchParamRecord): Set<string> {
+  const segments = pathname.split('/').filter(Boolean);
+  const keys = new Set<string>();
+  for (const [key, value] of Object.entries(search)) {
+    if (typeof value === 'string' && segments.includes(value)) {
+      keys.add(key);
+    }
+  }
+  return keys;
+}
 
 export function RequireWallet({ children }: { children: ReactNode }) {
   const status = useWalletBootStatus();
@@ -11,9 +22,11 @@ export function RequireWallet({ children }: { children: ReactNode }) {
   const pathname = usePathname();
   const search = useGlobalSearchParams() as SearchParamRecord;
 
+  const pathParamKeys = useMemo(() => extractPathParamKeys(pathname, search), [pathname, search]);
+
   useEffect(() => {
     if (status !== 'disconnected') return;
-    const fullPath = buildReturnToPath(pathname, search);
+    const fullPath = buildReturnToPath(pathname, search, pathParamKeys);
     const target = `/connect?returnTo=${encodeURIComponent(fullPath)}`;
     navigateRoute({ router, path: target, method: 'push' });
   }, [status]);

--- a/apps/app/src/wallet-boot/RequireWallet.tsx
+++ b/apps/app/src/wallet-boot/RequireWallet.tsx
@@ -16,7 +16,7 @@ export function RequireWallet({ children }: { children: ReactNode }) {
     const fullPath = buildReturnToPath(pathname, search);
     const target = `/connect?returnTo=${encodeURIComponent(fullPath)}`;
     navigateRoute({ router, path: target, method: 'push' });
-  }, [status]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [status]);
 
   if (status === 'hydrating-storage' || status === 'checking-browser-wallet') {
     return <BootScreen status={status} />;

--- a/apps/app/src/wallet-boot/WalletBootProvider.native.tsx
+++ b/apps/app/src/wallet-boot/WalletBootProvider.native.tsx
@@ -8,6 +8,7 @@ export function WalletBootProvider({ children }: { children: ReactNode }) {
   const hasHydrated = useStore(walletSessionStore, (s) => s.hasHydrated);
   const connectionKind = useStore(walletSessionStore, (s) => s.connectionKind);
   const walletAddress = useStore(walletSessionStore, (s) => s.walletAddress);
+  const browserRestoreAddress = useStore(walletSessionStore, (s) => s.browserRestoreAddress);
 
   const status = useMemo(
     () =>
@@ -15,12 +16,13 @@ export function WalletBootProvider({ children }: { children: ReactNode }) {
         hasHydrated,
         connectionKind,
         walletAddress,
+        browserRestoreAddress,
         connectorStatus: { status: 'disconnected' },
         connectorAccount: null,
         hasSeenConnectorInflight: true,
         restoreTimedOut: true,
       }),
-    [hasHydrated, connectionKind, walletAddress],
+    [hasHydrated, connectionKind, walletAddress, browserRestoreAddress],
   );
 
   return (

--- a/apps/app/src/wallet-boot/WalletBootProvider.native.tsx
+++ b/apps/app/src/wallet-boot/WalletBootProvider.native.tsx
@@ -1,0 +1,31 @@
+import { useMemo, type ReactNode } from 'react';
+import { useStore } from 'zustand';
+import { walletSessionStore } from '../state/walletSessionStore';
+import { deriveWalletBootStatus } from '../state/deriveWalletBootStatus';
+import { WalletBootContext } from './walletBootContext';
+
+export function WalletBootProvider({ children }: { children: ReactNode }) {
+  const hasHydrated = useStore(walletSessionStore, (s) => s.hasHydrated);
+  const connectionKind = useStore(walletSessionStore, (s) => s.connectionKind);
+  const walletAddress = useStore(walletSessionStore, (s) => s.walletAddress);
+
+  const status = useMemo(
+    () =>
+      deriveWalletBootStatus({
+        hasHydrated,
+        connectionKind,
+        walletAddress,
+        connectorStatus: { status: 'disconnected' },
+        connectorAccount: null,
+        hasSeenConnectorInflight: true,
+        restoreTimedOut: true,
+      }),
+    [hasHydrated, connectionKind, walletAddress],
+  );
+
+  return (
+    <WalletBootContext.Provider value={status}>
+      {children}
+    </WalletBootContext.Provider>
+  );
+}

--- a/apps/app/src/wallet-boot/WalletBootProvider.tsx
+++ b/apps/app/src/wallet-boot/WalletBootProvider.tsx
@@ -1,0 +1,1 @@
+export { WalletBootProvider } from './WalletBootProvider.native';

--- a/apps/app/src/wallet-boot/WalletBootProvider.web.test.tsx
+++ b/apps/app/src/wallet-boot/WalletBootProvider.web.test.tsx
@@ -24,6 +24,7 @@ function setConnector(next: { walletStatus: WalletStatus; account: string | null
   connectorListeners.forEach((l) => l());
 }
 
+/* eslint-disable @typescript-eslint/no-var-requires, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access */
 vi.mock('@solana/connector', () => {
   const { useSyncExternalStore } = require('react');
   return {

--- a/apps/app/src/wallet-boot/WalletBootProvider.web.test.tsx
+++ b/apps/app/src/wallet-boot/WalletBootProvider.web.test.tsx
@@ -1,0 +1,125 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, cleanup, render, screen } from '@testing-library/react';
+import type { WalletStatus } from '@solana/connector';
+
+vi.mock('@react-native-async-storage/async-storage', () => {
+  const mem = new Map<string, string>();
+  return {
+    default: {
+      setItem: vi.fn((k: string, v: string) => { mem.set(k, v); return Promise.resolve(); }),
+      getItem: vi.fn((k: string) => Promise.resolve(mem.get(k) ?? null)),
+      removeItem: vi.fn((k: string) => { mem.delete(k); return Promise.resolve(); }),
+      clear: vi.fn(() => { mem.clear(); return Promise.resolve(); }),
+    },
+  };
+});
+
+let connectorState: { walletStatus: WalletStatus; account: string | null } = {
+  walletStatus: { status: 'disconnected' },
+  account: null,
+};
+const connectorListeners = new Set<() => void>();
+function setConnector(next: { walletStatus: WalletStatus; account: string | null }) {
+  connectorState = next;
+  connectorListeners.forEach((l) => l());
+}
+
+vi.mock('@solana/connector', () => {
+  const { useSyncExternalStore } = require('react');
+  return {
+    useConnector: () =>
+      useSyncExternalStore(
+        (l: () => void) => { connectorListeners.add(l); return () => connectorListeners.delete(l); },
+        () => connectorState,
+        () => connectorState,
+      ),
+  };
+});
+
+import { walletSessionStore } from '../state/walletSessionStore';
+import { WalletBootProvider } from './WalletBootProvider.web';
+import { useWalletBootStatus } from './walletBootContext';
+
+function Probe() {
+  const status = useWalletBootStatus();
+  return <span data-testid="status">{status}</span>;
+}
+
+const ADDR = 'DemoWallet1111111111111111111111111111111111';
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  setConnector({ walletStatus: { status: 'disconnected' }, account: null });
+  walletSessionStore.setState({
+    walletAddress: null,
+    connectionKind: null,
+    hasHydrated: true,
+    lastConnectedAt: null,
+    isConnecting: false,
+    connectionOutcome: null,
+    platformCapabilities: null,
+  });
+});
+
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+});
+
+describe('WalletBootProvider (web)', () => {
+  it('starts in checking-browser-wallet for a persisted browser candidate', () => {
+    walletSessionStore.setState({ walletAddress: ADDR, connectionKind: 'browser' });
+    render(<WalletBootProvider><Probe /></WalletBootProvider>);
+    expect(screen.getByTestId('status').textContent).toBe('checking-browser-wallet');
+  });
+
+  it('resolves to connected when connector reaches connected with matching account', () => {
+    walletSessionStore.setState({ walletAddress: ADDR, connectionKind: 'browser' });
+    render(<WalletBootProvider><Probe /></WalletBootProvider>);
+    act(() => {
+      setConnector({ walletStatus: { status: 'connecting', connectorId: 'phantom' as never }, account: null });
+    });
+    expect(screen.getByTestId('status').textContent).toBe('checking-browser-wallet');
+    act(() => {
+      setConnector({ walletStatus: { status: 'connected', session: {} as never }, account: ADDR });
+    });
+    expect(screen.getByTestId('status').textContent).toBe('connected');
+  });
+
+  it('resolves to disconnected when connector returns to disconnected after being inflight', () => {
+    walletSessionStore.setState({ walletAddress: ADDR, connectionKind: 'browser' });
+    render(<WalletBootProvider><Probe /></WalletBootProvider>);
+    act(() => {
+      setConnector({ walletStatus: { status: 'connecting', connectorId: 'phantom' as never }, account: null });
+    });
+    act(() => {
+      setConnector({ walletStatus: { status: 'disconnected' }, account: null });
+    });
+    expect(screen.getByTestId('status').textContent).toBe('disconnected');
+  });
+
+  it('resolves to disconnected after the 1500ms watchdog when the connector never moves', () => {
+    walletSessionStore.setState({ walletAddress: ADDR, connectionKind: 'browser' });
+    render(<WalletBootProvider><Probe /></WalletBootProvider>);
+    expect(screen.getByTestId('status').textContent).toBe('checking-browser-wallet');
+    act(() => { vi.advanceTimersByTime(1500); });
+    expect(screen.getByTestId('status').textContent).toBe('disconnected');
+  });
+
+  it('returns connected for a persisted native session with no connector activity', () => {
+    walletSessionStore.setState({ walletAddress: ADDR, connectionKind: 'native' });
+    render(<WalletBootProvider><Probe /></WalletBootProvider>);
+    expect(screen.getByTestId('status').textContent).toBe('connected');
+  });
+
+  it('returns disconnected when there is no candidate', () => {
+    render(<WalletBootProvider><Probe /></WalletBootProvider>);
+    expect(screen.getByTestId('status').textContent).toBe('disconnected');
+  });
+
+  it('returns hydrating-storage while the store has not hydrated', () => {
+    walletSessionStore.setState({ hasHydrated: false, walletAddress: ADDR, connectionKind: 'browser' });
+    render(<WalletBootProvider><Probe /></WalletBootProvider>);
+    expect(screen.getByTestId('status').textContent).toBe('hydrating-storage');
+  });
+});

--- a/apps/app/src/wallet-boot/WalletBootProvider.web.test.tsx
+++ b/apps/app/src/wallet-boot/WalletBootProvider.web.test.tsx
@@ -107,6 +107,18 @@ describe('WalletBootProvider (web)', () => {
     expect(screen.getByTestId('status').textContent).toBe('disconnected');
   });
 
+  it('resolves to disconnected when connector connects with a different account', () => {
+    walletSessionStore.setState({ walletAddress: ADDR, connectionKind: 'browser' });
+    render(<WalletBootProvider><Probe /></WalletBootProvider>);
+    act(() => {
+      setConnector({ walletStatus: { status: 'connecting', connectorId: 'phantom' as never }, account: null });
+    });
+    act(() => {
+      setConnector({ walletStatus: { status: 'connected', session: {} as never }, account: 'AnotherWallet1111111111111111111111111111111' });
+    });
+    expect(screen.getByTestId('status').textContent).toBe('disconnected');
+  });
+
   it('returns connected for a persisted native session with no connector activity', () => {
     walletSessionStore.setState({ walletAddress: ADDR, connectionKind: 'native' });
     render(<WalletBootProvider><Probe /></WalletBootProvider>);

--- a/apps/app/src/wallet-boot/WalletBootProvider.web.test.tsx
+++ b/apps/app/src/wallet-boot/WalletBootProvider.web.test.tsx
@@ -54,6 +54,7 @@ beforeEach(() => {
   walletSessionStore.setState({
     walletAddress: null,
     connectionKind: null,
+    browserRestoreAddress: null,
     hasHydrated: true,
     lastConnectedAt: null,
     isConnecting: false,
@@ -69,13 +70,13 @@ afterEach(() => {
 
 describe('WalletBootProvider (web)', () => {
   it('starts in checking-browser-wallet for a persisted browser candidate', () => {
-    walletSessionStore.setState({ walletAddress: ADDR, connectionKind: 'browser' });
+    walletSessionStore.setState({ connectionKind: 'browser', browserRestoreAddress: ADDR });
     render(<WalletBootProvider><Probe /></WalletBootProvider>);
     expect(screen.getByTestId('status').textContent).toBe('checking-browser-wallet');
   });
 
   it('resolves to connected when connector reaches connected with matching account', () => {
-    walletSessionStore.setState({ walletAddress: ADDR, connectionKind: 'browser' });
+    walletSessionStore.setState({ connectionKind: 'browser', browserRestoreAddress: ADDR });
     render(<WalletBootProvider><Probe /></WalletBootProvider>);
     act(() => {
       setConnector({ walletStatus: { status: 'connecting', connectorId: 'phantom' as never }, account: null });
@@ -87,8 +88,19 @@ describe('WalletBootProvider (web)', () => {
     expect(screen.getByTestId('status').textContent).toBe('connected');
   });
 
+  it('sets walletAddress in store when boot resolves to connected for browser wallet', () => {
+    walletSessionStore.setState({ connectionKind: 'browser', browserRestoreAddress: ADDR, walletAddress: null });
+    render(<WalletBootProvider><Probe /></WalletBootProvider>);
+    expect(walletSessionStore.getState().walletAddress).toBeNull();
+    act(() => {
+      setConnector({ walletStatus: { status: 'connected', session: {} as never }, account: ADDR });
+    });
+    expect(screen.getByTestId('status').textContent).toBe('connected');
+    expect(walletSessionStore.getState().walletAddress).toBe(ADDR);
+  });
+
   it('resolves to disconnected when connector returns to disconnected after being inflight', () => {
-    walletSessionStore.setState({ walletAddress: ADDR, connectionKind: 'browser' });
+    walletSessionStore.setState({ connectionKind: 'browser', browserRestoreAddress: ADDR });
     render(<WalletBootProvider><Probe /></WalletBootProvider>);
     act(() => {
       setConnector({ walletStatus: { status: 'connecting', connectorId: 'phantom' as never }, account: null });
@@ -100,7 +112,7 @@ describe('WalletBootProvider (web)', () => {
   });
 
   it('resolves to disconnected after the 1500ms watchdog when the connector never moves', () => {
-    walletSessionStore.setState({ walletAddress: ADDR, connectionKind: 'browser' });
+    walletSessionStore.setState({ connectionKind: 'browser', browserRestoreAddress: ADDR });
     render(<WalletBootProvider><Probe /></WalletBootProvider>);
     expect(screen.getByTestId('status').textContent).toBe('checking-browser-wallet');
     act(() => { vi.advanceTimersByTime(1500); });
@@ -108,7 +120,7 @@ describe('WalletBootProvider (web)', () => {
   });
 
   it('resolves to disconnected when connector connects with a different account', () => {
-    walletSessionStore.setState({ walletAddress: ADDR, connectionKind: 'browser' });
+    walletSessionStore.setState({ connectionKind: 'browser', browserRestoreAddress: ADDR });
     render(<WalletBootProvider><Probe /></WalletBootProvider>);
     act(() => {
       setConnector({ walletStatus: { status: 'connecting', connectorId: 'phantom' as never }, account: null });
@@ -131,13 +143,13 @@ describe('WalletBootProvider (web)', () => {
   });
 
   it('returns hydrating-storage while the store has not hydrated', () => {
-    walletSessionStore.setState({ hasHydrated: false, walletAddress: ADDR, connectionKind: 'browser' });
+    walletSessionStore.setState({ hasHydrated: false, connectionKind: 'browser', browserRestoreAddress: ADDR });
     render(<WalletBootProvider><Probe /></WalletBootProvider>);
     expect(screen.getByTestId('status').textContent).toBe('hydrating-storage');
   });
 
   it('clears stale session from store when boot resolves to disconnected for browser wallet', () => {
-    walletSessionStore.setState({ walletAddress: ADDR, connectionKind: 'browser' });
+    walletSessionStore.setState({ connectionKind: 'browser', browserRestoreAddress: ADDR });
     render(<WalletBootProvider><Probe /></WalletBootProvider>);
     act(() => {
       setConnector({ walletStatus: { status: 'connecting', connectorId: 'phantom' as never }, account: null });
@@ -148,6 +160,7 @@ describe('WalletBootProvider (web)', () => {
     expect(screen.getByTestId('status').textContent).toBe('disconnected');
     expect(walletSessionStore.getState().walletAddress).toBeNull();
     expect(walletSessionStore.getState().connectionKind).toBeNull();
+    expect(walletSessionStore.getState().browserRestoreAddress).toBeNull();
   });
 
   it('does not clear native session when boot is disconnected (native owns its own lifecycle)', () => {

--- a/apps/app/src/wallet-boot/WalletBootProvider.web.test.tsx
+++ b/apps/app/src/wallet-boot/WalletBootProvider.web.test.tsx
@@ -135,4 +135,25 @@ describe('WalletBootProvider (web)', () => {
     render(<WalletBootProvider><Probe /></WalletBootProvider>);
     expect(screen.getByTestId('status').textContent).toBe('hydrating-storage');
   });
+
+  it('clears stale session from store when boot resolves to disconnected for browser wallet', () => {
+    walletSessionStore.setState({ walletAddress: ADDR, connectionKind: 'browser' });
+    render(<WalletBootProvider><Probe /></WalletBootProvider>);
+    act(() => {
+      setConnector({ walletStatus: { status: 'connecting', connectorId: 'phantom' as never }, account: null });
+    });
+    act(() => {
+      setConnector({ walletStatus: { status: 'disconnected' }, account: null });
+    });
+    expect(screen.getByTestId('status').textContent).toBe('disconnected');
+    expect(walletSessionStore.getState().walletAddress).toBeNull();
+    expect(walletSessionStore.getState().connectionKind).toBeNull();
+  });
+
+  it('does not clear native session when boot is disconnected (native owns its own lifecycle)', () => {
+    walletSessionStore.setState({ walletAddress: ADDR, connectionKind: 'native' });
+    render(<WalletBootProvider><Probe /></WalletBootProvider>);
+    expect(screen.getByTestId('status').textContent).toBe('connected');
+    expect(walletSessionStore.getState().walletAddress).toBe(ADDR);
+  });
 });

--- a/apps/app/src/wallet-boot/WalletBootProvider.web.tsx
+++ b/apps/app/src/wallet-boot/WalletBootProvider.web.tsx
@@ -12,9 +12,10 @@ export function WalletBootProvider({ children }: { children: ReactNode }) {
   const hasHydrated = useStore(walletSessionStore, (s) => s.hasHydrated);
   const connectionKind = useStore(walletSessionStore, (s) => s.connectionKind);
   const walletAddress = useStore(walletSessionStore, (s) => s.walletAddress);
+  const browserRestoreAddress = useStore(walletSessionStore, (s) => s.browserRestoreAddress);
 
   const hasBrowserRestoreCandidate =
-    connectionKind === 'browser' && walletAddress != null;
+    connectionKind === 'browser' && browserRestoreAddress != null;
 
   const hasSeenInflightRef = useRef(false);
   if (walletStatus.status === 'connecting' || walletStatus.status === 'connected') {
@@ -38,13 +39,23 @@ export function WalletBootProvider({ children }: { children: ReactNode }) {
         hasHydrated,
         connectionKind,
         walletAddress,
+        browserRestoreAddress,
         connectorStatus: walletStatus,
         connectorAccount: account,
         hasSeenConnectorInflight: hasSeenInflightRef.current,
         restoreTimedOut,
       }),
-    [hasHydrated, connectionKind, walletAddress, walletStatus, account, restoreTimedOut],
+    [hasHydrated, connectionKind, walletAddress, browserRestoreAddress, walletStatus, account, restoreTimedOut],
   );
+
+  useEffect(() => {
+    if (status === 'connected' && connectionKind === 'browser' && walletAddress == null) {
+      walletSessionStore.getState().markConnected({
+        walletAddress: browserRestoreAddress!,
+        connectionKind: 'browser',
+      });
+    }
+  }, [status, connectionKind, walletAddress, browserRestoreAddress]);
 
   useEffect(() => {
     if (status === 'disconnected' && connectionKind === 'browser') {

--- a/apps/app/src/wallet-boot/WalletBootProvider.web.tsx
+++ b/apps/app/src/wallet-boot/WalletBootProvider.web.tsx
@@ -46,6 +46,12 @@ export function WalletBootProvider({ children }: { children: ReactNode }) {
     [hasHydrated, connectionKind, walletAddress, walletStatus, account, restoreTimedOut],
   );
 
+  useEffect(() => {
+    if (status === 'disconnected' && connectionKind === 'browser') {
+      walletSessionStore.getState().disconnect();
+    }
+  }, [status, connectionKind]);
+
   return (
     <WalletBootContext.Provider value={status}>
       {children}

--- a/apps/app/src/wallet-boot/WalletBootProvider.web.tsx
+++ b/apps/app/src/wallet-boot/WalletBootProvider.web.tsx
@@ -1,0 +1,54 @@
+import { useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
+import { useStore } from 'zustand';
+import { useConnector } from '@solana/connector';
+import { walletSessionStore } from '../state/walletSessionStore';
+import { deriveWalletBootStatus } from '../state/deriveWalletBootStatus';
+import { WalletBootContext } from './walletBootContext';
+
+const WATCHDOG_MS = 1500;
+
+export function WalletBootProvider({ children }: { children: ReactNode }) {
+  const { walletStatus, account } = useConnector();
+  const hasHydrated = useStore(walletSessionStore, (s) => s.hasHydrated);
+  const connectionKind = useStore(walletSessionStore, (s) => s.connectionKind);
+  const walletAddress = useStore(walletSessionStore, (s) => s.walletAddress);
+
+  const hasBrowserRestoreCandidate =
+    connectionKind === 'browser' && walletAddress != null;
+
+  const hasSeenInflightRef = useRef(false);
+  if (walletStatus.status === 'connecting' || walletStatus.status === 'connected') {
+    hasSeenInflightRef.current = true;
+  }
+
+  const [restoreTimedOut, setRestoreTimedOut] = useState(false);
+
+  useEffect(() => {
+    if (!hasHydrated || !hasBrowserRestoreCandidate) {
+      setRestoreTimedOut(false);
+      return;
+    }
+    const t = setTimeout(() => setRestoreTimedOut(true), WATCHDOG_MS);
+    return () => clearTimeout(t);
+  }, [hasHydrated, hasBrowserRestoreCandidate]);
+
+  const status = useMemo(
+    () =>
+      deriveWalletBootStatus({
+        hasHydrated,
+        connectionKind,
+        walletAddress,
+        connectorStatus: walletStatus,
+        connectorAccount: account,
+        hasSeenConnectorInflight: hasSeenInflightRef.current,
+        restoreTimedOut,
+      }),
+    [hasHydrated, connectionKind, walletAddress, walletStatus, account, restoreTimedOut],
+  );
+
+  return (
+    <WalletBootContext.Provider value={status}>
+      {children}
+    </WalletBootContext.Provider>
+  );
+}

--- a/apps/app/src/wallet-boot/buildReturnToPath.test.ts
+++ b/apps/app/src/wallet-boot/buildReturnToPath.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+import { buildReturnToPath } from './buildReturnToPath';
+
+describe('buildReturnToPath', () => {
+  it('returns plain pathname when there is no search', () => {
+    expect(buildReturnToPath('/positions/abc', {})).toBe('/positions/abc');
+  });
+
+  it('joins pathname and querystring', () => {
+    expect(buildReturnToPath('/preview/abc', { triggerId: 'xyz' }))
+      .toBe('/preview/abc?triggerId=xyz');
+  });
+
+  it('joins multiple search params in declaration order', () => {
+    expect(buildReturnToPath('/signing/abc', { previewId: 'p', triggerId: 't' }))
+      .toBe('/signing/abc?previewId=p&triggerId=t');
+  });
+
+  it('strips an existing returnTo param to prevent recursion', () => {
+    expect(buildReturnToPath('/preview/abc', { triggerId: 'xyz', returnTo: '/whatever' }))
+      .toBe('/preview/abc?triggerId=xyz');
+  });
+
+  it('skips array-shaped params (treats only string params)', () => {
+    expect(buildReturnToPath('/x', { tag: ['a', 'b'], q: 'k' }))
+      .toBe('/x?q=k');
+  });
+
+  it('skips undefined values', () => {
+    expect(buildReturnToPath('/x', { q: 'k', empty: undefined }))
+      .toBe('/x?q=k');
+  });
+
+  it('returns plain pathname when only param is the stripped returnTo', () => {
+    expect(buildReturnToPath('/x', { returnTo: '/y' })).toBe('/x');
+  });
+
+  it('URL-encodes search values', () => {
+    expect(buildReturnToPath('/x', { q: 'a b/c' })).toBe('/x?q=a%20b%2Fc');
+  });
+});

--- a/apps/app/src/wallet-boot/buildReturnToPath.test.ts
+++ b/apps/app/src/wallet-boot/buildReturnToPath.test.ts
@@ -38,4 +38,24 @@ describe('buildReturnToPath', () => {
   it('URL-encodes search values', () => {
     expect(buildReturnToPath('/x', { q: 'a b/c' })).toBe('/x?q=a%20b%2Fc');
   });
+
+  it('excludes path param keys when provided', () => {
+    expect(buildReturnToPath('/signing/pending', { attemptId: 'pending', tab: 'details' }, new Set(['attemptId'])))
+      .toBe('/signing/pending?tab=details');
+  });
+
+  it('excludes multiple path param keys', () => {
+    expect(buildReturnToPath('/preview/xyz', { triggerId: 'xyz', attemptId: 'xyz' }, new Set(['triggerId', 'attemptId'])))
+      .toBe('/preview/xyz');
+  });
+
+  it('does not exclude a key if it is not in the pathParamKeys set', () => {
+    expect(buildReturnToPath('/signing/real-id', { attemptId: 'different-id', tab: 'details' }, new Set(['attemptId'])))
+      .toBe('/signing/real-id?tab=details');
+  });
+
+  it('returns plain pathname when all params are excluded as path params', () => {
+    expect(buildReturnToPath('/position/abc', { id: 'abc' }, new Set(['id'])))
+      .toBe('/position/abc');
+  });
 });

--- a/apps/app/src/wallet-boot/buildReturnToPath.ts
+++ b/apps/app/src/wallet-boot/buildReturnToPath.ts
@@ -1,0 +1,11 @@
+export type SearchParamRecord = Record<string, string | string[] | undefined>;
+
+export function buildReturnToPath(pathname: string, search: SearchParamRecord): string {
+  const parts: string[] = [];
+  for (const [key, value] of Object.entries(search)) {
+    if (key === 'returnTo') continue;
+    if (typeof value !== 'string') continue;
+    parts.push(`${encodeURIComponent(key)}=${encodeURIComponent(value)}`);
+  }
+  return parts.length === 0 ? pathname : `${pathname}?${parts.join('&')}`;
+}

--- a/apps/app/src/wallet-boot/buildReturnToPath.ts
+++ b/apps/app/src/wallet-boot/buildReturnToPath.ts
@@ -1,10 +1,16 @@
 export type SearchParamRecord = Record<string, string | string[] | undefined>;
 
-export function buildReturnToPath(pathname: string, search: SearchParamRecord): string {
+export function buildReturnToPath(
+  pathname: string,
+  search: SearchParamRecord,
+  pathParamKeys?: Set<string>,
+): string {
+  const excluded = pathParamKeys ?? new Set<string>();
   const parts: string[] = [];
   for (const [key, value] of Object.entries(search)) {
     if (key === 'returnTo') continue;
     if (typeof value !== 'string') continue;
+    if (excluded.has(key)) continue;
     parts.push(`${encodeURIComponent(key)}=${encodeURIComponent(value)}`);
   }
   return parts.length === 0 ? pathname : `${pathname}?${parts.join('&')}`;

--- a/apps/app/src/wallet-boot/parseReturnTo.test.ts
+++ b/apps/app/src/wallet-boot/parseReturnTo.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+import { parseReturnTo, RETURN_TO_FALLBACK } from './parseReturnTo';
+
+describe('parseReturnTo', () => {
+  it('returns fallback when input is undefined', () => {
+    expect(parseReturnTo(undefined)).toBe(RETURN_TO_FALLBACK);
+  });
+
+  it('returns fallback when input is an array (expo-router shape for repeated keys)', () => {
+    expect(parseReturnTo(['/positions', '/alerts'])).toBe(RETURN_TO_FALLBACK);
+  });
+
+  it('returns fallback for empty string', () => {
+    expect(parseReturnTo('')).toBe(RETURN_TO_FALLBACK);
+  });
+
+  it('returns fallback for input above 512 chars', () => {
+    const long = '/' + 'a'.repeat(600);
+    expect(parseReturnTo(long)).toBe(RETURN_TO_FALLBACK);
+  });
+
+  it('returns fallback when input cannot be decoded', () => {
+    expect(parseReturnTo('%E0%A4%A')).toBe(RETURN_TO_FALLBACK);
+  });
+
+  it('returns fallback for an absolute URL', () => {
+    expect(parseReturnTo(encodeURIComponent('https://evil.com/x'))).toBe(RETURN_TO_FALLBACK);
+  });
+
+  it('returns fallback for a protocol-relative URL', () => {
+    expect(parseReturnTo(encodeURIComponent('//evil.com/x'))).toBe(RETURN_TO_FALLBACK);
+  });
+
+  it('returns fallback for /connect (loop prevention)', () => {
+    expect(parseReturnTo(encodeURIComponent('/connect'))).toBe(RETURN_TO_FALLBACK);
+  });
+
+  it('returns fallback for /connect with query string', () => {
+    expect(parseReturnTo(encodeURIComponent('/connect?returnTo=/x'))).toBe(RETURN_TO_FALLBACK);
+  });
+
+  it('decodes and returns a valid relative path', () => {
+    expect(parseReturnTo(encodeURIComponent('/positions/abc'))).toBe('/positions/abc');
+  });
+
+  it('decodes and returns a valid path with query string', () => {
+    expect(parseReturnTo(encodeURIComponent('/preview/abc?triggerId=xyz')))
+      .toBe('/preview/abc?triggerId=xyz');
+  });
+
+  it('returns fallback for a path that does not start with /', () => {
+    expect(parseReturnTo(encodeURIComponent('positions/abc'))).toBe(RETURN_TO_FALLBACK);
+  });
+});

--- a/apps/app/src/wallet-boot/parseReturnTo.ts
+++ b/apps/app/src/wallet-boot/parseReturnTo.ts
@@ -1,0 +1,22 @@
+export const RETURN_TO_FALLBACK = '/(tabs)/positions';
+const MAX_LENGTH = 512;
+
+export function parseReturnTo(raw: string | string[] | undefined): string {
+  if (typeof raw !== 'string') return RETURN_TO_FALLBACK;
+  if (raw.length === 0 || raw.length > MAX_LENGTH) return RETURN_TO_FALLBACK;
+
+  let decoded: string;
+  try {
+    decoded = decodeURIComponent(raw);
+  } catch {
+    return RETURN_TO_FALLBACK;
+  }
+
+  if (!decoded.startsWith('/')) return RETURN_TO_FALLBACK;
+  if (decoded.startsWith('//')) return RETURN_TO_FALLBACK;
+  if (decoded === '/connect' || decoded.startsWith('/connect?') || decoded.startsWith('/connect/')) {
+    return RETURN_TO_FALLBACK;
+  }
+
+  return decoded;
+}

--- a/apps/app/src/wallet-boot/walletBootContext.ts
+++ b/apps/app/src/wallet-boot/walletBootContext.ts
@@ -1,0 +1,8 @@
+import { createContext, useContext } from 'react';
+import type { WalletBootStatus } from '../state/deriveWalletBootStatus';
+
+export const WalletBootContext = createContext<WalletBootStatus>('hydrating-storage');
+
+export function useWalletBootStatus(): WalletBootStatus {
+  return useContext(WalletBootContext);
+}


### PR DESCRIPTION
## Summary

Stops browser-wallet hard-navigation reloads in Phantom/Solflare mobile WebViews from falsely redirecting to `/connect`. Introduces a centralized `WalletBootStatus` derivation that gates protected routes while `@solana/connector`'s `autoConnect` settles, and preserves the user's intended route across reconnect via a `returnTo` query param.

Closes #38.

## Problem

Phantom and Solflare mobile in-app WebViews require `window.location` hard navigation. The current `walletSessionStore` strips browser-wallet identity (`walletAddress`, `connectionKind`) from persisted state on every reload, causing protected routes to redirect to `/connect` even when `autoConnect` would successfully restore the session moments later.

## Approach

A pure `deriveWalletBootStatus` function combines store hydration state, persisted browser-wallet candidate, `@solana/connector` status, an observed-inflight flag, and a 1500ms watchdog into four states: `hydrating-storage`, `checking-browser-wallet`, `connected`, `disconnected`. A `WalletBootProvider` mounted inside `BrowserWalletProvider` owns the derivation and publishes status through React context. Protected routes wrap their body in `<RequireWallet>`, which shows a `BootScreen` during boot, redirects to `/connect?returnTo=…` when truly disconnected, and renders children when connected.

Key decisions:
- **`autoConnect` is the single restore authority** — no second wallet restore mechanism
- **Watchdog is a backstop only** — if the connector never settles within 1500ms, the boot status resolves to `disconnected`
- **`BrowserWalletSessionSync` no longer eager-disconnects** — the boot controller owns the `checking-browser-wallet → disconnected` transition
- **Native bundle gets a `WalletBootProvider` shell** — feeds constant inputs into derive so native sessions resolve immediately to `connected`

## Files changed

| Category | Files |
|----------|-------|
| Root-cause fix | `walletSessionStore.ts` — persist browser identity in `partialize`; add `lastConnectedAt` |
| Pure derivation | `deriveWalletBootStatus.ts` + 12 tests |
| returnTo utilities | `parseReturnTo.ts` (12 tests), `buildReturnToPath.ts` (8 tests) |
| UI components | `BootScreen.tsx`, `walletBootContext.ts` |
| Providers | `WalletBootProvider.web.tsx` (7 tests), `WalletBootProvider.native.tsx`, `WalletBootProvider.tsx` |
| Route wrapper | `RequireWallet.tsx` (5 tests) |
| Provider wiring | `BrowserWalletProvider.web.tsx` — mount provider, remove eager-disconnect; `BrowserWalletProvider.native.tsx` — mount native shell |
| Connect screen | `connect.tsx` — parse and route to `returnTo` after connect |
| Protected routes | `position/[id].tsx`, `preview/[triggerId].tsx`, `signing/[attemptId].tsx`, `execution/[attemptId].tsx` — wrap in `<RequireWallet>` |

## Verification

- `pnpm typecheck` — pass
- `pnpm lint` — 0 errors
- `pnpm boundaries` — no violations
- `pnpm test` — 172/172 pass
- `pnpm build` — pass

### Manual verification

#### Phantom mobile browser (iOS or Android)
- [ ] Connect from /connect; hard-nav to /positions; reload — stays on /positions
- [ ] Direct-open /position/<id> with prior session — boot screen flashes, lands on position
- [ ] Direct-open /preview/<triggerId> with prior session — boot screen, lands on preview
- [ ] Direct-open /signing/<attemptId> with prior session — boot screen, lands on signing
- [ ] Direct-open /preview/<triggerId> while truly disconnected — redirects to /connect?returnTo=...; reconnect returns to original /preview path

#### Desktop Chrome with Phantom extension
- [ ] Soft-nav still works (no hard reload between Expo Router routes)
- [ ] Refresh on a protected route restores via boot screen, no false redirect
- [ ] Truly disconnected user lands on /connect when opening a protected route directly

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Claude_Code-glm-5.1-D97757?logo=claude&logoColor=white)