### PR TITLE
feat(ui): extract connect screen from app shell to packages/ui

### DIFF
--- a/apps/app/app/connect.tsx
+++ b/apps/app/app/connect.tsx
@@ -97,14 +97,16 @@ export default function ConnectRoute() {
     void platformCapabilityAdapter
       .getCapabilities()
       .then((caps) => { if (active) setPlatformCapabilities(caps); })
-      .catch(() => {
-        if (active) setPlatformCapabilities({
+      .catch((error) => {
+        if (!active) return;
+        setPlatformCapabilities({
           nativePushAvailable: false,
           browserNotificationAvailable: false,
           nativeWalletAvailable: false,
           browserWalletAvailable: false,
           isMobileWeb: false,
         });
+        handleConnectionError(error);
       });
     return () => { active = false; };
   }, [setPlatformCapabilities]);

--- a/apps/app/app/connect.tsx
+++ b/apps/app/app/connect.tsx
@@ -134,7 +134,7 @@ export default function ConnectRoute() {
       void walletPlatform.connectNativeWallet()
         .then((address) => {
           markConnected({ walletAddress: address, connectionKind: 'native' });
-          void enrollWalletForMonitoring(address);
+          void enrollWalletForMonitoring(address).catch(() => {});
           navigateRoute({ router, path: returnTo, method: 'replace' });
         })
         .catch(handleConnectionError);
@@ -144,7 +144,7 @@ export default function ConnectRoute() {
       void browserConnect.connect(walletId)
         .then(({ address }) => {
           markConnected({ walletAddress: address, connectionKind: 'browser' });
-          void enrollWalletForMonitoring(address);
+          void enrollWalletForMonitoring(address).catch(() => {});
           navigateRoute({ router, path: returnTo, method: 'replace' });
         })
         .catch(handleConnectionError);
@@ -154,7 +154,7 @@ export default function ConnectRoute() {
       void browserConnect.connect()
         .then(({ address }) => {
           markConnected({ walletAddress: address, connectionKind: 'browser' });
-          void enrollWalletForMonitoring(address);
+          void enrollWalletForMonitoring(address).catch(() => {});
           navigateRoute({ router, path: returnTo, method: 'replace' });
         })
         .catch(handleConnectionError);

--- a/apps/app/app/connect.tsx
+++ b/apps/app/app/connect.tsx
@@ -1,9 +1,13 @@
 import { useEffect, useMemo, useState } from 'react';
-import { View, Text, TouchableOpacity, ScrollView, Linking, Platform, ActivityIndicator, Image } from 'react-native';
+import { Platform, Linking } from 'react-native';
 import { useRouter, useLocalSearchParams } from 'expo-router';
 import { useStore } from 'zustand';
 import type { PlatformCapabilityState } from '@clmm/application/public';
-import type { BrowserWalletOption } from '../src/platform/browserWallet/browserWalletTypes';
+import {
+  WalletConnectScreen,
+  buildWalletConnectViewModel,
+} from '@clmm/ui';
+import type { FallbackState, WalletDiscoveryState, DiscoveredWallet, WalletConnectActions } from '@clmm/ui';
 import { platformCapabilityAdapter, walletPlatform } from '../src/composition/index';
 import { useBrowserWalletConnect } from '../src/platform/browserWallet/index';
 import {
@@ -16,14 +20,10 @@ import { mapWalletErrorToOutcome } from '../src/platform/walletConnection';
 import { navigateRoute } from '../src/platform/webNavigation';
 import { parseReturnTo } from '../src/wallet-boot/parseReturnTo';
 import { walletSessionStore } from '../src/state/walletSessionStore';
-import { getConnectionOutcomeDisplay } from '@clmm/ui';
 import { enrollWalletForMonitoring } from '../src/api/wallets';
 
 const NO_WALLET_MESSAGE = 'No supported browser wallet detected on this device';
 const WALLET_DISCOVERY_TIMEOUT_MS = 2000;
-
-type FallbackState = 'none' | 'wallet-fallback' | 'desktop-no-wallet' | 'social-webview';
-type WalletDiscoveryState = 'discovering' | 'ready' | 'timed-out';
 
 function detectFallbackState(
   platformCapabilities: PlatformCapabilityState | null,
@@ -51,26 +51,18 @@ function detectFallbackState(
   return 'none';
 }
 
-const FALLBACK_PLATFORM_CAPABILITIES: PlatformCapabilityState = {
-  nativePushAvailable: false,
-  browserNotificationAvailable: false,
-  nativeWalletAvailable: false,
-  browserWalletAvailable: false,
-  isMobileWeb: false,
-};
-
 export default function ConnectRoute() {
   const router = useRouter();
   const params = useLocalSearchParams<{ returnTo?: string | string[] }>();
   const returnTo = useMemo(() => parseReturnTo(params.returnTo), [params.returnTo]);
-  const platformCapabilities = useStore(walletSessionStore, (state) => state.platformCapabilities);
-  const connectionOutcome = useStore(walletSessionStore, (state) => state.connectionOutcome);
-  const isConnecting = useStore(walletSessionStore, (state) => state.isConnecting);
-  const setPlatformCapabilities = useStore(walletSessionStore, (state) => state.setPlatformCapabilities);
-  const beginConnection = useStore(walletSessionStore, (state) => state.beginConnection);
-  const markConnected = useStore(walletSessionStore, (state) => state.markConnected);
-  const markOutcome = useStore(walletSessionStore, (state) => state.markOutcome);
-  const clearOutcome = useStore(walletSessionStore, (state) => state.clearOutcome);
+  const platformCapabilities = useStore(walletSessionStore, (s) => s.platformCapabilities);
+  const connectionOutcome = useStore(walletSessionStore, (s) => s.connectionOutcome);
+  const isConnecting = useStore(walletSessionStore, (s) => s.isConnecting);
+  const setPlatformCapabilities = useStore(walletSessionStore, (s) => s.setPlatformCapabilities);
+  const beginConnection = useStore(walletSessionStore, (s) => s.beginConnection);
+  const markConnected = useStore(walletSessionStore, (s) => s.markConnected);
+  const markOutcome = useStore(walletSessionStore, (s) => s.markOutcome);
+  const clearOutcome = useStore(walletSessionStore, (s) => s.clearOutcome);
 
   const [socialEscapeAttempted, setSocialEscapeAttempted] = useState(false);
   const [discoveryTimedOut, setDiscoveryTimedOut] = useState(false);
@@ -78,7 +70,7 @@ export default function ConnectRoute() {
   const browserConnect = useBrowserWalletConnect();
   const walletCount = browserConnect.wallets.length;
 
-  const discoveryState: WalletDiscoveryState = useMemo(() => {
+  const discovery: WalletDiscoveryState = useMemo(() => {
     if (walletCount > 0) return 'ready';
     if (discoveryTimedOut) return 'timed-out';
     return 'discovering';
@@ -90,10 +82,32 @@ export default function ConnectRoute() {
     return () => clearTimeout(timer);
   }, [walletCount, discoveryTimedOut]);
 
-  const fallbackState = useMemo(
+  const fallback = useMemo(
     () => detectFallbackState(platformCapabilities, browserConnect.error),
     [platformCapabilities, browserConnect.error],
   );
+
+  const discoveredWallets: DiscoveredWallet[] = useMemo(
+    () => browserConnect.wallets.map((w) => ({ id: w.id, name: w.name, icon: w.icon })),
+    [browserConnect.wallets],
+  );
+
+  useEffect(() => {
+    let active = true;
+    void platformCapabilityAdapter
+      .getCapabilities()
+      .then((caps) => { if (active) setPlatformCapabilities(caps); })
+      .catch(() => {
+        if (active) setPlatformCapabilities({
+          nativePushAvailable: false,
+          browserNotificationAvailable: false,
+          nativeWalletAvailable: false,
+          browserWalletAvailable: false,
+          isMobileWeb: false,
+        });
+      });
+    return () => { active = false; };
+  }, [setPlatformCapabilities]);
 
   function handleConnectionError(error: unknown) {
     const outcome = mapWalletErrorToOutcome(error);
@@ -101,422 +115,73 @@ export default function ConnectRoute() {
       markOutcome({ kind: 'failed', reason: 'Unexpected connected error outcome' });
       return;
     }
-
     markOutcome(outcome);
   }
 
-  useEffect(() => {
-    let active = true;
+  const vm = buildWalletConnectViewModel({
+    platformCapabilities,
+    discovery,
+    discoveredWallets,
+    fallback,
+    socialEscapeAttempted,
+    isConnecting,
+    connectionOutcome,
+  });
 
-    void platformCapabilityAdapter
-      .getCapabilities()
-      .then((capabilities) => {
-        if (!active) {
-          return;
-        }
+  const actions: WalletConnectActions = useMemo(() => ({
+    onSelectNative: () => {
+      beginConnection();
+      void walletPlatform.connectNativeWallet()
+        .then((address) => {
+          markConnected({ walletAddress: address, connectionKind: 'native' });
+          void enrollWalletForMonitoring(address);
+          navigateRoute({ router, path: returnTo, method: 'replace' });
+        })
+        .catch(handleConnectionError);
+    },
+    onSelectDiscoveredWallet: (walletId: string) => {
+      beginConnection();
+      void browserConnect.connect(walletId)
+        .then(({ address }) => {
+          markConnected({ walletAddress: address, connectionKind: 'browser' });
+          void enrollWalletForMonitoring(address);
+          navigateRoute({ router, path: returnTo, method: 'replace' });
+        })
+        .catch(handleConnectionError);
+    },
+    onConnectDefaultBrowser: () => {
+      beginConnection();
+      void browserConnect.connect()
+        .then(({ address }) => {
+          markConnected({ walletAddress: address, connectionKind: 'browser' });
+          void enrollWalletForMonitoring(address);
+          navigateRoute({ router, path: returnTo, method: 'replace' });
+        })
+        .catch(handleConnectionError);
+    },
+    onOpenPhantom: () => {
+      if (typeof window !== 'undefined') {
+        const url = buildPhantomBrowseUrl(window.location.href);
+        void Linking.openURL(url);
+      }
+    },
+    onOpenSolflare: () => {
+      if (typeof window !== 'undefined') {
+        const url = buildSolflareBrowseUrl(window.location.href);
+        void Linking.openURL(url);
+      }
+    },
+    onOpenInBrowser: () => {
+      setSocialEscapeAttempted(true);
+      if (typeof window !== 'undefined') {
+        openInExternalBrowser(window.location.href);
+      }
+    },
+    onGoBack: () => {
+      clearOutcome();
+      router.back();
+    },
+  }), [router, returnTo, browserConnect, beginConnection, markConnected, markOutcome, clearOutcome, platformCapabilities, discovery, discoveredWallets, fallback, socialEscapeAttempted, isConnecting, connectionOutcome]);
 
-        setPlatformCapabilities(capabilities);
-      })
-      .catch((error) => {
-        if (!active) {
-          return;
-        }
-
-        setPlatformCapabilities(FALLBACK_PLATFORM_CAPABILITIES);
-        handleConnectionError(error);
-      });
-
-    return () => {
-      active = false;
-    };
-  }, [markOutcome, setPlatformCapabilities]);
-
-  async function handleSelectBrowserWallet(walletId: string) {
-    beginConnection();
-
-    try {
-      const { address } = await browserConnect.connect(walletId);
-      markConnected({ walletAddress: address, connectionKind: 'browser' });
-      enrollWalletForMonitoring(address).catch((err) => {
-        console.warn('Wallet enrollment failed:', err);
-      });
-      navigateRoute({ router, path: returnTo, method: 'replace' });
-    } catch (error) {
-      handleConnectionError(error);
-    }
-  }
-
-  async function handleConnectDefaultBrowser() {
-    beginConnection();
-
-    try {
-      const { address } = await browserConnect.connect();
-      markConnected({ walletAddress: address, connectionKind: 'browser' });
-      enrollWalletForMonitoring(address).catch((err) => {
-        console.warn('Wallet enrollment failed:', err);
-      });
-      navigateRoute({ router, path: returnTo, method: 'replace' });
-    } catch (error) {
-      handleConnectionError(error);
-    }
-  }
-
-  async function handleConnectNative() {
-    beginConnection();
-
-    try {
-      const walletAddress = await walletPlatform.connectNativeWallet();
-      markConnected({ walletAddress, connectionKind: 'native' });
-      enrollWalletForMonitoring(walletAddress).catch((err) => {
-        console.warn('Wallet enrollment failed:', err);
-      });
-      navigateRoute({ router, path: returnTo, method: 'replace' });
-    } catch (error) {
-      handleConnectionError(error);
-    }
-  }
-
-  function handleOpenPhantom() {
-    const url = buildPhantomBrowseUrl(window.location.href);
-    void Linking.openURL(url);
-  }
-
-  function handleOpenSolflare() {
-    const url = buildSolflareBrowseUrl(window.location.href);
-    void Linking.openURL(url);
-  }
-
-  function handleOpenInBrowser() {
-    setSocialEscapeAttempted(true);
-    openInExternalBrowser(window.location.href);
-  }
-
-  function renderWalletPicker(wallets: BrowserWalletOption[]) {
-    return wallets.map((wallet) => (
-      <TouchableOpacity
-        key={wallet.id}
-        onPress={() => void handleSelectBrowserWallet(wallet.id)}
-        disabled={isConnecting}
-        style={{
-          padding: 16,
-          backgroundColor: '#18181b',
-          borderRadius: 8,
-          marginBottom: 12,
-          borderWidth: 1,
-          borderColor: '#3f3f46',
-          flexDirection: 'row',
-          alignItems: 'center',
-          gap: 12,
-        }}
-      >
-        {wallet.icon ? (
-          <Image source={{ uri: wallet.icon }} style={{ width: 24, height: 24 }} />
-        ) : null}
-        <View style={{ flex: 1 }}>
-          <Text style={{ color: '#f4f4f5', fontSize: 16, fontWeight: '600' }}>
-            {wallet.name}
-          </Text>
-        </View>
-      </TouchableOpacity>
-    ));
-  }
-
-  function renderBrowserWalletSection() {
-    if (Platform.OS !== 'web') return null;
-
-    switch (discoveryState) {
-      case 'discovering':
-        return (
-          <View style={{ padding: 16, backgroundColor: '#18181b', borderRadius: 8, marginBottom: 12, borderWidth: 1, borderColor: '#3f3f46', flexDirection: 'row', alignItems: 'center', gap: 12 }}>
-            <ActivityIndicator size="small" color="#a1a1aa" />
-            <Text style={{ color: '#a1a1aa', fontSize: 14 }}>
-              Detecting browser wallets...
-            </Text>
-          </View>
-        );
-      case 'ready':
-        if (walletCount === 1) {
-          const wallet = browserConnect.wallets[0]!;
-          return (
-            <TouchableOpacity
-              onPress={() => void handleSelectBrowserWallet(wallet.id)}
-              disabled={isConnecting}
-              style={{
-                padding: 16,
-                backgroundColor: '#18181b',
-                borderRadius: 8,
-                marginBottom: 12,
-                borderWidth: 1,
-                borderColor: '#3f3f46',
-                flexDirection: 'row',
-                alignItems: 'center',
-                gap: 12,
-              }}
-            >
-              {wallet.icon ? (
-                <Image source={{ uri: wallet.icon }} style={{ width: 24, height: 24 }} />
-              ) : null}
-              <View style={{ flex: 1 }}>
-                <Text style={{ color: '#f4f4f5', fontSize: 16, fontWeight: '600' }}>
-                  {wallet.name}
-                </Text>
-              </View>
-            </TouchableOpacity>
-          );
-        }
-        return renderWalletPicker(browserConnect.wallets);
-      case 'timed-out':
-        return (
-          <TouchableOpacity
-            onPress={() => void handleConnectDefaultBrowser()}
-            disabled={isConnecting}
-            style={{
-              padding: 16,
-              backgroundColor: '#18181b',
-              borderRadius: 8,
-              marginBottom: 12,
-              borderWidth: 1,
-              borderColor: '#3f3f46',
-            }}
-          >
-            <Text style={{ color: '#f4f4f5', fontSize: 16, fontWeight: '600' }}>
-              Connect Browser Wallet
-            </Text>
-            <Text style={{ color: '#a1a1aa', fontSize: 13, marginTop: 4 }}>
-              Sign transactions with your browser wallet extension.
-            </Text>
-          </TouchableOpacity>
-        );
-    }
-  }
-
-  if (!platformCapabilities) {
-    return (
-      <View style={{ flex: 1, backgroundColor: '#0a0a0a', justifyContent: 'center', alignItems: 'center' }}>
-        <Text style={{ color: '#a1a1aa' }}>Loading...</Text>
-      </View>
-    );
-  }
-
-  return (
-    <ScrollView style={{ flex: 1, backgroundColor: '#0a0a0a' }} contentContainerStyle={{ padding: 16 }}>
-      <Text style={{ color: '#f4f4f5', fontSize: 24, fontWeight: '700' }}>
-        Connect Wallet
-      </Text>
-      <Text style={{ color: '#a1a1aa', fontSize: 16, marginTop: 8 }}>
-        Choose a wallet to connect. Only supported wallet options for this device are shown.
-      </Text>
-
-      {fallbackState === 'social-webview' ? (
-        <View style={{ marginTop: 24 }}>
-          <View style={{
-            padding: 12,
-            backgroundColor: '#422006',
-            borderRadius: 8,
-            borderWidth: 1,
-            borderColor: '#f59e0b',
-            marginBottom: 16,
-          }}>
-            <Text style={{ color: '#f59e0b', fontSize: 14, fontWeight: '600' }}>
-              Social app browsers block wallet extensions.
-            </Text>
-            <Text style={{ color: '#a1a1aa', fontSize: 13, marginTop: 4 }}>
-              Open this page in Safari or Chrome to connect your wallet, or use Phantom / Solflare directly below.
-            </Text>
-          </View>
-
-          <TouchableOpacity
-            onPress={() => void handleOpenInBrowser()}
-            disabled={socialEscapeAttempted}
-            style={{
-              padding: 16,
-              backgroundColor: socialEscapeAttempted ? '#27272a' : '#18181b',
-              borderRadius: 8,
-              marginBottom: 12,
-              borderWidth: 1,
-              borderColor: socialEscapeAttempted ? '#3f3f46' : '#3b82f6',
-            }}
-          >
-            <Text style={{
-              color: socialEscapeAttempted ? '#71717a' : '#3b82f6',
-              fontSize: 16,
-              fontWeight: '600',
-            }}>
-              Open in Browser
-            </Text>
-            <Text style={{ color: '#a1a1aa', fontSize: 13, marginTop: 4 }}>
-              Opens this page in your default browser where wallet extensions work.
-            </Text>
-          </TouchableOpacity>
-
-          <View style={{ marginTop: 8 }}>
-            <Text style={{ color: '#71717a', fontSize: 13, marginBottom: 8 }}>
-              Or open in a wallet browser:
-            </Text>
-            <TouchableOpacity
-              onPress={() => handleOpenPhantom()}
-              style={{
-                padding: 12,
-                backgroundColor: '#18181b',
-                borderRadius: 8,
-                marginBottom: 8,
-                borderWidth: 1,
-                borderColor: '#3f3f46',
-              }}
-            >
-              <Text style={{ color: '#ab9ff2', fontSize: 15, fontWeight: '600' }}>Open in Phantom</Text>
-            </TouchableOpacity>
-            <TouchableOpacity
-              onPress={() => handleOpenSolflare()}
-              style={{
-                padding: 12,
-                backgroundColor: '#18181b',
-                borderRadius: 8,
-                borderWidth: 1,
-                borderColor: '#3f3f46',
-              }}
-            >
-              <Text style={{ color: '#fc8748', fontSize: 15, fontWeight: '600' }}>Open in Solflare</Text>
-            </TouchableOpacity>
-          </View>
-        </View>
-      ) : (
-        <>
-          {(platformCapabilities.nativeWalletAvailable || platformCapabilities.browserWalletAvailable) && (
-            <View style={{ marginTop: 24 }}>
-              {platformCapabilities.nativeWalletAvailable && (
-                <TouchableOpacity
-                  onPress={() => void handleConnectNative()}
-                  disabled={isConnecting}
-                  style={{
-                    padding: 16,
-                    backgroundColor: '#18181b',
-                    borderRadius: 8,
-                    marginBottom: 12,
-                    borderWidth: 1,
-                    borderColor: '#3f3f46',
-                  }}
-                >
-                  <Text style={{ color: '#f4f4f5', fontSize: 16, fontWeight: '600' }}>
-                    Connect Mobile Wallet
-                  </Text>
-                  <Text style={{ color: '#a1a1aa', fontSize: 13, marginTop: 4 }}>
-                    Sign transactions with your mobile wallet app.
-                  </Text>
-                </TouchableOpacity>
-              )}
-              {renderBrowserWalletSection()}
-            </View>
-          )}
-
-          {fallbackState === 'wallet-fallback' && (
-            <View style={{ marginTop: 16 }}>
-              {!platformCapabilities.nativeWalletAvailable && !platformCapabilities.browserWalletAvailable && (
-                <View style={{
-                  padding: 12,
-                  backgroundColor: '#422006',
-                  borderRadius: 8,
-                  borderWidth: 1,
-                  borderColor: '#f59e0b',
-                  marginBottom: 12,
-                }}>
-                  <Text style={{ color: '#f59e0b', fontSize: 14, fontWeight: '600' }}>
-                    No wallet extension detected in this browser.
-                  </Text>
-                  <Text style={{ color: '#a1a1aa', fontSize: 13, marginTop: 4 }}>
-                    You can open this page directly in a wallet browser, or switch to a desktop browser with an installed extension.
-                  </Text>
-                </View>
-              )}
-              <Text style={{ color: '#71717a', fontSize: 13, marginBottom: 8 }}>
-                Open in a wallet browser:
-              </Text>
-              <TouchableOpacity
-                onPress={() => handleOpenPhantom()}
-                style={{
-                  padding: 12,
-                  backgroundColor: '#18181b',
-                  borderRadius: 8,
-                  marginBottom: 8,
-                  borderWidth: 1,
-                  borderColor: '#3f3f46',
-                }}
-              >
-                <Text style={{ color: '#ab9ff2', fontSize: 15, fontWeight: '600' }}>Open in Phantom</Text>
-              </TouchableOpacity>
-              <TouchableOpacity
-                onPress={() => handleOpenSolflare()}
-                style={{
-                  padding: 12,
-                  backgroundColor: '#18181b',
-                  borderRadius: 8,
-                  borderWidth: 1,
-                  borderColor: '#3f3f46',
-                }}
-              >
-                <Text style={{ color: '#fc8748', fontSize: 15, fontWeight: '600' }}>Open in Solflare</Text>
-              </TouchableOpacity>
-            </View>
-          )}
-
-          {fallbackState === 'desktop-no-wallet' && (
-            <View style={{ marginTop: 24 }}>
-              <View style={{
-                padding: 12,
-                backgroundColor: '#422006',
-                borderRadius: 8,
-                borderWidth: 1,
-                borderColor: '#f59e0b',
-                marginBottom: 12,
-              }}>
-                <Text style={{ color: '#f59e0b', fontSize: 14, fontWeight: '600' }}>
-                  No wallet extension detected.
-                </Text>
-                <Text style={{ color: '#a1a1aa', fontSize: 13, marginTop: 4 }}>
-                  Install a Solana wallet extension like Phantom or Solflare, then refresh this page.
-                </Text>
-              </View>
-            </View>
-          )}
-        </>
-      )}
-
-      {isConnecting && (
-        <View style={{ marginTop: 24 }}>
-          <Text style={{ color: '#a1a1aa', fontSize: 14 }}>Connecting...</Text>
-        </View>
-      )}
-
-      {connectionOutcome && connectionOutcome.kind !== 'connected' && (() => {
-        const display = getConnectionOutcomeDisplay(connectionOutcome);
-        const severityColor = display.severity === 'error' ? '#ef4444' : display.severity === 'warning' ? '#f59e0b' : '#a1a1aa';
-        const severityBg = display.severity === 'error' ? '#450a0a' : display.severity === 'warning' ? '#422006' : '#18181b';
-        const severityBorder = display.severity === 'error' ? '#dc2626' : display.severity === 'warning' ? '#f59e0b' : '#3f3f46';
-        return (
-          <View style={{
-            marginTop: 16,
-            padding: 12,
-            backgroundColor: severityBg,
-            borderRadius: 8,
-            borderWidth: 1,
-            borderColor: severityBorder,
-          }}>
-            <Text style={{ color: severityColor, fontSize: 14, fontWeight: '600' }}>
-              {display.title}
-            </Text>
-            <Text style={{ color: '#a1a1aa', fontSize: 13, marginTop: 4 }}>
-              {display.detail}
-            </Text>
-          </View>
-        );
-      })()}
-
-      <TouchableOpacity
-        onPress={() => { clearOutcome(); router.back(); }}
-        style={{ marginTop: 16, alignSelf: 'center', padding: 8 }}
-      >
-        <Text style={{ color: '#71717a', fontSize: 14 }}>Go Back</Text>
-      </TouchableOpacity>
-    </ScrollView>
-  );
+  return <WalletConnectScreen vm={vm} actions={actions} />;
 }

--- a/docs/solutions/ui-bugs/connect-screen-extraction-regression-review-findings-2026-04-25.md
+++ b/docs/solutions/ui-bugs/connect-screen-extraction-regression-review-findings-2026-04-25.md
@@ -1,0 +1,144 @@
+---
+title: Connect screen extraction dropped platform guards, error handlers, and wallet icons
+date: 2026-04-25
+category: ui-bugs
+module: packages/ui
+problem_type: ui_bug
+component: development_workflow
+severity: high
+symptoms:
+  - Browser wallet CTA and discovery spinner rendered on native platforms where no browser wallets exist
+  - Unhandled promise rejections from fire-and-forget enrollWalletForMonitoring calls
+  - getCapabilities catch path silently swallowed errors instead of surfacing them as outcome banners
+  - Social-webview renderer dropped outcome banner, masking capability/connection failures from in-app browser users
+  - Discovered wallet buttons showed generic Feather icon instead of each wallet's branded icon URL
+root_cause: logic_error
+resolution_type: code_fix
+tags: [view-model, extraction, platform-guard, react-native, connect-screen, error-handling, wallet-icons]
+related_components: [packages/ui, apps/app]
+---
+
+# Connect screen extraction dropped platform guards, error handlers, and wallet icons
+
+## Problem
+
+A connect screen extraction refactor from `apps/app/app/connect.tsx` into `packages/ui` introduced five bugs where platform-specific guards, error handlers, and data-to-render bindings from the original code were silently dropped. None of these omissions caused type errors or compile failures — they were logic regressions that only manifested at runtime on specific platforms or error paths.
+
+## Symptoms
+
+- On iOS/Android, after the discovery timeout, a "Connect Browser Wallet" button appears. Tapping it always fails because the native connector has no browser wallets — the original code gated this with `Platform.OS !== 'web'`.
+- `enrollWalletForMonitoring()` rejections appear as unhandled promise rejections in dev consoles and crash reporters.
+- When `getCapabilities()` rejects (adapter/runtime failure), the user sees nothing — the screen silently falls back to safe capabilities instead of showing an outcome banner.
+- Users on social in-app browsers (Instagram, Facebook) who encounter connection errors see no feedback — `renderSocialWebview` never renders `vm.outcomeDisplay`.
+- Every discovered wallet button shows a generic wallet Feather icon instead of the wallet's branded icon (Phantom purple, Solflare orange).
+
+## What Didn't Work
+
+All five bugs were caught in code review rather than runtime investigation. The reviewer identified that:
+
+- The original `Platform.OS` guard was dropped and not replaced with a data-driven equivalent in the view model.
+- `.catch()` handlers were dropped as boilerplate during extraction.
+- The `renderSocialWebview` function was factored out in isolation, never receiving the outcome banner that the parent route rendered.
+- Wallet icon data existed in the `DiscoveredWallet` type but the render path regressed to a hardcoded `<Icon name="wallet" />`.
+
+## Solution
+
+Five targeted fixes, each restoring a defensive behavior through the view model's data model rather than re-introducing platform API calls in `packages/ui`:
+
+### 1. Gate browser wallet sections on `browserWalletAvailable`
+
+Added `browserWalletAvailable: boolean` to `WalletConnectViewModel`, derived from the existing `caps.browserWalletAvailable` field. Screen components now conditionally render discovery/timeout sections only when `vm.browserWalletAvailable` is true.
+
+```ts
+// WalletConnectionViewModel.ts — type and builder
+export type WalletConnectViewModel = {
+  browserWalletAvailable: boolean;
+  // ... other fields
+};
+
+// In builder
+return {
+  browserWalletAvailable: caps.browserWalletAvailable,
+  // ...
+};
+```
+
+```tsx
+// WalletConnectScreen.tsx — gated rendering
+{!vm.isConnecting && vm.browserWalletAvailable && vm.discovery === 'discovering' ? (...) : null}
+{!vm.isConnecting && vm.browserWalletAvailable && vm.discovery === 'ready' && vm.discoveredWallets.length > 0 ? (...) : null}
+{!vm.isConnecting && vm.browserWalletAvailable && vm.discovery === 'timed-out' ? (...) : null}
+```
+
+### 2. Add `.catch()` to fire-and-forget enrollment calls
+
+```ts
+void enrollWalletForMonitoring(address).catch(() => {});
+// Applied to all three call sites in connect.tsx
+```
+
+### 3. Restore `handleConnectionError` in capability probe catch path
+
+```ts
+.catch((error) => {
+  if (!active) return;
+  setPlatformCapabilities({...fallback});
+  handleConnectionError(error); // restored — surfaces errors as outcome banners
+});
+```
+
+### 4. Render outcome banner in social-webview path
+
+Added `vm.outcomeDisplay` rendering at the top of `renderSocialWebview`, before the social warning banner.
+
+```tsx
+{vm.outcomeDisplay ? (
+  <View style={[styles.outcomeBanner, { borderColor: severityBorderColor(vm.outcomeDisplay.severity) }]}>
+    <Text style={[styles.outcomeTitle, { color: severityTextColor(vm.outcomeDisplay.severity) }]}>
+      {vm.outcomeDisplay.title}
+    </Text>
+    {vm.outcomeDisplay.detail ? (
+      <Text style={styles.outcomeDetail}>{vm.outcomeDisplay.detail}</Text>
+    ) : null}
+  </View>
+) : null}
+```
+
+### 5. Render wallet-specific icons with fallback
+
+```tsx
+{wallet.icon ? (
+  <Image source={{ uri: wallet.icon }} style={styles.walletIcon} />
+) : (
+  <Icon name="wallet" size={20} color={colors.textPrimary} />
+)}
+```
+
+Added `walletIcon: { width: 24, height: 24 }` to StyleSheet and `Image` to React Native imports.
+
+## Why This Works
+
+The root cause across all five bugs was the same pattern: **during extraction/refactor, platform-specific guards and error-handling paths from the original code were silently dropped because they didn't cause compile errors or type failures.** The original code was defensive — it gated browser wallet UI on `Platform.OS`, caught enrollment errors, surfaced capability failures, rendered outcome banners across all code paths, and had wallet icon data available. The refactored code removed these defensive pieces because:
+
+- The `vm.discovery` state model replaced the ad-hoc `Platform.OS` check, but the new model lacked a `browserWalletAvailable` field to carry the same semantics. Without it, the type system couldn't flag the omission — `vm.discovery` is a valid enum on all platforms.
+- `.catch()` handlers were dropped as "boilerplate" during extraction.
+- `renderSocialWebview` was factored out in isolation, never receiving the outcome banner the parent route rendered.
+- Wallet icon data was preserved in the type system but the render path regressed to a hardcoded icon.
+
+Each fix restores the defensive behavior through the view model's data model (rather than coupling back to `Platform.OS` directly), restoring error handlers, or ensuring all render paths include outcome banners.
+
+## Prevention
+
+- **Platform-gated UI must carry its guard into the view model.** When replacing `Platform.OS` checks with a view model, include a field like `browserWalletAvailable` so the gate travels with the data. Without it, `vm.discovery` is a valid enum on all platforms and the type system can't flag the omission.
+- **Every `void`-prefixed fire-and-forget call must have a `.catch()`.** Enforce with `@typescript-eslint/no-floating-promises` or a PR checklist item.
+- **Error-surfacing paths must be preserved in `.catch()` chains.** When a catch handler falls back to safe defaults, it must also surface the error. Code review should verify that `.catch()` paths that replace data also call error-surfacing functions.
+- **All UI render branches must display outcome banners.** When factoring out a new render function, verify that every branch renders `vm.outcomeDisplay`. A visual test per platform-route branch catches this class of regression.
+- **Type-level data must flow to the render layer.** If a type carries UI-relevant data (icons, labels, colors), the render path should use it. Use conditional rendering with fallback (`icon ? <Image> : <Icon>`) rather than ignoring the field entirely.
+- **Extraction-specific review checklist.** For extraction/refactor PRs, explicitly verify: (a) all platform guards are preserved in the new abstraction, (b) all `.catch()` chains are preserved, (c) all render branches display outcome/feedback, (d) all type-level UI data flows to renders.
+
+## Related Issues
+
+- [GitHub #37](https://github.com/opsclawd/clmm-v2/issues/37) — Extract connect screen from app shell into packages/ui
+- [GitHub #45](https://github.com/opsclawd/clmm-v2/pull/45) — PR with review findings and fixes
+- `docs/solutions/integration-issues/phantom-mobile-injected-provider-migrated-to-connectorkit-wallet-standard-2026-04-24.md` — Direct ancestor; the CK migration introduced the connect screen code being extracted
+- `docs/solutions/ui-bugs/signing-status-error-invisible-when-state-loaded-2026-04-23.md` — Same bug class: conditional-rendering gates that silently drop error/outcome state

--- a/docs/superpowers/plans/2026-04-25-position-data-enrichment.md
+++ b/docs/superpowers/plans/2026-04-25-position-data-enrichment.md
@@ -1,0 +1,2050 @@
+# Position Data Enrichment Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Enrich position list and detail views with token pair labels, human-readable prices, unclaimed fees/rewards in USD, pool data, and range distance percentages.
+
+**Architecture:** Application-layer orchestration with a new `PricePort` in the application layer. Adapters return raw on-chain data; use cases call `PricePort` and compute USD values. Graceful degradation when prices are unavailable.
+
+**Tech Stack:** `@solana/kit`, `@orca-so/whirlpools-client`, Jupiter Price API v6, NestJS DI
+
+**Design doc:** `docs/superpowers/specs/2026-04-25-position-data-enrichment-design.md`
+
+---
+
+## File Structure
+
+### New files
+
+| File | Responsibility |
+|------|---------------|
+| `packages/domain/src/positions/enrichment.ts` | Computed-value pure functions: `priceFromSqrtPrice`, `tickToPrice`, `rangeDistancePercent`, `tokenAmountToUsd` |
+| `packages/domain/src/positions/enrichment.test.ts` | Unit tests for computed-value functions |
+| `packages/adapters/src/outbound/price/JupiterPriceAdapter.ts` | Jupiter Price API v6 adapter with TTL cache |
+| `packages/adapters/src/outbound/price/JupiterPriceAdapter.test.ts` | Adapter tests with recorded responses |
+| `packages/adapters/src/outbound/price/known-tokens.ts` | Static `KNOWN_TOKENS` map (SOL/USDC mints, symbols, decimals) |
+| `packages/testing/src/fakes/FakePricePort.ts` | Fake `PricePort` for testing |
+
+### Modified files
+
+| File | Change |
+|------|--------|
+| `packages/domain/src/positions/index.ts` | Add `TokenPair`, `PoolData`, `PositionFees`, `PositionRewardInfo`, `PositionDetail`, `PriceQuote` type exports |
+| `packages/domain/src/shared/index.ts` | Add `makePoolId` use (already exported); no changes needed |
+| `packages/domain/src/index.ts` | Re-export new types from `positions/enrichment.js` |
+| `packages/application/src/ports/index.ts` | Add `PricePort` interface; extend `SupportedPositionReadPort` with `getPositionDetail` and `getPoolData` |
+| `packages/application/src/dto/index.ts` | Extend `PositionSummaryDto` and `PositionDetailDto`; add `TokenAmountValue`, `RewardAmountValue` |
+| `packages/application/src/use-cases/positions/ListSupportedPositions.ts` | Add `pricePort` param; enrich with pool data, prices, range distances |
+| `packages/application/src/use-cases/positions/ListSupportedPositions.test.ts` | Update tests for enriched use case |
+| `packages/application/src/use-cases/positions/GetPositionDetail.ts` | Add `pricePort` param; enrich with fees, rewards, USD values |
+| `packages/application/src/use-cases/positions/GetPositionDetail.test.ts` | Update tests for enriched use case |
+| `packages/application/src/index.ts` | Re-export `PricePort` |
+| `packages/adapters/src/outbound/solana-position-reads/SolanaPositionSnapshotReader.ts` | Extend `fetchWhirlpoolsBatched` return type to include full `WhirlpoolData`; add `fetchPositionDetail` method |
+| `packages/adapters/src/outbound/solana-position-reads/OrcaPositionReadAdapter.ts` | Add `getPoolData` and `getPositionDetail` methods |
+| `packages/adapters/src/index.ts` | Export `JupiterPriceAdapter` |
+| `packages/adapters/src/inbound/http/tokens.ts` | Add `PRICE_PORT` token |
+| `packages/adapters/src/inbound/http/AppModule.ts` | Wire `JupiterPriceAdapter` to `PRICE_PORT` |
+| `packages/adapters/src/composition/AdaptersModule.ts` | Wire `JupiterPriceAdapter` to `PRICE_PORT` |
+| `packages/adapters/src/inbound/http/PositionController.ts` | Inject `PricePort`; update `toPositionSummaryDto` / `toPositionDetailDto` mappers; pass `pricePort` to use cases |
+| `packages/ui/src/view-models/PositionListViewModel.ts` | Use enriched DTO fields; update `buildPositionListViewModel` |
+| `packages/ui/src/view-models/PositionDetailViewModel.ts` | Use enriched DTO fields; update `buildPositionDetailViewModel` |
+| `packages/ui/src/view-models/PositionDetailViewModel.test.ts` | Update tests for enriched view model |
+| `packages/ui/src/components/PositionCard.tsx` | Render new view model fields (price, fees, pool label) |
+| `packages/testing/src/fakes/FakeSupportedPositionReadPort.ts` | Add `getPositionDetail` and `getPoolData` methods |
+| `packages/testing/src/fixtures/positions.ts` | Add fixture pool data, fees, and price quotes |
+| `packages/testing/src/contracts/PositionReadPortContract.ts` | Add contract tests for new port methods |
+| `packages/testing/src/index.ts` | Export `FakePricePort` |
+
+---
+
+### Task 1: Domain computed-value functions
+
+**Files:**
+- Create: `packages/domain/src/positions/enrichment.ts`
+- Create: `packages/domain/src/positions/enrichment.test.ts`
+- Modify: `packages/domain/src/positions/index.ts`
+- Modify: `packages/domain/src/index.ts`
+
+- [ ] **Step 1: Write the failing tests for computed-value functions**
+
+```typescript
+// packages/domain/src/positions/enrichment.test.ts
+import { describe, it, expect } from 'vitest';
+import {
+  priceFromSqrtPrice,
+  tickToPrice,
+  rangeDistancePercent,
+  tokenAmountToUsd,
+} from './enrichment.js';
+
+describe('priceFromSqrtPrice', () => {
+  it('converts a known sqrtPrice X64 to human-readable price', () => {
+    // SOL/USDC pool: if sqrtPrice represents $150 per SOL
+    // price = (sqrtPrice / 2^64)^2 * 10^(decimalsA - decimalsB)
+    // For SOL (9 decimals) / USDC (6 decimals): exponent = 9 - 6 = 3
+    // $150 => sqrtPrice = sqrt(150) * 2^64 * 10^(-3/2)
+    const targetPrice = 150;
+    const decimalsA = 9;
+    const decimalsB = 6;
+    // sqrtPrice = sqrt(targetPrice * 10^(decimalsB - decimalsA)) * 2^64
+    const sqrtPriceX64 = BigInt(Math.round(Math.sqrt(targetPrice * 10 ** (decimalsB - decimalsA)) * (2 ** 64)));
+    const result = priceFromSqrtPrice(sqrtPriceX64, decimalsA, decimalsB);
+    expect(result).toBeCloseTo(targetPrice, 1);
+  });
+
+  it('returns 0 for zero sqrtPrice', () => {
+    expect(priceFromSqrtPrice(0n, 9, 6)).toBe(0);
+  });
+
+  it('handles inverted decimals (decimalsA < decimalsB)', () => {
+    const targetPrice = 0.00667;
+    const decimalsA = 6;
+    const decimalsB = 9;
+    const sqrtPriceX64 = BigInt(Math.round(Math.sqrt(targetPrice * 10 ** (decimalsB - decimalsA)) * (2 ** 64)));
+    const result = priceFromSqrtPrice(sqrtPriceX64, decimalsA, decimalsB);
+    expect(result).toBeCloseTo(targetPrice, 4);
+  });
+});
+
+describe('tickToPrice', () => {
+  it('converts tick index 0 to price 1.0 with equal decimals', () => {
+    expect(tickToPrice(0, 9, 9)).toBeCloseTo(1.0, 6);
+  });
+
+  it('converts positive tick to price > 1', () => {
+    // tick 100 => 1.0001^100 ≈ 1.01005
+    const result = tickToPrice(100, 9, 9);
+    expect(result).toBeCloseTo(1.0001 ** 100, 4);
+  });
+
+  it('converts negative tick to price < 1', () => {
+    // tick -100 => 1.0001^-100 ≈ 0.99005
+    const result = tickToPrice(-100, 9, 9);
+    expect(result).toBeCloseTo(1.0001 ** (-100), 4);
+  });
+
+  it('adjusts for decimal difference', () => {
+    // With decimalsA=9, decimalsB=6: multiply by 10^3
+    const result = tickToPrice(0, 9, 6);
+    expect(result).toBeCloseTo(1000, 1);
+  });
+});
+
+describe('rangeDistancePercent', () => {
+  it('returns 0 for both when in range', () => {
+    const result = rangeDistancePercent(150, 100, 200);
+    expect(result.belowLowerPercent).toBe(0);
+    expect(result.aboveUpperPercent).toBe(0);
+  });
+
+  it('returns positive belowLowerPercent when below lower bound', () => {
+    const result = rangeDistancePercent(80, 100, 200);
+    expect(result.belowLowerPercent).toBeGreaterThan(0);
+    expect(result.aboveUpperPercent).toBe(0);
+  });
+
+  it('returns positive aboveUpperPercent when above upper bound', () => {
+    const result = rangeDistancePercent(250, 100, 200);
+    expect(result.aboveUpperPercent).toBeGreaterThan(0);
+    expect(result.belowLowerPercent).toBe(0);
+  });
+
+  it('computes correct percentage below lower bound', () => {
+    // current tick 80, lower bound 100: 20 ticks below / 100 = 20%
+    const result = rangeDistancePercent(80, 100, 200);
+    expect(result.belowLowerPercent).toBeCloseTo(20, 1);
+  });
+
+  it('computes correct percentage above upper bound', () => {
+    // current tick 250, upper bound 200: 50 ticks above / 200 = 25%
+    const result = rangeDistancePercent(250, 100, 200);
+    expect(result.aboveUpperPercent).toBeCloseTo(25, 1);
+  });
+});
+
+describe('tokenAmountToUsd', () => {
+  it('converts raw token amount with decimals to USD', () => {
+    // 1.5 SOL = 1_500_000_000 raw (9 decimals) at $150/SOL = $225
+    const result = tokenAmountToUsd(1_500_000_000n, 9, 150);
+    expect(result).toBeCloseTo(225, 2);
+  });
+
+  it('converts USDC amount to USD directly', () => {
+    // 50 USDC = 50_000_000 raw (6 decimals) at $1/USDC = $50
+    const result = tokenAmountToUsd(50_000_000n, 6, 1);
+    expect(result).toBeCloseTo(50, 2);
+  });
+
+  it('returns 0 for zero amount', () => {
+    expect(tokenAmountToUsd(0n, 9, 150)).toBe(0);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pnpm test --filter @clmm/domain -- --reporter=verbose --run packages/domain/src/positions/enrichment.test.ts`
+Expected: FAIL — `enrichment.js` does not exist
+
+- [ ] **Step 3: Write the implementation**
+
+```typescript
+// packages/domain/src/positions/enrichment.ts
+export function priceFromSqrtPrice(
+  sqrtPriceX64: bigint,
+  decimalsA: number,
+  decimalsB: number,
+): number {
+  if (sqrtPriceX64 === 0n) return 0;
+
+  const Q64 = 2n ** 64n;
+  const ratio = Number(sqrtPriceX64) / Number(Q64);
+  const price = ratio * ratio * 10 ** (decimalsA - decimalsB);
+  return price;
+}
+
+export function tickToPrice(
+  tickIndex: number,
+  decimalsA: number,
+  decimalsB: number,
+): number {
+  const price = Math.pow(1.0001, tickIndex) * 10 ** (decimalsA - decimalsB);
+  return price;
+}
+
+export function rangeDistancePercent(
+  currentTick: number,
+  lowerTick: number,
+  upperTick: number,
+): { belowLowerPercent: number; aboveUpperPercent: number } {
+  if (currentTick < lowerTick) {
+    return {
+      belowLowerPercent: Math.abs(currentTick - lowerTick) / Math.abs(lowerTick) * 100,
+      aboveUpperPercent: 0,
+    };
+  }
+
+  if (currentTick > upperTick) {
+    return {
+      belowLowerPercent: 0,
+      aboveUpperPercent: Math.abs(currentTick - upperTick) / Math.abs(upperTick) * 100,
+    };
+  }
+
+  return { belowLowerPercent: 0, aboveUpperPercent: 0 };
+}
+
+export function tokenAmountToUsd(
+  amount: bigint,
+  decimals: number,
+  usdPrice: number,
+): number {
+  if (amount === 0n) return 0;
+  const humanReadable = Number(amount) / 10 ** decimals;
+  return humanReadable * usdPrice;
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pnpm test --filter @clmm/domain -- --reporter=verbose --run packages/domain/src/positions/enrichment.test.ts`
+Expected: PASS
+
+- [ ] **Step 5: Export from barrel files**
+
+Add to `packages/domain/src/positions/index.ts`:
+
+```typescript
+export type TokenPair = {
+  readonly mintA: string;
+  readonly mintB: string;
+  readonly symbolA: string;
+  readonly symbolB: string;
+  readonly decimalsA: number;
+  readonly decimalsB: number;
+};
+
+export type PoolData = {
+  readonly poolId: PoolId;
+  readonly tokenPair: TokenPair;
+  readonly sqrtPrice: bigint;
+  readonly feeRate: number;
+  readonly tickSpacing: number;
+  readonly liquidity: bigint;
+  readonly tickCurrentIndex: number;
+};
+
+export type PositionFees = {
+  readonly feeOwedA: bigint;
+  readonly feeOwedB: bigint;
+  readonly rewardInfos: readonly PositionRewardInfo[];
+};
+
+export type PositionRewardInfo = {
+  readonly mint: string;
+  readonly amountOwed: bigint;
+  readonly decimals: number;
+};
+
+export type PositionDetail = {
+  readonly position: LiquidityPosition;
+  readonly poolData: PoolData;
+  readonly fees: PositionFees;
+  readonly positionLiquidity: bigint;
+};
+
+export type PriceQuote = {
+  readonly tokenMint: string;
+  readonly usdValue: number;
+  readonly symbol: string;
+  readonly quotedAt: ClockTimestamp;
+};
+
+export {
+  priceFromSqrtPrice,
+  tickToPrice,
+  rangeDistancePercent,
+  tokenAmountToUsd,
+} from './enrichment.js';
+```
+
+Update the import at top of `packages/domain/src/positions/index.ts` to include `ClockTimestamp`:
+
+```typescript
+import type { PositionId, WalletId, PoolId, ClockTimestamp } from '../shared/index.js';
+```
+
+Add to `packages/domain/src/index.ts`:
+
+```typescript
+export {
+  priceFromSqrtPrice,
+  tickToPrice,
+  rangeDistancePercent,
+  tokenAmountToUsd,
+  TokenPair,
+  PoolData,
+  PositionFees,
+  PositionRewardInfo,
+  PositionDetail,
+  PriceQuote,
+} from './positions/index.js';
+```
+
+- [ ] **Step 6: Run domain build + typecheck**
+
+Run: `pnpm build --filter @clmm/domain && pnpm typecheck --filter @clmm/domain`
+Expected: PASS
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/domain/src/positions/enrichment.ts packages/domain/src/positions/enrichment.test.ts packages/domain/src/positions/index.ts packages/domain/src/index.ts
+git commit -m "feat(domain): add position enrichment types and computed-value functions"
+```
+
+---
+
+### Task 2: Application-layer PricePort and extended SupportedPositionReadPort
+
+**Files:**
+- Modify: `packages/application/src/ports/index.ts`
+- Modify: `packages/application/src/dto/index.ts`
+- Modify: `packages/application/src/index.ts`
+
+- [ ] **Step 1: Add PricePort interface to ports**
+
+Add to `packages/application/src/ports/index.ts`, after the `// --- Position read ports ---` section and before the existing `SupportedPositionReadPort`:
+
+```typescript
+// --- Price ports ---
+
+export interface PricePort {
+  getPrices(tokenMints: readonly string[]): Promise<readonly PriceQuote[]>;
+}
+```
+
+Import `PriceQuote` from `@clmm/domain` by adding it to the existing import statement at the top of the file:
+
+```typescript
+import type {
+  LiquidityPosition,
+  PriceQuote,
+} from '@clmm/domain';
+```
+
+- [ ] **Step 2: Extend SupportedPositionReadPort**
+
+Add `getPositionDetail` and `getPoolData` methods to the `SupportedPositionReadPort` interface. Import `PoolData` and `PositionDetail` from `@clmm/domain`:
+
+```typescript
+import type {
+  LiquidityPosition,
+  PriceQuote,
+  PoolData,
+  PositionDetail,
+} from '@clmm/domain';
+```
+
+Then update the interface:
+
+```typescript
+export interface SupportedPositionReadPort {
+  listSupportedPositions(walletId: WalletId): Promise<LiquidityPosition[]>;
+  getPosition(walletId: WalletId, positionId: PositionId): Promise<LiquidityPosition | null>;
+  getPositionDetail(walletId: WalletId, positionId: PositionId): Promise<PositionDetail | null>;
+  getPoolData(poolId: PoolId): Promise<PoolData | null>;
+}
+```
+
+- [ ] **Step 3: Extend DTOs**
+
+In `packages/application/src/dto/index.ts`, import the new domain types:
+
+```typescript
+import type {
+  PositionId,
+  PoolId,
+  BreachDirection,
+  PostExitAssetPosture,
+  AssetSymbol,
+  BreachEpisodeId,
+  ClockTimestamp,
+} from '@clmm/domain';
+```
+
+(No new imports needed — `PositionId`, `PoolId` are already imported.)
+
+Replace `PositionSummaryDto` with the enriched version:
+
+```typescript
+export type PositionSummaryDto = {
+  positionId: PositionId;
+  poolId: PoolId;
+  tokenPairLabel: string;
+  currentPrice: number;
+  currentPriceLabel: string;
+  feeRateLabel: string;
+  rangeState: 'in-range' | 'below-range' | 'above-range';
+  rangeDistance: {
+    belowLowerPercent: number;
+    aboveUpperPercent: number;
+  };
+  hasActionableTrigger: boolean;
+  monitoringStatus: 'active' | 'degraded' | 'inactive';
+};
+```
+
+Replace `PositionDetailDto` with the enriched version:
+
+```typescript
+export type TokenAmountValue = {
+  raw: bigint;
+  decimals: number;
+  symbol: string;
+  usdValue: number;
+};
+
+export type RewardAmountValue = {
+  mint: string;
+  amount: bigint;
+  decimals: number;
+  symbol: string;
+  usdValue: number;
+};
+
+export type PositionDetailDto = PositionSummaryDto & {
+  lowerBound: number;
+  upperBound: number;
+  currentPrice: number;
+  sqrtPrice: bigint;
+  unclaimedFees: {
+    feeOwedA: TokenAmountValue;
+    feeOwedB: TokenAmountValue;
+    totalUsd: number;
+  };
+  unclaimedRewards: {
+    rewards: RewardAmountValue[];
+    totalUsd: number;
+  };
+  positionLiquidity: bigint;
+  poolLiquidity: bigint;
+  poolDepthLabel: string;
+  triggerId?: ExitTriggerId;
+  breachDirection?: BreachDirection;
+  srLevels?: SrLevelsBlock;
+};
+```
+
+- [ ] **Step 4: Run application build + typecheck**
+
+Run: `pnpm build --filter @clmm/application && pnpm typecheck --filter @clmm/application`
+Expected: FAIL at this point (use cases don't match yet — that's OK, we're just checking the port/DTO definitions compile)
+
+If the build fails because existing use cases don't yet pass the new `pricePort` param, that's expected — we'll fix those in Task 5. If it fails for port/DTO type reasons, fix those now.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/application/src/ports/index.ts packages/application/src/dto/index.ts packages/application/src/index.ts
+git commit -m "feat(application): add PricePort, extend SupportedPositionReadPort and DTOs"
+```
+
+---
+
+### Task 3: Known tokens map and JupiterPriceAdapter
+
+**Files:**
+- Create: `packages/adapters/src/outbound/price/known-tokens.ts`
+- Create: `packages/adapters/src/outbound/price/JupiterPriceAdapter.ts`
+- Create: `packages/adapters/src/outbound/price/JupiterPriceAdapter.test.ts`
+- Modify: `packages/adapters/src/index.ts`
+
+- [ ] **Step 1: Create known-tokens map**
+
+```typescript
+// packages/adapters/src/outbound/price/known-tokens.ts
+export const SOL_MINT = 'So11111111111111111111111111111111111111112';
+export const USDC_MINT = 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v';
+
+export const KNOWN_TOKENS: Record<string, { symbol: string; decimals: number }> = {
+  [SOL_MINT]: { symbol: 'SOL', decimals: 9 },
+  [USDC_MINT]: { symbol: 'USDC', decimals: 6 },
+};
+```
+
+- [ ] **Step 2: Write the failing test for JupiterPriceAdapter**
+
+```typescript
+// packages/adapters/src/outbound/price/JupiterPriceAdapter.test.ts
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { JupiterPriceAdapter } from './JupiterPriceAdapter.js';
+import { SOL_MINT, USDC_MINT } from './known-tokens.js';
+
+describe('JupiterPriceAdapter', () => {
+  let adapter: JupiterPriceAdapter;
+
+  beforeEach(() => {
+    adapter = new JupiterPriceAdapter({ cacheTtlMs: 30000 });
+  });
+
+  it('fetches prices for known token mints', async () => {
+    const mockResponse = {
+      data: {
+        [SOL_MINT]: { id: SOL_MINT, symbol: 'SOL', price: 150.5 },
+        [USDC_MINT]: { id: USDC_MINT, symbol: 'USDC', price: 1.0 },
+      },
+    };
+
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(mockResponse),
+    }));
+
+    const quotes = await adapter.getPrices([SOL_MINT, USDC_MINT]);
+    expect(quotes).toHaveLength(2);
+    expect(quotes[0]?.usdValue).toBe(150.5);
+    expect(quotes[0]?.symbol).toBe('SOL');
+    expect(quotes[1]?.usdValue).toBe(1.0);
+    expect(quotes[1]?.symbol).toBe('USDC');
+
+    vi.restoreAllMocks();
+  });
+
+  it('uses cache on second call within TTL', async () => {
+    const mockResponse = {
+      data: {
+        [SOL_MINT]: { id: SOL_MINT, symbol: 'SOL', price: 150.5 },
+      },
+    };
+
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(mockResponse),
+    });
+
+    vi.stubGlobal('fetch', fetchMock);
+
+    await adapter.getPrices([SOL_MINT]);
+    await adapter.getPrices([SOL_MINT]);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    vi.restoreAllMocks();
+  });
+
+  it('throws when API returns non-OK response', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: false,
+      status: 429,
+      statusText: 'Too Many Requests',
+    }));
+
+    await expect(adapter.getPrices([SOL_MINT])).rejects.toThrow();
+
+    vi.restoreAllMocks();
+  });
+
+  it('fetches only uncached mints on partial cache miss', async () => {
+    const mockResponseSOL = {
+      data: {
+        [SOL_MINT]: { id: SOL_MINT, symbol: 'SOL', price: 150.5 },
+      },
+    };
+    const mockResponseUSDC = {
+      data: {
+        [USDC_MINT]: { id: USDC_MINT, symbol: 'USDC', price: 1.0 },
+      },
+    };
+
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve(mockResponseSOL),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve(mockResponseUSDC),
+      });
+
+    vi.stubGlobal('fetch', fetchMock);
+
+    await adapter.getPrices([SOL_MINT]);
+    await adapter.getPrices([SOL_MINT, USDC_MINT]);
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+
+    vi.restoreAllMocks();
+  });
+});
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `pnpm test --filter @clmm/adapters -- --reporter=verbose --run packages/adapters/src/outbound/price/JupiterPriceAdapter.test.ts`
+Expected: FAIL — `JupiterPriceAdapter.js` does not exist
+
+- [ ] **Step 4: Write the JupiterPriceAdapter implementation**
+
+```typescript
+// packages/adapters/src/outbound/price/JupiterPriceAdapter.ts
+import type { PricePort } from '@clmm/application';
+import type { PriceQuote } from '@clmm/domain';
+import { makeClockTimestamp } from '@clmm/domain';
+
+const JUPITER_PRICE_API_BASE = 'https://price-api.jup.ag/v6';
+
+type CachedPrice = {
+  price: number;
+  symbol: string;
+  fetchedAt: number;
+};
+
+export class JupiterPriceAdapter implements PricePort {
+  private readonly cache = new Map<string, CachedPrice>();
+  private readonly cacheTtlMs: number;
+  private readonly apiKey: string | undefined;
+
+  constructor(config: { apiKey?: string; cacheTtlMs?: number } = {}) {
+    this.apiKey = config.apiKey ?? (process.env as Record<string, string | undefined>)['JUPITER_API_KEY'];
+    this.cacheTtlMs = config.cacheTtlMs ?? 30000;
+  }
+
+  async getPrices(tokenMints: readonly string[]): Promise<readonly PriceQuote[]> {
+    const now = Date.now();
+    const results: PriceQuote[] = [];
+    const uncached: string[] = [];
+
+    for (const mint of tokenMints) {
+      const cached = this.cache.get(mint);
+      if (cached && (now - cached.fetchedAt) < this.cacheTtlMs) {
+        results.push({
+          tokenMint: mint,
+          usdValue: cached.price,
+          symbol: cached.symbol,
+          quotedAt: makeClockTimestamp(cached.fetchedAt),
+        });
+      } else {
+        uncached.push(mint);
+      }
+    }
+
+    if (uncached.length > 0) {
+      const freshQuotes = await this.fetchFromApi(uncached, now);
+      results.push(...freshQuotes);
+    }
+
+    return results;
+  }
+
+  private async fetchFromApi(mints: string[], now: number): Promise<PriceQuote[]> {
+    const ids = mints.join(',');
+    const headers: Record<string, string> = {};
+    if (this.apiKey) {
+      headers['Authorization'] = `Bearer ${this.apiKey}`;
+    }
+
+    const url = `${JUPITER_PRICE_API_BASE}/price?ids=${ids}`;
+    const res = await fetch(url, { headers });
+
+    if (!res.ok) {
+      throw new Error(`JupiterPriceAdapter: Price API error ${res.status} ${res.statusText}`);
+    }
+
+    const data = (await res.json()) as {
+      data: Record<string, { id: string; symbol?: string; price: number }>;
+    };
+
+    const quotes: PriceQuote[] = [];
+    for (const mint of mints) {
+      const tokenData = data.data[mint];
+      if (tokenData) {
+        const symbol = tokenData.symbol ?? mint;
+        this.cache.set(mint, { price: tokenData.price, symbol, fetchedAt: now });
+        quotes.push({
+          tokenMint: mint,
+          usdValue: tokenData.price,
+          symbol,
+          quotedAt: makeClockTimestamp(now),
+        });
+      }
+    }
+
+    return quotes;
+  }
+}
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `pnpm test --filter @clmm/adapters -- --reporter=verbose --run packages/adapters/src/outbound/price/JupiterPriceAdapter.test.ts`
+Expected: PASS
+
+- [ ] **Step 6: Export from adapters barrel**
+
+Add to `packages/adapters/src/index.ts`:
+
+```typescript
+export { JupiterPriceAdapter } from './outbound/price/JupiterPriceAdapter';
+```
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/adapters/src/outbound/price/ packages/adapters/src/index.ts
+git commit -m "feat(adapters): add JupiterPriceAdapter with TTL cache"
+```
+
+---
+
+### Task 4: Extend SolanaPositionSnapshotReader and OrcaPositionReadAdapter
+
+**Files:**
+- Modify: `packages/adapters/src/outbound/solana-position-reads/SolanaPositionSnapshotReader.ts`
+- Modify: `packages/adapters/src/outbound/solana-position-reads/OrcaPositionReadAdapter.ts`
+- Modify: `packages/adapters/src/outbound/solana-position-reads/SolanaPositionSnapshotReader.test.ts`
+- Modify: `packages/adapters/src/outbound/solana-position-reads/OrcaPositionReadAdapter.test.ts`
+
+- [ ] **Step 1: Extend `fetchWhirlpoolsBatched` return type**
+
+In `packages/adapters/src/outbound/solana-position-reads/SolanaPositionSnapshotReader.ts`, add the `WhirlpoolData` type and update `fetchWhirlpoolsBatched`:
+
+```typescript
+export type WhirlpoolData = {
+  tickCurrentIndex: number;
+  sqrtPrice: bigint;
+  tokenMintA: string;
+  tokenMintB: string;
+  feeRate: number;
+  tickSpacing: number;
+  liquidity: bigint;
+};
+```
+
+Update the method signature:
+
+```typescript
+async fetchWhirlpoolsBatched(
+  rpc: ReturnType<typeof createSolanaRpc>,
+  whirlpoolAddresses: string[],
+): Promise<Map<string, WhirlpoolData>>
+```
+
+And update the inner extraction (line 109):
+
+```typescript
+results.set(addr, {
+  tickCurrentIndex: whirlpoolAccount.data.tickCurrentIndex,
+  sqrtPrice: whirlpoolAccount.data.sqrtPrice,
+  tokenMintA: whirlpoolAccount.data.tokenMintA.toString(),
+  tokenMintB: whirlpoolAccount.data.tokenMintB.toString(),
+  feeRate: whirlpoolAccount.data.feeRate,
+  tickSpacing: whirlpoolAccount.data.tickSpacing,
+  liquidity: whirlpoolAccount.data.liquidity,
+});
+```
+
+Update the empty results initialization:
+
+```typescript
+const results = new Map<string, WhirlpoolData>();
+```
+
+- [ ] **Step 2: Add `fetchPositionDetail` method to SolanaPositionSnapshotReader**
+
+Add a new method that reads full position account data including fees:
+
+```typescript
+async fetchPositionDetail(
+  rpc: ReturnType<typeof createSolanaRpc>,
+  positionId: PositionId,
+  walletId: WalletId,
+): Promise<{
+  position: LiquidityPosition;
+  poolData: import('@clmm/domain').PoolData;
+  fees: import('@clmm/domain').PositionFees;
+  positionLiquidity: bigint;
+} | null> {
+  try {
+    const positionMint = address(positionId);
+    const [positionAddress] = await getPositionAddress(positionMint);
+    const positionAccount = await fetchPosition(rpc, positionAddress);
+    const position = positionAccount.data;
+
+    const isOwner = await this.verifyOwnership(rpc, walletId, positionId);
+    if (!isOwner) {
+      return null;
+    }
+
+    const whirlpoolAddress = position.whirlpool;
+    const whirlpoolAccount = await fetchWhirlpool(rpc, whirlpoolAddress);
+    const whirlpool = whirlpoolAccount.data;
+
+    const bounds = {
+      lowerBound: position.tickLowerIndex,
+      upperBound: position.tickUpperIndex,
+    };
+
+    const currentTick = whirlpool.tickCurrentIndex;
+    const rangeState = evaluateRangeState(bounds, currentTick);
+
+    const { KNOWN_TOKENS } = await import('../price/known-tokens.js');
+
+    const mintA = whirlpool.tokenMintA.toString();
+    const mintB = whirlpool.tokenMintB.toString();
+    const knownA = KNOWN_TOKENS[mintA];
+    const knownB = KNOWN_TOKENS[mintB];
+
+    return {
+      position: {
+        positionId,
+        walletId,
+        poolId: makePoolId(whirlpoolAddress.toString()),
+        bounds,
+        lastObservedAt: makeClockTimestamp(Date.now()),
+        rangeState,
+        monitoringReadiness: { kind: 'active' },
+      },
+      poolData: {
+        poolId: makePoolId(whirlpoolAddress.toString()),
+        tokenPair: {
+          mintA,
+          mintB,
+          symbolA: knownA?.symbol ?? mintA,
+          symbolB: knownB?.symbol ?? mintB,
+          decimalsA: knownA?.decimals ?? 0,
+          decimalsB: knownB?.decimals ?? 0,
+        },
+        sqrtPrice: whirlpool.sqrtPrice,
+        feeRate: whirlpool.feeRate,
+        tickSpacing: whirlpool.tickSpacing,
+        liquidity: whirlpool.liquidity,
+        tickCurrentIndex: whirlpool.tickCurrentIndex,
+      },
+      fees: {
+        feeOwedA: position.feeOwedA ?? 0n,
+        feeOwedB: position.feeOwedB ?? 0n,
+        rewardInfos: (position.rewardInfos ?? []).map((r: { mint: unknown; amountOwed: unknown; decimals?: unknown }) => ({
+          mint: r.mint?.toString() ?? '',
+          amountOwed: typeof r.amountOwed === 'bigint' ? r.amountOwed : BigInt(r.amountOwed ?? 0),
+          decimals: typeof r.decimals === 'number' ? r.decimals : 0,
+        })),
+      },
+      positionLiquidity: position.liquidity,
+    };
+  } catch {
+    return null;
+  }
+}
+```
+
+Add the required imports at the top of the file:
+
+```typescript
+import type { PoolData, PositionFees } from '@clmm/domain';
+```
+
+- [ ] **Step 3: Add `getPoolData` and `getPositionDetail` to OrcaPositionReadAdapter**
+
+In `packages/adapters/src/outbound/solana-position-reads/OrcaPositionReadAdapter.ts`, update imports:
+
+```typescript
+import type { SupportedPositionReadPort } from '@clmm/application';
+import type { LiquidityPosition, WalletId, PositionId, PoolData, PositionDetail } from '@clmm/domain';
+import {
+  makePositionId,
+  makePoolId,
+  makeClockTimestamp,
+  evaluateRangeState,
+} from '@clmm/domain';
+```
+
+Add the two new methods to the class:
+
+```typescript
+async getPoolData(poolId: PoolId): Promise<PoolData | null> {
+  const rpc = this.getRpc();
+  const { fetchWhirlpool } = await import('@orca-so/whirlpools-client');
+  const { KNOWN_TOKENS } = await import('../price/known-tokens.js');
+
+  try {
+    const whirlpoolAccount = await fetchWhirlpool(rpc, address(poolId));
+    const w = whirlpoolAccount.data;
+
+    const mintA = w.tokenMintA.toString();
+    const mintB = w.tokenMintB.toString();
+    const knownA = KNOWN_TOKENS[mintA];
+    const knownB = KNOWN_TOKENS[mintB];
+
+    return {
+      poolId,
+      tokenPair: {
+        mintA,
+        mintB,
+        symbolA: knownA?.symbol ?? mintA,
+        symbolB: knownB?.symbol ?? mintB,
+        decimalsA: knownA?.decimals ?? 0,
+        decimalsB: knownB?.decimals ?? 0,
+      },
+      sqrtPrice: w.sqrtPrice,
+      feeRate: w.feeRate,
+      tickSpacing: w.tickSpacing,
+      liquidity: w.liquidity,
+      tickCurrentIndex: w.tickCurrentIndex,
+    };
+  } catch {
+    return null;
+  }
+}
+
+async getPositionDetail(walletId: WalletId, positionId: PositionId): Promise<PositionDetail | null> {
+  const rpc = this.getRpc();
+  const detail = await this.snapshotReader.fetchPositionDetail(rpc, positionId, walletId);
+  if (!detail) return null;
+
+  const now = Date.now();
+  await this.db
+    .insert(walletPositionOwnership)
+    .values({
+      walletId,
+      positionId,
+      firstSeenAt: now,
+      lastSeenAt: now,
+    })
+    .onConflictDoUpdate({
+      target: [walletPositionOwnership.walletId, walletPositionOwnership.positionId],
+      set: { lastSeenAt: now },
+    });
+
+  return detail;
+}
+```
+
+Add `address` to the import from `@solana/kit`:
+
+```typescript
+import { createSolanaRpc, address } from '@solana/kit';
+```
+
+- [ ] **Step 4: Update the `listSupportedPositions` method to use `WhirlpoolData`**
+
+In `OrcaPositionReadAdapter.ts`, the existing loop at line 137 already accesses `whirlpoolData.tickCurrentIndex`. Since `fetchWhirlpoolsBatched` now returns `WhirlpoolData` (which still has `tickCurrentIndex`), the existing code continues to work. No changes needed in the loop body.
+
+- [ ] **Step 5: Run adapter build + typecheck**
+
+Run: `pnpm build --filter @clmm/adapters && pnpm typecheck --filter @clmm/adapters`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/adapters/src/outbound/solana-position-reads/SolanaPositionSnapshotReader.ts packages/adapters/src/outbound/solana-position-reads/OrcaPositionReadAdapter.ts
+git commit -m "feat(adapters): extend whirlpool data extraction and add position detail read"
+```
+
+---
+
+### Task 5: Update application use cases for enrichment
+
+**Files:**
+- Modify: `packages/application/src/use-cases/positions/ListSupportedPositions.ts`
+- Modify: `packages/application/src/use-cases/positions/ListSupportedPositions.test.ts`
+- Modify: `packages/application/src/use-cases/positions/GetPositionDetail.ts`
+- Modify: `packages/application/src/use-cases/positions/GetPositionDetail.test.ts`
+
+- [ ] **Step 1: Rewrite `ListSupportedPositions` use case**
+
+```typescript
+// packages/application/src/use-cases/positions/ListSupportedPositions.ts
+import type { SupportedPositionReadPort, PricePort } from '../../ports/index.js';
+import type { WalletId, LiquidityPosition, PoolId } from '@clmm/domain';
+import type { PositionSummaryDto } from '../../dto/index.js';
+import {
+  priceFromSqrtPrice,
+  rangeDistancePercent,
+} from '@clmm/domain';
+
+export type ListSupportedPositionsResult = {
+  positions: LiquidityPosition[];
+  summaryDtos: PositionSummaryDto[];
+};
+
+export async function listSupportedPositions(params: {
+  walletId: WalletId;
+  positionReadPort: SupportedPositionReadPort;
+  pricePort: PricePort;
+}): Promise<ListSupportedPositionsResult> {
+  const positions = await params.positionReadPort.listSupportedPositions(params.walletId);
+
+  const uniquePoolIds = [...new Set(positions.map((p) => p.poolId))];
+  const poolDataMap = new Map<PoolId, Awaited<ReturnType<SupportedPositionReadPort['getPoolData']>>>();
+
+  await Promise.all(uniquePoolIds.map(async (poolId) => {
+    const poolData = await params.positionReadPort.getPoolData(poolId);
+    if (poolData) poolDataMap.set(poolId, poolData);
+  }));
+
+  let priceMap = new Map<string, { usdValue: number; symbol: string }>();
+  try {
+    const allMints = [...poolDataMap.values()].flatMap((pd) =>
+      pd ? [pd.tokenPair.mintA, pd.tokenPair.mintB] : [],
+    );
+    if (allMints.length > 0) {
+      const quotes = await params.pricePort.getPrices([...new Set(allMints)]);
+      for (const q of quotes) {
+        priceMap.set(q.tokenMint, { usdValue: q.usdValue, symbol: q.symbol });
+      }
+    }
+  } catch {
+    // Price fetch failed — degrade gracefully, no USD values
+  }
+
+  const summaryDtos: PositionSummaryDto[] = positions.map((p) => {
+    const poolData = poolDataMap.get(p.poolId);
+    const currentPrice = poolData
+      ? priceFromSqrtPrice(poolData.sqrtPrice, poolData.tokenPair.decimalsA, poolData.tokenPair.decimalsB)
+      : p.rangeState.currentPrice;
+
+    const distance = rangeDistancePercent(
+      p.rangeState.currentPrice,
+      p.bounds.lowerBound,
+      p.bounds.upperBound,
+    );
+
+    return {
+      positionId: p.positionId,
+      poolId: p.poolId,
+      tokenPairLabel: poolData ? `${poolData.tokenPair.symbolA} / ${poolData.tokenPair.symbolB}` : `Pool ${p.poolId}`,
+      currentPrice,
+      currentPriceLabel: poolData ? `$${currentPrice.toFixed(2)}` : `tick: ${p.rangeState.currentPrice}`,
+      feeRateLabel: poolData ? `${poolData.feeRate} bps` : '',
+      rangeState: p.rangeState.kind,
+      rangeDistance: {
+        belowLowerPercent: distance.belowLowerPercent,
+        aboveUpperPercent: distance.aboveUpperPercent,
+      },
+      hasActionableTrigger: false,
+      monitoringStatus: p.monitoringReadiness.kind,
+    };
+  });
+
+  return { positions, summaryDtos };
+}
+```
+
+- [ ] **Step 2: Update `ListSupportedPositions` tests**
+
+```typescript
+// packages/application/src/use-cases/positions/ListSupportedPositions.test.ts
+import { describe, it, expect } from 'vitest';
+import { listSupportedPositions } from './ListSupportedPositions.js';
+import {
+  FakeSupportedPositionReadPort,
+  FakePricePort,
+  FIXTURE_WALLET_ID,
+  FIXTURE_POSITION_IN_RANGE,
+  FIXTURE_POSITION_BELOW_RANGE,
+  FIXTURE_POOL_DATA,
+  FIXTURE_SOL_PRICE_QUOTE,
+  FIXTURE_USDC_PRICE_QUOTE,
+} from '@clmm/testing';
+import type { PricePort } from '@clmm/application';
+import type { PriceQuote } from '@clmm/domain';
+import { makeClockTimestamp } from '@clmm/domain';
+
+describe('ListSupportedPositions', () => {
+  it('returns enriched summaries with pool data and prices', async () => {
+    const positionReadPort = new FakeSupportedPositionReadPort(
+      [FIXTURE_POSITION_IN_RANGE],
+      { [FIXTURE_POSITION_IN_RANGE.poolId]: FIXTURE_POOL_DATA },
+    );
+    const pricePort = new FakePricePort([FIXTURE_SOL_PRICE_QUOTE, FIXTURE_USDC_PRICE_QUOTE]);
+
+    const result = await listSupportedPositions({
+      walletId: FIXTURE_WALLET_ID,
+      positionReadPort,
+      pricePort,
+    });
+
+    expect(result.positions).toHaveLength(1);
+    expect(result.summaryDtos).toHaveLength(1);
+    expect(result.summaryDtos[0]?.tokenPairLabel).toContain('SOL');
+  });
+
+  it('degrades gracefully when price fetch fails', async () => {
+    const positionReadPort = new FakeSupportedPositionReadPort(
+      [FIXTURE_POSITION_IN_RANGE],
+      { [FIXTURE_POSITION_IN_RANGE.poolId]: FIXTURE_POOL_DATA },
+    );
+    const pricePort: PricePort = {
+      getPrices: async () => { throw new Error('price unavailable'); },
+    };
+
+    const result = await listSupportedPositions({
+      walletId: FIXTURE_WALLET_ID,
+      positionReadPort,
+      pricePort,
+    });
+
+    expect(result.summaryDtos).toHaveLength(1);
+    expect(result.summaryDtos[0]?.currentPriceLabel).toContain('tick:');
+  });
+
+  it('returns empty list when wallet has no positions', async () => {
+    const positionReadPort = new FakeSupportedPositionReadPort([]);
+    const pricePort = new FakePricePort([]);
+
+    const result = await listSupportedPositions({
+      walletId: FIXTURE_WALLET_ID,
+      positionReadPort,
+      pricePort,
+    });
+
+    expect(result.positions).toHaveLength(0);
+    expect(result.summaryDtos).toHaveLength(0);
+  });
+});
+```
+
+- [ ] **Step 3: Rewrite `GetPositionDetail` use case**
+
+```typescript
+// packages/application/src/use-cases/positions/GetPositionDetail.ts
+import type { SupportedPositionReadPort, PricePort } from '../../ports/index.js';
+import type { PositionId, WalletId } from '@clmm/domain';
+import type { PositionDetailDto, TokenAmountValue, RewardAmountValue } from '../../dto/index.js';
+import {
+  priceFromSqrtPrice,
+  rangeDistancePercent,
+  tokenAmountToUsd,
+} from '@clmm/domain';
+
+export type GetPositionDetailResult =
+  | { kind: 'found'; position: import('@clmm/domain').LiquidityPosition; detailDto: PositionDetailDto }
+  | { kind: 'not-found' };
+
+export async function getPositionDetail(params: {
+  walletId: WalletId;
+  positionId: PositionId;
+  positionReadPort: SupportedPositionReadPort;
+  pricePort: PricePort;
+}): Promise<GetPositionDetailResult> {
+  const detail = await params.positionReadPort.getPositionDetail(params.walletId, params.positionId);
+  if (!detail) return { kind: 'not-found' };
+
+  const { position, poolData, fees, positionLiquidity } = detail;
+
+  let priceMap = new Map<string, { usdValue: number; symbol: string }>();
+  try {
+    const mints = [poolData.tokenPair.mintA, poolData.tokenPair.mintB];
+    const rewardMints = fees.rewardInfos.map((r) => r.mint).filter((m) => !mints.includes(m));
+    const allMints = [...mints, ...rewardMints];
+    const quotes = await params.pricePort.getPrices([...new Set(allMints)]);
+    for (const q of quotes) {
+      priceMap.set(q.tokenMint, { usdValue: q.usdValue, symbol: q.symbol });
+    }
+  } catch {
+    // Price fetch failed — degrade gracefully
+  }
+
+  const currentPrice = priceFromSqrtPrice(poolData.sqrtPrice, poolData.tokenPair.decimalsA, poolData.tokenPair.decimalsB);
+  const distance = rangeDistancePercent(
+    position.rangeState.currentPrice,
+    position.bounds.lowerBound,
+    position.bounds.upperBound,
+  );
+
+  const priceA = priceMap.get(poolData.tokenPair.mintA);
+  const priceB = priceMap.get(poolData.tokenPair.mintB);
+
+  const feeOwedA: TokenAmountValue = {
+    raw: fees.feeOwedA,
+    decimals: poolData.tokenPair.decimalsA,
+    symbol: poolData.tokenPair.symbolA,
+    usdValue: priceA ? tokenAmountToUsd(fees.feeOwedA, poolData.tokenPair.decimalsA, priceA.usdValue) : 0,
+  };
+
+  const feeOwedB: TokenAmountValue = {
+    raw: fees.feeOwedB,
+    decimals: poolData.tokenPair.decimalsB,
+    symbol: poolData.tokenPair.symbolB,
+    usdValue: priceB ? tokenAmountToUsd(fees.feeOwedB, poolData.tokenPair.decimalsB, priceB.usdValue) : 0,
+  };
+
+  const totalFeesUsd = feeOwedA.usdValue + feeOwedB.usdValue;
+
+  const rewardValues: RewardAmountValue[] = fees.rewardInfos.map((r) => {
+    const rPrice = priceMap.get(r.mint);
+    return {
+      mint: r.mint,
+      amount: r.amountOwed,
+      decimals: r.decimals,
+      symbol: rPrice?.symbol ?? r.mint,
+      usdValue: rPrice ? tokenAmountToUsd(r.amountOwed, r.decimals, rPrice.usdValue) : 0,
+    };
+  });
+
+  const totalRewardsUsd = rewardValues.reduce((sum, r) => sum + r.usdValue, 0);
+
+  const poolDepthUsd = priceB
+    ? tokenAmountToUsd(poolData.liquidity, poolData.tokenPair.decimalsB, priceB.usdValue)
+    : 0;
+  const poolDepthLabel = poolDepthUsd > 0
+    ? `$${(poolDepthUsd / 1_000_000).toFixed(1)}M pool depth`
+    : 'depth unavailable';
+
+  const detailDto: PositionDetailDto = {
+    positionId: position.positionId,
+    poolId: position.poolId,
+    tokenPairLabel: `${poolData.tokenPair.symbolA} / ${poolData.tokenPair.symbolB}`,
+    currentPrice,
+    currentPriceLabel: `$${currentPrice.toFixed(2)}`,
+    feeRateLabel: `${poolData.feeRate} bps`,
+    rangeState: position.rangeState.kind,
+    rangeDistance: {
+      belowLowerPercent: distance.belowLowerPercent,
+      aboveUpperPercent: distance.aboveUpperPercent,
+    },
+    hasActionableTrigger: false,
+    monitoringStatus: position.monitoringReadiness.kind,
+    lowerBound: position.bounds.lowerBound,
+    upperBound: position.bounds.upperBound,
+    sqrtPrice: poolData.sqrtPrice,
+    unclaimedFees: {
+      feeOwedA,
+      feeOwedB,
+      totalUsd: totalFeesUsd,
+    },
+    unclaimedRewards: {
+      rewards: rewardValues,
+      totalUsd: totalRewardsUsd,
+    },
+    positionLiquidity,
+    poolLiquidity: poolData.liquidity,
+    poolDepthLabel,
+  };
+
+  return { kind: 'found', position, detailDto };
+}
+```
+
+- [ ] **Step 4: Update `GetPositionDetail` tests**
+
+```typescript
+// packages/application/src/use-cases/positions/GetPositionDetail.test.ts
+import { describe, it, expect } from 'vitest';
+import { getPositionDetail } from './GetPositionDetail.js';
+import {
+  FakeSupportedPositionReadPort,
+  FakePricePort,
+  FIXTURE_POSITION_ID,
+  FIXTURE_POSITION_IN_RANGE,
+  FIXTURE_WALLET_ID,
+  FIXTURE_POOL_DATA,
+  FIXTURE_POSITION_DETAIL,
+  FIXTURE_SOL_PRICE_QUOTE,
+  FIXTURE_USDC_PRICE_QUOTE,
+} from '@clmm/testing';
+import { makePositionId, makeWalletId } from '@clmm/domain';
+import type { PricePort } from '@clmm/application';
+
+describe('GetPositionDetail', () => {
+  it('returns enriched detail with fees and USD values', async () => {
+    const positionReadPort = new FakeSupportedPositionReadPort(
+      [FIXTURE_POSITION_IN_RANGE],
+      { [FIXTURE_POSITION_IN_RANGE.poolId]: FIXTURE_POOL_DATA },
+      FIXTURE_POSITION_DETAIL,
+    );
+    const pricePort = new FakePricePort([FIXTURE_SOL_PRICE_QUOTE, FIXTURE_USDC_PRICE_QUOTE]);
+
+    const result = await getPositionDetail({
+      walletId: FIXTURE_WALLET_ID,
+      positionId: FIXTURE_POSITION_ID,
+      positionReadPort,
+      pricePort,
+    });
+
+    expect(result.kind).toBe('found');
+    if (result.kind === 'found') {
+      expect(result.detailDto.tokenPairLabel).toContain('SOL');
+      expect(result.detailDto.unclaimedFees).toBeDefined();
+    }
+  });
+
+  it('degrades gracefully when price fetch fails', async () => {
+    const positionReadPort = new FakeSupportedPositionReadPort(
+      [FIXTURE_POSITION_IN_RANGE],
+      { [FIXTURE_POSITION_IN_RANGE.poolId]: FIXTURE_POOL_DATA },
+      FIXTURE_POSITION_DETAIL,
+    );
+    const pricePort: PricePort = {
+      getPrices: async () => { throw new Error('price unavailable'); },
+    };
+
+    const result = await getPositionDetail({
+      walletId: FIXTURE_WALLET_ID,
+      positionId: FIXTURE_POSITION_ID,
+      positionReadPort,
+      pricePort,
+    });
+
+    expect(result.kind).toBe('found');
+    if (result.kind === 'found') {
+      expect(result.detailDto.unclaimedFees.totalUsd).toBe(0);
+    }
+  });
+
+  it('returns not-found when position does not exist', async () => {
+    const positionReadPort = new FakeSupportedPositionReadPort([]);
+    const pricePort = new FakePricePort([]);
+
+    const result = await getPositionDetail({
+      walletId: FIXTURE_WALLET_ID,
+      positionId: makePositionId('nonexistent'),
+      positionReadPort,
+      pricePort,
+    });
+
+    expect(result.kind).toBe('not-found');
+  });
+});
+```
+
+- [ ] **Step 5: Run application tests**
+
+Run: `pnpm test --filter @clmm/application -- --reporter=verbose --run`
+Expected: PASS (tests will need the fakes from Task 6 first — run after Task 6)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/application/src/use-cases/positions/ListSupportedPositions.ts packages/application/src/use-cases/positions/ListSupportedPositions.test.ts packages/application/src/use-cases/positions/GetPositionDetail.ts packages/application/src/use-cases/positions/GetPositionDetail.test.ts
+git commit -m "feat(application): enrich position use cases with pool data, prices, and USD values"
+```
+
+---
+
+### Task 6: Update testing fakes and fixtures
+
+**Files:**
+- Create: `packages/testing/src/fakes/FakePricePort.ts`
+- Modify: `packages/testing/src/fakes/FakeSupportedPositionReadPort.ts`
+- Modify: `packages/testing/src/fixtures/positions.ts`
+- Modify: `packages/testing/src/contracts/PositionReadPortContract.ts`
+- Modify: `packages/testing/src/fakes/index.ts`
+- Modify: `packages/testing/src/fixtures/index.ts`
+- Modify: `packages/testing/src/index.ts`
+
+- [ ] **Step 1: Create FakePricePort**
+
+```typescript
+// packages/testing/src/fakes/FakePricePort.ts
+import type { PricePort } from '@clmm/application';
+import type { PriceQuote } from '@clmm/domain';
+
+export class FakePricePort implements PricePort {
+  constructor(private readonly quotes: PriceQuote[] = []) {}
+
+  async getPrices(tokenMints: readonly string[]): Promise<readonly PriceQuote[]> {
+    return this.quotes.filter((q) => tokenMints.includes(q.tokenMint));
+  }
+}
+```
+
+- [ ] **Step 2: Update FakeSupportedPositionReadPort**
+
+```typescript
+// packages/testing/src/fakes/FakeSupportedPositionReadPort.ts
+import type { SupportedPositionReadPort } from '@clmm/application';
+import type { LiquidityPosition, PositionId, WalletId, PoolId, PoolData, PositionDetail } from '@clmm/domain';
+
+export class FakeSupportedPositionReadPort implements SupportedPositionReadPort {
+  constructor(
+    private readonly _positions: LiquidityPosition[] = [],
+    private readonly _poolDataMap: Record<string, PoolData> = {},
+    private readonly _positionDetail: PositionDetail | null = null,
+  ) {}
+
+  async listSupportedPositions(_walletId: WalletId): Promise<LiquidityPosition[]> {
+    return [...this._positions];
+  }
+
+  async getPosition(walletId: WalletId, positionId: PositionId): Promise<LiquidityPosition | null> {
+    return this._positions.find((p) => p.walletId === walletId && p.positionId === positionId) ?? null;
+  }
+
+  async getPositionDetail(_walletId: WalletId, _positionId: PositionId): Promise<PositionDetail | null> {
+    return this._positionDetail;
+  }
+
+  async getPoolData(poolId: PoolId): Promise<PoolData | null> {
+    return this._poolDataMap[poolId] ?? null;
+  }
+}
+```
+
+- [ ] **Step 3: Add fixtures**
+
+Add to `packages/testing/src/fixtures/positions.ts`:
+
+```typescript
+import type { PoolData, PositionDetail, PriceQuote } from '@clmm/domain';
+
+export const FIXTURE_POOL_DATA: PoolData = {
+  poolId: FIXTURE_POOL_ID,
+  tokenPair: {
+    mintA: 'So11111111111111111111111111111111111111112',
+    mintB: 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
+    symbolA: 'SOL',
+    symbolB: 'USDC',
+    decimalsA: 9,
+    decimalsB: 6,
+  },
+  sqrtPrice: 184467440737095516n,
+  feeRate: 10,
+  tickSpacing: 64,
+  liquidity: 2400000000n,
+  tickCurrentIndex: 150,
+};
+
+export const FIXTURE_POSITION_DETAIL: PositionDetail = {
+  position: FIXTURE_POSITION_IN_RANGE,
+  poolData: FIXTURE_POOL_DATA,
+  fees: {
+    feeOwedA: 120000000n,
+    feeOwedB: 47230000n,
+    rewardInfos: [],
+  },
+  positionLiquidity: 5000000000n,
+};
+
+export const FIXTURE_SOL_PRICE_QUOTE: PriceQuote = {
+  tokenMint: 'So11111111111111111111111111111111111111112',
+  usdValue: 150,
+  symbol: 'SOL',
+  quotedAt: makeClockTimestamp(Date.now()),
+};
+
+export const FIXTURE_USDC_PRICE_QUOTE: PriceQuote = {
+  tokenMint: 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
+  usdValue: 1,
+  symbol: 'USDC',
+  quotedAt: makeClockTimestamp(Date.now()),
+};
+```
+
+- [ ] **Step 4: Update barrel exports**
+
+Add to `packages/testing/src/fakes/index.ts`:
+
+```typescript
+export { FakePricePort } from './FakePricePort.js';
+```
+
+Add to `packages/testing/src/fixtures/index.ts`:
+
+```typescript
+export {
+  FIXTURE_POOL_DATA,
+  FIXTURE_POSITION_DETAIL,
+  FIXTURE_SOL_PRICE_QUOTE,
+  FIXTURE_USDC_PRICE_QUOTE,
+} from './positions.js';
+```
+
+Update `packages/testing/src/index.ts` to re-export the new fakes and fixtures.
+
+- [ ] **Step 5: Update contract tests**
+
+Add to `packages/testing/src/contracts/PositionReadPortContract.ts`:
+
+```typescript
+it('implements getPositionDetail returning PositionDetail or null', async () => {
+  const port = factory();
+  const result = await port.getPositionDetail(makeWalletId('test-wallet'), makePositionId('test-pos'));
+  expect(result === null || (typeof result === 'object' && 'position' in result && 'poolData' in result && 'fees' in result)).toBe(true);
+});
+
+it('implements getPoolData returning PoolData or null', async () => {
+  const port = factory();
+  const result = await port.getPoolData(makePoolId('test-pool'));
+  expect(result === null || (typeof result === 'object' && 'tokenPair' in result && 'sqrtPrice' in result)).toBe(true);
+});
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/testing/src/fakes/FakePricePort.ts packages/testing/src/fakes/FakeSupportedPositionReadPort.ts packages/testing/src/fakes/index.ts packages/testing/src/fixtures/positions.ts packages/testing/src/fixtures/index.ts packages/testing/src/contracts/PositionReadPortContract.ts packages/testing/src/index.ts
+git commit -m "feat(testing): add FakePricePort, update fakes/fixtures for position enrichment"
+```
+
+---
+
+### Task 7: Update PositionController and DI wiring
+
+**Files:**
+- Modify: `packages/adapters/src/inbound/http/tokens.ts`
+- Modify: `packages/adapters/src/inbound/http/PositionController.ts`
+- Modify: `packages/adapters/src/inbound/http/AppModule.ts`
+- Modify: `packages/adapters/src/composition/AdaptersModule.ts`
+
+- [ ] **Step 1: Add PRICE_PORT token**
+
+Add to `packages/adapters/src/inbound/http/tokens.ts`:
+
+```typescript
+export const PRICE_PORT = 'PRICE_PORT';
+```
+
+- [ ] **Step 2: Update PositionController**
+
+Update `packages/adapters/src/inbound/http/PositionController.ts` to inject `PricePort` and use enriched use case results.
+
+Replace the `toPositionSummaryDto` function:
+
+```typescript
+function toPositionSummaryDto(
+  dto: PositionSummaryDto,
+  hasActionableTrigger = false,
+): PositionSummaryDto {
+  return {
+    ...dto,
+    hasActionableTrigger,
+  };
+}
+```
+
+Replace the `toPositionDetailDto` function — it now spreads the enriched `PositionDetailDto` from the use case:
+
+```typescript
+function toPositionDetailDto(
+  dto: PositionDetailDto,
+  trigger: ExitTrigger | null,
+): PositionDetailDto {
+  return {
+    ...dto,
+    hasActionableTrigger: trigger !== null,
+    ...(trigger
+      ? {
+          triggerId: trigger.triggerId,
+          breachDirection: trigger.breachDirection,
+        }
+      : {}),
+  };
+}
+```
+
+Update imports to include `PricePort` and `PRICE_PORT`:
+
+```typescript
+import type {
+  SupportedPositionReadPort,
+  PricePort,
+  TriggerRepository,
+} from '@clmm/application';
+import type {
+  PositionSummaryDto,
+  PositionDetailDto,
+} from '@clmm/application';
+import { PRICE_PORT, SUPPORTED_POSITION_READ_PORT, TRIGGER_REPOSITORY, CURRENT_SR_LEVELS_PORT, SR_LEVELS_POOL_ALLOWLIST } from './tokens.js';
+```
+
+Update the constructor to inject `PricePort`:
+
+```typescript
+constructor(
+  @Inject(SUPPORTED_POSITION_READ_PORT)
+  private readonly positionReadPort: SupportedPositionReadPort,
+  @Inject(PRICE_PORT)
+  private readonly pricePort: PricePort,
+  @Inject(TRIGGER_REPOSITORY)
+  private readonly triggerRepo: TriggerRepository,
+  @Inject(CURRENT_SR_LEVELS_PORT)
+  private readonly srLevelsPort: CurrentSrLevelsPort,
+  @Inject(SR_LEVELS_POOL_ALLOWLIST)
+  private readonly srLevelsAllowlist: Map<string, { symbol: string; source: string }>,
+) {}
+```
+
+Update the `listPositions` method to use the enriched `summaryDtos`:
+
+```typescript
+@Get(':walletId')
+async listPositions(@Param('walletId') walletId: string) {
+  const wallet = makeWalletId(walletId);
+
+  let summaryDtos: PositionSummaryDto[];
+  try {
+    const result = await listSupportedPositions({
+      walletId: wallet,
+      positionReadPort: this.positionReadPort,
+      pricePort: this.pricePort,
+    });
+    summaryDtos = result.summaryDtos;
+  } catch (error: unknown) {
+    if (!isTransientPositionReadFailure(error)) {
+      throw error;
+    }
+    return {
+      positions: [],
+      error: 'Unable to fetch positions. Position data temporarily unavailable.',
+    };
+  }
+
+  let triggerPositionIds: ReadonlySet<string> = new Set();
+  let triggerError: string | undefined;
+
+  try {
+    const actionableTriggers = await this.triggerRepo.listActionableTriggers(wallet);
+    triggerPositionIds = new Set(actionableTriggers.map((t) => t.positionId));
+  } catch (error: unknown) {
+    if (!isTransientPositionReadFailure(error)) {
+      throw error;
+    }
+    triggerError = 'Unable to fetch trigger data. Trigger status may be incomplete.';
+  }
+
+  return {
+    positions: summaryDtos.map((dto) => toPositionSummaryDto(dto, triggerPositionIds.has(dto.positionId))),
+    ...(triggerError ? { error: triggerError } : {}),
+  };
+}
+```
+
+Update the `getPosition` (detail) method to use enriched `detailDto`:
+
+```typescript
+@Get(':walletId/:positionId')
+async getPosition(
+  @Param('walletId') walletId: string,
+  @Param('positionId') positionId: string,
+) {
+  const wallet = makeWalletId(walletId);
+  const result = await getPositionDetail({
+    walletId: wallet,
+    positionId: makePositionId(positionId),
+    positionReadPort: this.positionReadPort,
+    pricePort: this.pricePort,
+  });
+
+  if (result.kind === 'not-found') {
+    throw new NotFoundException(`Position not found: ${positionId}`);
+  }
+
+  if (result.position.walletId !== wallet) {
+    throw new NotFoundException(`Position not found: ${positionId}`);
+  }
+
+  let trigger: import('@clmm/domain').ExitTrigger | null = null;
+  let triggerError: string | undefined;
+  let srLevels: DtoSrLevelsBlock | undefined;
+
+  const allowlistEntry = this.srLevelsAllowlist.get(result.position.poolId);
+
+  if (allowlistEntry) {
+    const [triggerResult, srResult] = await Promise.all([
+      this.triggerRepo.listActionableTriggers(wallet).then(
+        (triggers) => ({ ok: true as const, triggers }),
+        (error: unknown) => ({ ok: false as const, error }),
+      ),
+      this.srLevelsPort.fetchCurrent(allowlistEntry.symbol, allowlistEntry.source).then(
+        (block) => block,
+        () => null,
+      ),
+    ]);
+
+    if (triggerResult.ok) {
+      trigger = triggerResult.triggers.find((c) => c.positionId === result.position.positionId) ?? null;
+    } else if (isTransientPositionReadFailure(triggerResult.error)) {
+      triggerError = 'Unable to fetch trigger data. Position data temporarily unavailable.';
+    } else {
+      throw triggerResult.error;
+    }
+
+    if (srResult) {
+      srLevels = srResult;
+    }
+  } else {
+    try {
+      const actionableTriggers = await this.triggerRepo.listActionableTriggers(wallet);
+      trigger =
+        actionableTriggers.find((candidate) => candidate.positionId === result.position.positionId) ?? null;
+    } catch (error: unknown) {
+      if (!isTransientPositionReadFailure(error)) {
+        throw error;
+      }
+      triggerError = 'Unable to fetch trigger data. Position data temporarily unavailable.';
+    }
+  }
+
+  return {
+    position: {
+      ...toPositionDetailDto(result.detailDto, trigger),
+      ...(srLevels ? { srLevels } : {}),
+    },
+    ...(triggerError ? { error: triggerError } : {}),
+  };
+}
+```
+
+- [ ] **Step 3: Wire JupiterPriceAdapter in AppModule**
+
+In `packages/adapters/src/inbound/http/AppModule.ts`, add imports and wiring:
+
+```typescript
+import { JupiterPriceAdapter } from '../../outbound/price/JupiterPriceAdapter.js';
+```
+
+Add to the `tokens.js` import:
+
+```typescript
+import {
+  // ... existing tokens
+  PRICE_PORT,
+} from './tokens.js';
+```
+
+Create the adapter instance:
+
+```typescript
+const jupiterPrice = new JupiterPriceAdapter();
+```
+
+Add to the providers array:
+
+```typescript
+{ provide: PRICE_PORT, useValue: jupiterPrice },
+```
+
+- [ ] **Step 4: Wire JupiterPriceAdapter in AdaptersModule**
+
+In `packages/adapters/src/composition/AdaptersModule.ts`, add the same wiring:
+
+```typescript
+import { JupiterPriceAdapter } from '../outbound/price/JupiterPriceAdapter.js';
+```
+
+Add `PRICE_PORT` to the tokens import from `'../inbound/jobs/tokens.js'`.
+
+Create the instance and add to `sharedProviders`:
+
+```typescript
+const jupiterPrice = new JupiterPriceAdapter();
+```
+
+```typescript
+{ provide: PRICE_PORT, useValue: jupiterPrice },
+```
+
+- [ ] **Step 5: Run build + typecheck**
+
+Run: `pnpm build && pnpm typecheck`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/adapters/src/inbound/http/tokens.ts packages/adapters/src/inbound/http/PositionController.ts packages/adapters/src/inbound/http/AppModule.ts packages/adapters/src/composition/AdaptersModule.ts
+git commit -m "feat(adapters): wire PricePort and update PositionController for enriched data"
+```
+
+---
+
+### Task 8: Update UI view models and components
+
+**Files:**
+- Modify: `packages/ui/src/view-models/PositionListViewModel.ts`
+- Modify: `packages/ui/src/view-models/PositionDetailViewModel.ts`
+- Modify: `packages/ui/src/view-models/PositionDetailViewModel.test.ts`
+- Modify: `packages/ui/src/components/PositionCard.tsx`
+
+- [ ] **Step 1: Update PositionListViewModel**
+
+```typescript
+// packages/ui/src/view-models/PositionListViewModel.ts
+import type { PositionSummaryDto } from '@clmm/application/public';
+
+export type PositionListItemViewModel = {
+  positionId: string;
+  poolLabel: string;
+  currentPriceLabel: string;
+  feeRateLabel: string;
+  rangeStatusLabel: string;
+  rangeStatusKind: 'in-range' | 'below-range' | 'above-range';
+  rangeDistanceLabel: string;
+  hasAlert: boolean;
+  monitoringLabel: string;
+};
+
+export type PositionListViewModel = {
+  items: PositionListItemViewModel[];
+  isEmpty: boolean;
+};
+
+function rangeStateLabel(kind: string): string {
+  switch (kind) {
+    case 'in-range': return 'In Range';
+    case 'below-range': return 'Below Range';
+    case 'above-range': return 'Above Range';
+    default: return 'Unknown';
+  }
+}
+
+function monitoringLabel(status: string): string {
+  switch (status) {
+    case 'active': return 'Monitoring Active';
+    case 'degraded': return 'Monitoring Degraded';
+    case 'inactive': return 'Monitoring Inactive';
+    default: return 'Unknown';
+  }
+}
+
+function rangeDistanceLabel(distance: { belowLowerPercent: number; aboveUpperPercent: number }): string {
+  if (distance.belowLowerPercent > 0) {
+    return `${distance.belowLowerPercent.toFixed(1)}% below lower`;
+  }
+  if (distance.aboveUpperPercent > 0) {
+    return `${distance.aboveUpperPercent.toFixed(1)}% above upper`;
+  }
+  return 'In range';
+}
+
+export function buildPositionListViewModel(positions: PositionSummaryDto[]): PositionListViewModel {
+  const items: PositionListItemViewModel[] = positions.map((p) => ({
+    positionId: p.positionId,
+    poolLabel: p.tokenPairLabel,
+    currentPriceLabel: p.currentPriceLabel,
+    feeRateLabel: p.feeRateLabel,
+    rangeStatusLabel: rangeStateLabel(p.rangeState),
+    rangeStatusKind: p.rangeState,
+    rangeDistanceLabel: rangeDistanceLabel(p.rangeDistance),
+    hasAlert: p.hasActionableTrigger,
+    monitoringLabel: monitoringLabel(p.monitoringStatus),
+  }));
+
+  return { items, isEmpty: items.length === 0 };
+}
+```
+
+- [ ] **Step 2: Update PositionDetailViewModel**
+
+```typescript
+// packages/ui/src/view-models/PositionDetailViewModel.ts
+import type { PositionDetailDto } from '@clmm/application/public';
+import { getRangeStatusBadgeProps } from '../components/RangeStatusBadgeUtils.js';
+
+export type SrLevelsViewModelBlock = {
+  supportsSorted: Array<{ priceLabel: string; rankLabel?: string }>;
+  resistancesSorted: Array<{ priceLabel: string; rankLabel?: string }>;
+  freshnessLabel: string;
+  isStale: boolean;
+};
+
+export type PositionDetailViewModel = {
+  positionId: string;
+  poolLabel: string;
+  currentPriceLabel: string;
+  feeRateLabel: string;
+  rangeBoundsLabel: string;
+  rangeStatusLabel: string;
+  rangeStatusColorKey: string;
+  rangeDistanceLabel: string;
+  unclaimedFeesLabel: string;
+  unclaimedFeesBreakdown: {
+    feeA: string;
+    feeB: string;
+  };
+  unclaimedRewardsLabel: string;
+  positionSizeLabel: string;
+  poolDepthLabel: string;
+  hasAlert: boolean;
+  alertLabel: string;
+  breachDirectionLabel?: string;
+  srLevels?: SrLevelsViewModelBlock;
+};
+
+function computeFreshness(capturedAtUnixMs: number, now: number): { freshnessLabel: string; isStale: boolean } {
+  const ageMs = now - capturedAtUnixMs;
+  if (ageMs < 3600000) {
+    const minutes = Math.max(1, Math.round(ageMs / 60000));
+    return { freshnessLabel: `captured ${minutes}m ago`, isStale: false };
+  }
+  const hours = Math.round(ageMs / 3600000);
+  if (ageMs < 172800000) {
+    return { freshnessLabel: `captured ${hours}h ago`, isStale: false };
+  }
+  return { freshnessLabel: `captured ${hours}h ago · stale`, isStale: true };
+}
+
+function toSrLevelsViewModelBlock(
+  block: NonNullable<PositionDetailDto['srLevels']>,
+  now: number,
+): SrLevelsViewModelBlock {
+  const { freshnessLabel, isStale } = computeFreshness(block.capturedAtUnixMs, now);
+
+  const supportsSorted = [...block.supports]
+    .sort((a, b) => a.price - b.price)
+    .map((s) => ({
+      priceLabel: `$${s.price.toFixed(2)}`,
+      ...(s.rank ? { rankLabel: s.rank } : {}),
+    }));
+
+  const resistancesSorted = [...block.resistances]
+    .sort((a, b) => a.price - b.price)
+    .map((r) => ({
+      priceLabel: `$${r.price.toFixed(2)}`,
+      ...(r.rank ? { rankLabel: r.rank } : {}),
+    }));
+
+  return { supportsSorted, resistancesSorted, freshnessLabel, isStale };
+}
+
+function formatTokenAmount(raw: bigint, decimals: number, symbol: string): string {
+  const humanReadable = Number(raw) / 10 ** decimals;
+  return `${humanReadable.toFixed(decimals > 2 ? 4 : 2)} ${symbol}`;
+}
+
+function rangeDistanceLabel(distance: { belowLowerPercent: number; aboveUpperPercent: number }): string {
+  if (distance.belowLowerPercent > 0) {
+    return `${distance.belowLowerPercent.toFixed(1)}% below lower bound`;
+  }
+  if (distance.aboveUpperPercent > 0) {
+    return `${distance.aboveUpperPercent.toFixed(1)}% above upper bound`;
+  }
+  return 'In range';
+}
+
+export function buildPositionDetailViewModel(dto: PositionDetailDto, now: number): PositionDetailViewModel {
+  const badge = getRangeStatusBadgeProps(dto.rangeState);
+
+  const unclaimedFeesLabel = dto.unclaimedFees.totalUsd > 0
+    ? `$${dto.unclaimedFees.totalUsd.toFixed(2)} in unclaimed fees`
+    : `${formatTokenAmount(dto.unclaimedFees.feeOwedA.raw, dto.unclaimedFees.feeOwedA.decimals, dto.unclaimedFees.feeOwedA.symbol)} + ${formatTokenAmount(dto.unclaimedFees.feeOwedB.raw, dto.unclaimedFees.feeOwedB.decimals, dto.unclaimedFees.feeOwedB.symbol)} unclaimed`;
+
+  const unclaimedRewardsLabel = dto.unclaimedRewards.totalUsd > 0
+    ? `$${dto.unclaimedRewards.totalUsd.toFixed(2)} in rewards`
+    : dto.unclaimedRewards.rewards.length > 0
+      ? dto.unclaimedRewards.rewards.map((r) => formatTokenAmount(r.amount, r.decimals, r.symbol)).join(', ') + ' rewards'
+      : 'No rewards';
+
+  const base = {
+    positionId: dto.positionId,
+    poolLabel: dto.tokenPairLabel,
+    currentPriceLabel: dto.currentPriceLabel,
+    feeRateLabel: dto.feeRateLabel,
+    rangeBoundsLabel: `$${dto.lowerBound} — $${dto.upperBound}`,
+    rangeStatusLabel: badge.label,
+    rangeStatusColorKey: badge.colorKey,
+    rangeDistanceLabel: rangeDistanceLabel(dto.rangeDistance),
+    unclaimedFeesLabel,
+    unclaimedFeesBreakdown: {
+      feeA: formatTokenAmount(dto.unclaimedFees.feeOwedA.raw, dto.unclaimedFees.feeOwedA.decimals, dto.unclaimedFees.feeOwedA.symbol),
+      feeB: formatTokenAmount(dto.unclaimedFees.feeOwedB.raw, dto.unclaimedFees.feeOwedB.decimals, dto.unclaimedFees.feeOwedB.symbol),
+    },
+    unclaimedRewardsLabel,
+    positionSizeLabel: `${dto.positionLiquidity.toString()} liquidity units`,
+    poolDepthLabel: dto.poolDepthLabel,
+    hasAlert: dto.hasActionableTrigger,
+    alertLabel: dto.hasActionableTrigger ? 'Action Required' : 'No Alerts',
+  };
+
+  const srLevelsVm = dto.srLevels
+    ? toSrLevelsViewModelBlock(dto.srLevels, now)
+    : undefined;
+
+  if (dto.breachDirection) {
+    return {
+      ...base,
+      breachDirectionLabel: dto.breachDirection.kind === 'lower-bound-breach'
+        ? 'Price dropped below lower bound'
+        : 'Price rose above upper bound',
+      ...(srLevelsVm ? { srLevels: srLevelsVm } : {}),
+    };
+  }
+
+  return { ...base, ...(srLevelsVm ? { srLevels: srLevelsVm } : {}) };
+}
+```
+
+- [ ] **Step 3: Update PositionDetailViewModel tests**
+
+Update `packages/ui/src/view-models/PositionDetailViewModel.test.ts` to use the enriched DTO structure. The test data needs to match the new `PositionDetailDto` shape with `tokenPairLabel`, `currentPriceLabel`, `feeRateLabel`, `rangeDistance`, and the nested `unclaimedFees`/`unclaimedRewards` structures.
+
+- [ ] **Step 4: Update PositionCard component**
+
+Update `packages/ui/src/components/PositionCard.tsx` to render the new view model fields (`currentPriceLabel`, `feeRateLabel`, `rangeDistanceLabel`) instead of the old minimal fields.
+
+- [ ] **Step 5: Run UI tests + typecheck**
+
+Run: `pnpm test --filter @clmm/ui -- --reporter=verbose --run && pnpm typecheck --filter @clmm/ui`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/ui/src/view-models/PositionListViewModel.ts packages/ui/src/view-models/PositionDetailViewModel.ts packages/ui/src/view-models/PositionDetailViewModel.test.ts packages/ui/src/components/PositionCard.tsx
+git commit -m "feat(ui): update view models and components for enriched position display"
+```
+
+---
+
+### Task 9: Full repo validation
+
+**Files:** None (verification only)
+
+- [ ] **Step 1: Run full repo checks**
+
+Run: `pnpm build && pnpm typecheck && pnpm lint && pnpm boundaries && pnpm test`
+Expected: All PASS
+
+- [ ] **Step 2: Fix any failures**
+
+Address type errors, lint issues, boundary violations, or test failures.
+
+- [ ] **Step 3: Commit any fixes**
+
+```bash
+git add -A
+git commit -m "fix: resolve validation issues from position data enrichment"
+```

--- a/docs/superpowers/specs/2026-04-25-position-data-enrichment-design.md
+++ b/docs/superpowers/specs/2026-04-25-position-data-enrichment-design.md
@@ -1,0 +1,403 @@
+# Position Data Enrichment Design
+
+**Issue**: https://github.com/opsclawd/clmm-v2/issues/43
+**Date**: 2026-04-25
+**Status**: Draft
+
+## Problem
+
+The `/positions` and `/positions/:walletId/:positionId` endpoints fetch substantial data from Orca whirlpool RPCs but discard most of it. Only `tickCurrentIndex` is extracted from whirlpool responses. Position accounts contain `feeOwedA/B`, `rewardInfos`, and `liquidity` that are never surfaced. Users see raw tick indices instead of human-readable prices, pool labels like "Pool <address>" instead of "SOL / USDC", and no fee or value information.
+
+## Scope
+
+Full issue scope as specified in #43:
+
+- Display token pair symbols on list and detail views
+- Display current price in human-readable terms (derived from sqrtPrice)
+- Display pool fee tier, tick spacing, and pool depth
+- Display unclaimed fees (feeOwedA/B) with USD values
+- Display unclaimed rewards with USD values
+- Display position size indicator
+- Display range distance percentages
+- Price source: sqrtPrice from whirlpool (primary), Jupiter Price API v6 (for USD values and token symbols)
+
+**Out of scope** (per the issue): historical entry price / PnL, impermanent loss calculation, fee history over time, price chart / portfolio value over time.
+
+## Architecture Decision: Application-Layer Enrichment
+
+**Chosen approach**: Application-layer orchestration with a new `PricePort` in the domain layer.
+
+- Adapters return raw on-chain data (token mints, fee amounts, sqrtPrice, etc.)
+- Application use cases call `PricePort` to get prices, then compute USD values and human-readable prices
+- Domain stays pure — it defines the port interface and computed-value functions
+- Price failures don't break position reads — graceful degradation to raw values
+
+This was chosen over:
+- **Enrichment in adapter**: Couples position reads to price fetching, violates adapter isolation
+- **Dedicated enrichment port**: Adds an extra port without much gain over application-layer orchestration
+
+## Domain Layer Changes
+
+### New types in `packages/domain/src/positions/`
+
+#### `TokenPair`
+
+```typescript
+type TokenPair = {
+  readonly mintA: string;    // base58 mint address
+  readonly mintB: string;
+  readonly symbolA: string;  // e.g. "SOL"
+  readonly symbolB: string;  // e.g. "USDC"
+  readonly decimalsA: number;
+  readonly decimalsB: number;
+};
+```
+
+#### `PoolData`
+
+```typescript
+type PoolData = {
+  readonly poolId: PoolId;
+  readonly tokenPair: TokenPair;
+  readonly sqrtPrice: bigint;      // raw X64 from whirlpool
+  readonly feeRate: number;         // basis points
+  readonly tickSpacing: number;
+  readonly liquidity: bigint;       // pool depth
+  readonly tickCurrentIndex: number;
+};
+```
+
+#### `PositionFees`
+
+```typescript
+type PositionFees = {
+  readonly feeOwedA: bigint;
+  readonly feeOwedB: bigint;
+  readonly rewardInfos: readonly PositionRewardInfo[];
+};
+
+type PositionRewardInfo = {
+  readonly mint: string;
+  readonly amountOwed: bigint;
+  readonly decimals: number;
+};
+```
+
+#### `PositionDetail`
+
+```typescript
+type PositionDetail = {
+  readonly position: LiquidityPosition;
+  readonly poolData: PoolData;
+  readonly fees: PositionFees;
+  readonly positionLiquidity: bigint;
+};
+```
+
+#### `PriceQuote`
+
+```typescript
+type PriceQuote = {
+  readonly tokenMint: string;
+  readonly usdValue: number;      // e.g. 142.35
+  readonly symbol: string;        // e.g. "SOL"
+  readonly quotedAt: ClockTimestamp;
+};
+```
+
+### New port in `packages/domain/src/ports/`
+
+#### `PricePort`
+
+```typescript
+interface PricePort {
+  getPrices(tokenMints: readonly string[]): Promise<readonly PriceQuote[]>;
+}
+```
+
+### Extended port in `packages/application/src/ports/`
+
+#### `SupportedPositionReadPort` (extended)
+
+```typescript
+interface SupportedPositionReadPort {
+  listSupportedPositions(walletId: WalletId): Promise<LiquidityPosition[]>;
+  getPosition(walletId: WalletId, positionId: PositionId): Promise<LiquidityPosition | null>;
+  // NEW:
+  getPositionDetail(walletId: WalletId, positionId: PositionId): Promise<PositionDetail | null>;
+  getPoolData(poolId: PoolId): Promise<PoolData | null>;
+}
+```
+
+### Computed value functions in `packages/domain/src/positions/`
+
+Pure functions for display calculations. No external dependencies.
+
+```typescript
+function tickToPrice(tickIndex: number, decimalsA: number, decimalsB: number): number;
+function priceFromSqrtPrice(sqrtPriceX64: bigint, decimalsA: number, decimalsB: number): number;
+function rangeDistancePercent(
+  currentTick: number,
+  lowerTick: number,
+  upperTick: number,
+): { belowLowerPercent: number; aboveUpperPercent: number };
+function tokenAmountToUsd(amount: bigint, decimals: number, usdPrice: number): number;
+```
+
+- `tickToPrice`: Converts a tick index to a human-readable price using `price = 1.0001^tick * 10^(decimalsA - decimalsB)`
+- `priceFromSqrtPrice`: Converts X64 sqrtPrice to human-readable price using `price = (sqrtPriceX64 / 2^64)^2 * 10^(decimalsA - decimalsB)`
+- `rangeDistancePercent`: Returns how far the current tick is from the lower and upper bounds as percentages. When in-range, both values are 0 or show distance to nearest bound.
+- `tokenAmountToUsd`: Converts raw token amount + decimals to USD using `amount / 10^decimals * usdPrice`
+
+## Application Layer Changes
+
+### `ListSupportedPositions` use case (extended)
+
+```typescript
+async function listSupportedPositions(params: {
+  walletId: WalletId;
+  positionReadPort: SupportedPositionReadPort;
+  pricePort: PricePort;
+}): Promise<ListSupportedPositionsResult>
+```
+
+Orchestration:
+1. Call `positionReadPort.listSupportedPositions(walletId)` to get position list
+2. Collect unique pool IDs from positions
+3. Call `positionReadPort.getPoolData()` for each unique pool
+4. Collect all token mints from pool data
+5. Call `pricePort.getPrices()` with all token mints (single batched call)
+6. Compute: token pair labels, current prices from sqrtPrice, range distance percentages, fee rate labels, pool depth indicators
+7. Return enriched `PositionSummaryDto[]`
+
+### `GetPositionDetail` use case (extended)
+
+```typescript
+async function getPositionDetail(params: {
+  walletId: WalletId;
+  positionId: PositionId;
+  positionReadPort: SupportedPositionReadPort;
+  pricePort: PricePort;
+}): Promise<GetPositionDetailResult>
+```
+
+Orchestration:
+1. Call `positionReadPort.getPositionDetail(walletId, positionId)` to get position + pool data + fees
+2. Collect token mints from pool data and reward infos
+3. Call `pricePort.getPrices()` with all relevant token mints
+4. Compute: USD fee values, USD reward values, position notional estimate, human-readable price, range distances
+5. Return enriched `PositionDetailDto`
+
+### Updated DTOs in `packages/application/src/dto/`
+
+#### `PositionSummaryDto` (extended)
+
+```typescript
+type PositionSummaryDto = {
+  positionId: PositionId;
+  poolId: PoolId;
+  tokenPairLabel: string;          // "SOL / USDC"
+  currentPrice: number;            // human-readable, e.g. 142.35
+  currentPriceLabel: string;       // "$142.35"
+  feeRateLabel: string;            // "10 bps"
+  rangeState: 'in-range' | 'below-range' | 'above-range';
+  rangeDistance: {
+    belowLowerPercent: number;    // e.g. 12.3 (or 0 if in-range/above)
+    aboveUpperPercent: number;    // e.g. 8.7 (or 0 if in-range/below)
+  };
+  hasActionableTrigger: boolean;
+  monitoringStatus: 'active' | 'degraded' | 'inactive';
+};
+```
+
+#### `PositionDetailDto` (extended)
+
+```typescript
+type PositionDetailDto = PositionSummaryDto & {
+  lowerBound: number;                // tick index (still needed for SR levels)
+  upperBound: number;
+  sqrtPrice: bigint;                  // raw X64 for precision needs
+  unclaimedFees: {
+    feeOwedA: TokenAmountValue;
+    feeOwedB: TokenAmountValue;
+    totalUsd: number;
+  };
+  unclaimedRewards: {
+    rewards: RewardAmountValue[];
+    totalUsd: number;
+  };
+  positionLiquidity: bigint;
+  poolLiquidity: bigint;
+  poolDepthLabel: string;           // e.g. "$2.4M pool depth"
+};
+
+type TokenAmountValue = {
+  raw: bigint;
+  decimals: number;
+  symbol: string;
+  usdValue: number;
+};
+
+type RewardAmountValue = {
+  mint: string;
+  amount: bigint;
+  decimals: number;
+  symbol: string;
+  usdValue: number;
+};
+```
+
+## Adapter Layer Changes
+
+### `JupiterPriceAdapter` (new file)
+
+Location: `packages/adapters/src/outbound/price/JupiterPriceAdapter.ts`
+
+Implements `PricePort`. Uses Jupiter Price API v6 at `https://price-api.jup.ag/v6/price`.
+
+```typescript
+class JupiterPriceAdapter implements PricePort {
+  constructor(config: { apiKey?: string; cacheTtlMs: number });
+
+  async getPrices(tokenMints: readonly string[]): Promise<readonly PriceQuote[]>
+}
+```
+
+Behavior:
+- Accepts `JUPITER_API_KEY` env var (optional; unauthenticated mode works for low volume)
+- In-memory TTL cache (default 30s): `Map<string, { price: number; symbol: string; fetchedAt: number }>`
+- Batch request: Jupiter Price API accepts multiple mints in one call
+- On cache hit for all mints, returns immediately without network call
+- On partial cache miss, fetches only missing mints
+- On API failure (429, 5xx, network), throws `PriceUnavailableError`; use case catches and degrades gracefully
+
+### `SolanaPositionSnapshotReader` changes
+
+#### `fetchWhirlpoolsBatched` extended return type
+
+```typescript
+// Before: Map<string, { tickCurrentIndex: number }>
+// After:  Map<string, WhirlpoolData>
+
+type WhirlpoolData = {
+  tickCurrentIndex: number;
+  sqrtPrice: bigint;
+  tokenMintA: string;
+  tokenMintB: string;
+  feeRate: number;
+  tickSpacing: number;
+  liquidity: bigint;
+};
+```
+
+No new RPC calls required — the data is already present in the whirlpool account response. We stop discarding it.
+
+### `OrcaPositionReadAdapter` changes
+
+#### New `getPoolData(poolId)` method
+
+- Looks up the pool ID in cached whirlpool data, or makes a single fetch
+- Maps to `PoolData` domain type with `TokenPair` using the known token map and Jupiter symbol fallback
+
+#### New `getPositionDetail(walletId, positionId)` method
+
+- Same ownership verification as existing `getPosition`
+- Additionally reads from the position account: `feeOwedA`, `feeOwedB`, `rewardInfos[]`, `liquidity`
+- Fetches associated whirlpool data
+- Returns `PositionDetail` with all raw on-chain values
+
+### Known token map
+
+A static map in the adapter layer for supported tokens:
+
+```typescript
+const KNOWN_TOKENS: Record<string, { symbol: string; decimals: number }> = {
+  [SOL_MINT]:  { symbol: 'SOL',  decimals: 9  },
+  [USDC_MINT]: { symbol: 'USDC', decimals: 6  },
+};
+```
+
+Token mints not in this map get their symbol from Jupiter's price response (which includes `data.symbol`). This avoids adding a separate token metadata API dependency.
+
+## UI Layer Changes
+
+### Updated view models
+
+#### `PositionListItemViewModel` (extended)
+
+```typescript
+type PositionListItemViewModel = {
+  positionId: string;
+  poolLabel: string;              // "SOL / USDC" (was "Pool <address>")
+  currentPriceLabel: string;     // "$142.35" (was "Current: -18130")
+  feeRateLabel: string;           // "10 bps"
+  rangeStatusLabel: string;
+  rangeStatusKind: 'in-range' | 'below-range' | 'above-range';
+  rangeDistanceLabel: string;     // "12.3% below lower" or "8.7% above upper"
+  hasAlert: boolean;
+  monitoringLabel: string;
+};
+```
+
+#### `PositionDetailViewModel` (extended)
+
+```typescript
+type PositionDetailViewModel = {
+  positionId: string;
+  poolLabel: string;              // "SOL / USDC"
+  currentPriceLabel: string;     // "$142.35"
+  feeRateLabel: string;           // "10 bps"
+  rangeBoundsLabel: string;      // "$130.00 — $160.00" (was "-18130 — -17930")
+  rangeStatusLabel: string;
+  rangeStatusColorKey: string;
+  rangeDistanceLabel: string;    // "12.3% below lower bound"
+  unclaimedFeesLabel: string;    // "$64.50 in unclaimed fees"
+  unclaimedFeesBreakdown: {
+    feeA: string;                 // "47.23 USDC"
+    feeB: string;                 // "0.12 SOL"
+  };
+  unclaimedRewardsLabel: string; // "$12.50 in rewards" or "No rewards"
+  positionSizeLabel: string;     // "~$5,200 position" or raw liquidity
+  poolDepthLabel: string;        // "$2.4M pool depth"
+  hasAlert: boolean;
+  alertLabel: string;
+  breachDirectionLabel?: string;
+  srLevels?: SrLevelsViewModelBlock;
+};
+```
+
+### Component rendering
+
+All formatting happens in the view model builders. Components render pre-formatted strings. No computation in React components.
+
+### Fallback behavior (price unavailable)
+
+| Field | With price | Without price |
+|-------|-----------|---------------|
+| `poolLabel` | "SOL / USDC" | "SOL / USDC" (from known token map) |
+| `currentPriceLabel` | "$142.35" | "tick: -18130" |
+| `unclaimedFeesLabel` | "$64.50 in unclaimed fees" | "0.12 SOL + 47.23 USDC unclaimed" |
+| `unclaimedRewardsLabel` | "$12.50 in rewards" | "12.50 ORCA rewards" |
+| `poolDepthLabel` | "$2.4M pool depth" | "depth unavailable" |
+| `rangeBoundsLabel` | "$130.00 — $160.00" | "tick -18130 — -17930" |
+
+## Error Handling
+
+- **Price API failure**: Use case catches `PricePort` errors, returns `null` prices. View models format graceful fallbacks. Position list/detail never fails due to price unavailability.
+- **Whirlpool fetch failure**: Positions referencing failed whirlpool fetches are excluded from the list (existing behavior). `getPoolData` returns `null`; use case skips pool enrichment for that position.
+- **Position account fetch failure**: `getPositionDetail` returns `null`. Detail endpoint returns 404 (existing behavior).
+- **Jupiter rate limiting (429)**: TTL cache minimizes requests. On 429 or 5xx, `JupiterPriceAdapter` throws `PriceUnavailableError`; use case catches and degrades.
+
+## Testing
+
+- **Domain**: Unit tests for `tickToPrice`, `priceFromSqrtPrice`, `rangeDistancePercent`, `tokenAmountToUsd`. Edge cases: tick = 0, sqrtPrice = 0, inverted decimals, boundary ticks.
+- **Application**: Integration-style tests with mock ports. Verify orchestration of position + price data, null price handling, DTO formation.
+- **Adapters**: `JupiterPriceAdapter` tested with recorded HTTP responses (no live API calls). Cache behavior tested with fake timers. Whirlpool data extraction tested with fixture account data.
+- **UI**: View model builder tests with various DTO combinations (full data, partial data, price unavailable).
+
+## Out of Scope
+
+- Historical entry price / PnL
+- Impermanent loss calculation
+- Fee history over time
+- Price chart / portfolio value over time

--- a/docs/superpowers/specs/2026-04-25-position-data-enrichment-design.md
+++ b/docs/superpowers/specs/2026-04-25-position-data-enrichment-design.md
@@ -105,7 +105,7 @@ type PriceQuote = {
 };
 ```
 
-### New port in `packages/domain/src/ports/`
+### New port in `packages/application/src/ports/`
 
 #### `PricePort`
 
@@ -115,7 +115,9 @@ interface PricePort {
 }
 ```
 
-### Extended port in `packages/application/src/ports/`
+`PricePort` lives in the application layer alongside `SupportedPositionReadPort` and `SwapQuotePort`. The domain layer has no knowledge of prices — it only provides pure computation functions (`tickToPrice`, `tokenAmountToUsd`, etc.) that the application layer calls with price data fetched through this port.
+
+### Extended port (same location)
 
 #### `SupportedPositionReadPort` (extended)
 
@@ -146,7 +148,7 @@ function tokenAmountToUsd(amount: bigint, decimals: number, usdPrice: number): n
 
 - `tickToPrice`: Converts a tick index to a human-readable price using `price = 1.0001^tick * 10^(decimalsA - decimalsB)`
 - `priceFromSqrtPrice`: Converts X64 sqrtPrice to human-readable price using `price = (sqrtPriceX64 / 2^64)^2 * 10^(decimalsA - decimalsB)`
-- `rangeDistancePercent`: Returns how far the current tick is from the lower and upper bounds as percentages. When in-range, both values are 0 or show distance to nearest bound.
+- `rangeDistancePercent`: Returns how far the current tick is from the lower and upper bounds as percentages. For out-of-range positions: `belowLowerPercent` is positive when below the lower bound, `aboveUpperPercent` is positive when above the upper bound. For in-range positions: both values are 0 (no breach).
 - `tokenAmountToUsd`: Converts raw token amount + decimals to USD using `amount / 10^decimals * usdPrice`
 
 ## Application Layer Changes
@@ -358,7 +360,7 @@ type PositionDetailViewModel = {
   };
   unclaimedRewardsLabel: string; // "$12.50 in rewards" or "No rewards"
   positionSizeLabel: string;     // "~$5,200 position" or raw liquidity
-  poolDepthLabel: string;        // "$2.4M pool depth"
+  poolDepthLabel: string;        // "$2.4M pool depth" (estimated from pool liquidity * price; shows "depth unavailable" without prices)
   hasAlert: boolean;
   alertLabel: string;
   breachDirectionLabel?: string;

--- a/packages/ui/src/components/WalletConnectionUtils.ts
+++ b/packages/ui/src/components/WalletConnectionUtils.ts
@@ -119,3 +119,30 @@ export function buildPlatformNotice(caps: PlatformCapabilities): PlatformNotice 
     severity: 'error',
   };
 }
+
+export type FallbackState =
+  | 'none'
+  | 'wallet-fallback'
+  | 'desktop-no-wallet'
+  | 'social-webview';
+
+export type WalletDiscoveryState =
+  | 'discovering'
+  | 'ready'
+  | 'timed-out';
+
+export type DiscoveredWallet = {
+  id: string;
+  name: string;
+  icon: string | null;
+};
+
+export type WalletConnectActions = {
+  onSelectNative: () => void;
+  onSelectDiscoveredWallet: (walletId: string) => void;
+  onConnectDefaultBrowser: () => void;
+  onOpenPhantom: () => void;
+  onOpenSolflare: () => void;
+  onOpenInBrowser: () => void;
+  onGoBack: () => void;
+};

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -44,6 +44,10 @@ export type {
   ConnectionOutcomeDisplay,
   PlatformNotice,
   ConnectedWalletSummary,
+  FallbackState,
+  WalletDiscoveryState,
+  DiscoveredWallet,
+  WalletConnectActions,
 } from './components/WalletConnectionUtils.js';
 
 // View models — for testing and screen composition

--- a/packages/ui/src/screens/WalletConnectScreen.test.tsx
+++ b/packages/ui/src/screens/WalletConnectScreen.test.tsx
@@ -16,6 +16,7 @@ function makeVm(overrides: Partial<WalletConnectViewModel> = {}): WalletConnectV
   return {
     screenState: 'standard',
     nativeWalletAvailable: false,
+    browserWalletAvailable: true,
     discovery: 'ready',
     discoveredWallets: [],
     fallback: 'none',
@@ -248,5 +249,25 @@ describe('WalletConnectScreen', () => {
     const lastButton = goBackButtons[goBackButtons.length - 1]!;
     fireEvent.click(lastButton);
     expect(onGoBack).toHaveBeenCalled();
+  });
+
+  it('hides browser wallet discovery when browserWalletAvailable is false', () => {
+    render(
+      <WalletConnectScreen
+        vm={makeVm({ browserWalletAvailable: false, discovery: 'discovering' })}
+        actions={makeActions()}
+      />,
+    );
+    expect(screen.queryByText('Detecting browser wallets...')).toBeNull();
+  });
+
+  it('hides timed-out browser wallet CTA when browserWalletAvailable is false', () => {
+    render(
+      <WalletConnectScreen
+        vm={makeVm({ browserWalletAvailable: false, discovery: 'timed-out' })}
+        actions={makeActions()}
+      />,
+    );
+    expect(screen.queryByText('Connect Browser Wallet')).toBeNull();
   });
 });

--- a/packages/ui/src/screens/WalletConnectScreen.test.tsx
+++ b/packages/ui/src/screens/WalletConnectScreen.test.tsx
@@ -220,6 +220,7 @@ describe('WalletConnectScreen', () => {
     expect(screen.getByText('Open in Browser')).toBeTruthy();
     expect(screen.getByText('Open in Phantom')).toBeTruthy();
     expect(screen.getByText('Open in Solflare')).toBeTruthy();
+    expect(screen.getByText('Go Back')).toBeTruthy();
   });
 
   it('shows outcome banner in social-webview state', () => {
@@ -234,6 +235,19 @@ describe('WalletConnectScreen', () => {
     );
     expect(screen.getByText('Connection Failed')).toBeTruthy();
     expect(screen.getByText('Social app browsers block wallet extensions.')).toBeTruthy();
+  });
+
+  it('calls onGoBack from social-webview state', () => {
+    const onGoBack = vi.fn();
+    render(
+      <WalletConnectScreen
+        vm={makeVm({ screenState: 'social-webview' })}
+        actions={makeActions({ onGoBack })}
+      />,
+    );
+    const goBackButtons = screen.getAllByText('Go Back');
+    fireEvent.click(goBackButtons[0]!);
+    expect(onGoBack).toHaveBeenCalled();
   });
 
   it('renders wallet fallback with deep links', () => {

--- a/packages/ui/src/screens/WalletConnectScreen.test.tsx
+++ b/packages/ui/src/screens/WalletConnectScreen.test.tsx
@@ -2,7 +2,8 @@ import React from 'react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { cleanup, fireEvent, render, screen } from '@testing-library/react';
 import { WalletConnectScreen } from './WalletConnectScreen.js';
-import type { PlatformCapabilities } from '../components/DegradedCapabilityBannerUtils.js';
+import type { WalletConnectViewModel } from '../view-models/WalletConnectionViewModel.js';
+import type { WalletConnectActions } from '../components/WalletConnectionUtils.js';
 
 vi.mock('@expo/vector-icons/Feather', () => ({
   default: function MockFeather({ name, size, color }: { name: string; size: number; color: string }) {
@@ -11,13 +12,30 @@ vi.mock('@expo/vector-icons/Feather', () => ({
   glyphMap: {},
 }));
 
-function makeCaps(overrides: Partial<PlatformCapabilities> = {}) {
+function makeVm(overrides: Partial<WalletConnectViewModel> = {}): WalletConnectViewModel {
   return {
-    nativePushAvailable: false,
-    browserNotificationAvailable: false,
+    screenState: 'standard',
     nativeWalletAvailable: false,
-    browserWalletAvailable: false,
-    isMobileWeb: false,
+    discovery: 'ready',
+    discoveredWallets: [],
+    fallback: 'none',
+    socialEscapeAttempted: false,
+    isConnecting: false,
+    outcomeDisplay: null,
+    platformNotice: null,
+    ...overrides,
+  };
+}
+
+function makeActions(overrides: Partial<WalletConnectActions> = {}): WalletConnectActions {
+  return {
+    onSelectNative: vi.fn(),
+    onSelectDiscoveredWallet: vi.fn(),
+    onConnectDefaultBrowser: vi.fn(),
+    onOpenPhantom: vi.fn(),
+    onOpenSolflare: vi.fn(),
+    onOpenInBrowser: vi.fn(),
+    onGoBack: vi.fn(),
     ...overrides,
   };
 }
@@ -27,13 +45,14 @@ afterEach(() => {
 });
 
 describe('WalletConnectScreen', () => {
-  it('renders loading spinner when platformCapabilities is null', () => {
-    render(<WalletConnectScreen />);
+  it('renders loading state', () => {
+    render(<WalletConnectScreen vm={makeVm({ screenState: 'loading' })} actions={makeActions()} />);
     expect(screen.getByRole('progressbar')).toBeTruthy();
+    expect(screen.getByText('Loading...')).toBeTruthy();
   });
 
-  it('renders title and subtitle', () => {
-    render(<WalletConnectScreen platformCapabilities={makeCaps()} />);
+  it('renders title and subtitle in standard state', () => {
+    render(<WalletConnectScreen vm={makeVm()} actions={makeActions()} />);
     expect(screen.getByText('Protect your Orca positions')).toBeTruthy();
     expect(
       screen.getByText(
@@ -43,79 +62,115 @@ describe('WalletConnectScreen', () => {
   });
 
   it('renders feature bullets', () => {
-    render(<WalletConnectScreen platformCapabilities={makeCaps()} />);
+    render(<WalletConnectScreen vm={makeVm()} actions={makeActions()} />);
     expect(screen.getByText('Read-only by default')).toBeTruthy();
     expect(screen.getByText('Debounced breach logic')).toBeTruthy();
     expect(screen.getByText('Action history')).toBeTruthy();
   });
 
-  it('renders back button when onGoBack is provided', () => {
-    const onGoBack = vi.fn();
-    render(
-      <WalletConnectScreen
-        platformCapabilities={makeCaps()}
-        onGoBack={onGoBack}
-      />,
-    );
+  it('renders back button in standard state', () => {
+    const actions = makeActions();
+    render(<WalletConnectScreen vm={makeVm()} actions={actions} />);
     expect(screen.getByLabelText('Back')).toBeTruthy();
-  });
-
-  it('does not render back button when onGoBack is omitted', () => {
-    render(<WalletConnectScreen platformCapabilities={makeCaps()} />);
-    expect(screen.queryByLabelText('Back')).toBeNull();
   });
 
   it('calls onGoBack when back button is pressed', () => {
     const onGoBack = vi.fn();
-    render(
-      <WalletConnectScreen
-        platformCapabilities={makeCaps()}
-        onGoBack={onGoBack}
-      />,
-    );
+    render(<WalletConnectScreen vm={makeVm()} actions={makeActions({ onGoBack })} />);
     fireEvent.click(screen.getByLabelText('Back'));
     expect(onGoBack).toHaveBeenCalled();
   });
 
   it('renders connecting state', () => {
-    render(
-      <WalletConnectScreen
-        platformCapabilities={makeCaps()}
-        isConnecting
-      />,
-    );
+    render(<WalletConnectScreen vm={makeVm({ isConnecting: true })} actions={makeActions()} />);
     expect(screen.getByText('Connecting...')).toBeTruthy();
   });
 
-  it('renders wallet options when capabilities allow', () => {
+  it('renders native wallet button when available', () => {
     render(
       <WalletConnectScreen
-        platformCapabilities={makeCaps({ browserWalletAvailable: true })}
+        vm={makeVm({ nativeWalletAvailable: true })}
+        actions={makeActions()}
+      />,
+    );
+    expect(screen.getByText('Connect Mobile Wallet')).toBeTruthy();
+  });
+
+  it('calls onSelectNative when native wallet button is pressed', () => {
+    const onSelectNative = vi.fn();
+    render(
+      <WalletConnectScreen
+        vm={makeVm({ nativeWalletAvailable: true })}
+        actions={makeActions({ onSelectNative })}
+      />,
+    );
+    fireEvent.click(screen.getByText('Connect Mobile Wallet'));
+    expect(onSelectNative).toHaveBeenCalled();
+  });
+
+  it('renders discovery indicator when discovering', () => {
+    render(
+      <WalletConnectScreen
+        vm={makeVm({ discovery: 'discovering' })}
+        actions={makeActions()}
+      />,
+    );
+    expect(screen.getByText('Detecting browser wallets...')).toBeTruthy();
+  });
+
+  it('renders discovered wallets', () => {
+    render(
+      <WalletConnectScreen
+        vm={makeVm({
+          discovery: 'ready',
+          discoveredWallets: [
+            { id: 'phantom', name: 'Phantom', icon: null },
+          ],
+        })}
+        actions={makeActions()}
+      />,
+    );
+    expect(screen.getByText('Phantom')).toBeTruthy();
+  });
+
+  it('calls onSelectDiscoveredWallet when a discovered wallet is pressed', () => {
+    const onSelectDiscoveredWallet = vi.fn();
+    render(
+      <WalletConnectScreen
+        vm={makeVm({
+          discovery: 'ready',
+          discoveredWallets: [
+            { id: 'phantom', name: 'Phantom', icon: null },
+          ],
+        })}
+        actions={makeActions({ onSelectDiscoveredWallet })}
+      />,
+    );
+    fireEvent.click(screen.getByText('Phantom'));
+    expect(onSelectDiscoveredWallet).toHaveBeenCalledWith('phantom');
+  });
+
+  it('renders fallback browser wallet button on discovery timeout', () => {
+    render(
+      <WalletConnectScreen
+        vm={makeVm({ discovery: 'timed-out' })}
+        actions={makeActions()}
       />,
     );
     expect(screen.getByText('Connect Browser Wallet')).toBeTruthy();
   });
 
-  it('calls onSelectWallet when a wallet option is pressed', () => {
-    const onSelectWallet = vi.fn();
-    render(
-      <WalletConnectScreen
-        platformCapabilities={makeCaps({
-          browserWalletAvailable: true,
-          nativeWalletAvailable: true,
-        })}
-        onSelectWallet={onSelectWallet}
-      />,
-    );
-    fireEvent.click(screen.getByText('Connect Browser Wallet'));
-    expect(onSelectWallet).toHaveBeenCalledWith('browser');
-  });
-
   it('renders outcome banner on error', () => {
     render(
       <WalletConnectScreen
-        platformCapabilities={makeCaps()}
-        connectionOutcome={{ kind: 'failed', reason: 'timeout' }}
+        vm={makeVm({
+          outcomeDisplay: {
+            title: 'Connection Failed',
+            detail: 'Could not connect to wallet: timeout. Please try again.',
+            severity: 'error',
+          },
+        })}
+        actions={makeActions()}
       />,
     );
     expect(screen.getByText('Connection Failed')).toBeTruthy();
@@ -125,39 +180,73 @@ describe('WalletConnectScreen', () => {
   it('renders outcome banner on success', () => {
     render(
       <WalletConnectScreen
-        platformCapabilities={makeCaps()}
-        connectionOutcome={{ kind: 'connected' }}
+        vm={makeVm({
+          outcomeDisplay: {
+            title: 'Wallet Connected',
+            detail: 'Your wallet is connected.',
+            severity: 'success',
+          },
+        })}
+        actions={makeActions()}
       />,
     );
     expect(screen.getByText('Wallet Connected')).toBeTruthy();
   });
 
-  it('renders outcome banner for cancelled connection', () => {
+  it('renders platform notice when set', () => {
     render(
       <WalletConnectScreen
-        platformCapabilities={makeCaps()}
-        connectionOutcome={{ kind: 'cancelled' }}
-      />,
-    );
-    expect(screen.getByText('Connection Cancelled')).toBeTruthy();
-  });
-
-  it('renders outcome banner for interrupted connection', () => {
-    render(
-      <WalletConnectScreen
-        platformCapabilities={makeCaps()}
-        connectionOutcome={{ kind: 'interrupted' }}
-      />,
-    );
-    expect(screen.getByText('Connection Interrupted')).toBeTruthy();
-  });
-
-  it('renders platform notice when no wallet is available', () => {
-    render(
-      <WalletConnectScreen
-        platformCapabilities={makeCaps()}
+        vm={makeVm({
+          platformNotice: {
+            message: 'No supported wallet detected on this device.',
+            severity: 'error',
+          },
+        })}
+        actions={makeActions()}
       />,
     );
     expect(screen.getByText(/No supported wallet/)).toBeTruthy();
+  });
+
+  it('renders social webview state', () => {
+    render(
+      <WalletConnectScreen
+        vm={makeVm({ screenState: 'social-webview', socialEscapeAttempted: false })}
+        actions={makeActions()}
+      />,
+    );
+    expect(screen.getByText('Social app browsers block wallet extensions.')).toBeTruthy();
+    expect(screen.getByText('Open in Browser')).toBeTruthy();
+    expect(screen.getByText('Open in Phantom')).toBeTruthy();
+    expect(screen.getByText('Open in Solflare')).toBeTruthy();
+  });
+
+  it('renders wallet fallback with deep links', () => {
+    render(
+      <WalletConnectScreen
+        vm={makeVm({ fallback: 'wallet-fallback' })}
+        actions={makeActions()}
+      />,
+    );
+    expect(screen.getByText('No wallet extension detected in this browser.')).toBeTruthy();
+  });
+
+  it('renders desktop no-wallet fallback', () => {
+    render(
+      <WalletConnectScreen
+        vm={makeVm({ fallback: 'desktop-no-wallet' })}
+        actions={makeActions()}
+      />,
+    );
+    expect(screen.getByText('No wallet extension detected.')).toBeTruthy();
+  });
+
+  it('renders Go Back button at bottom', () => {
+    const onGoBack = vi.fn();
+    render(<WalletConnectScreen vm={makeVm()} actions={makeActions({ onGoBack })} />);
+    const goBackButtons = screen.getAllByText('Go Back');
+    const lastButton = goBackButtons[goBackButtons.length - 1]!;
+    fireEvent.click(lastButton);
+    expect(onGoBack).toHaveBeenCalled();
   });
 });

--- a/packages/ui/src/screens/WalletConnectScreen.test.tsx
+++ b/packages/ui/src/screens/WalletConnectScreen.test.tsx
@@ -222,6 +222,20 @@ describe('WalletConnectScreen', () => {
     expect(screen.getByText('Open in Solflare')).toBeTruthy();
   });
 
+  it('shows outcome banner in social-webview state', () => {
+    render(
+      <WalletConnectScreen
+        vm={makeVm({
+          screenState: 'social-webview',
+          outcomeDisplay: { title: 'Connection Failed', detail: 'Capability probe failed', severity: 'error' },
+        })}
+        actions={makeActions()}
+      />,
+    );
+    expect(screen.getByText('Connection Failed')).toBeTruthy();
+    expect(screen.getByText('Social app browsers block wallet extensions.')).toBeTruthy();
+  });
+
   it('renders wallet fallback with deep links', () => {
     render(
       <WalletConnectScreen

--- a/packages/ui/src/screens/WalletConnectScreen.tsx
+++ b/packages/ui/src/screens/WalletConnectScreen.tsx
@@ -9,17 +9,13 @@ import {
   StyleSheet,
 } from 'react-native';
 import { colors, typography } from '../design-system/index.js';
-import { buildWalletConnectViewModel } from '../view-models/WalletConnectionViewModel.js';
+import type { WalletConnectViewModel } from '../view-models/WalletConnectionViewModel.js';
+import type { WalletConnectActions, DiscoveredWallet } from '../components/WalletConnectionUtils.js';
 import { Icon } from '../components/Icon.js';
-import type { PlatformCapabilities } from '../components/DegradedCapabilityBannerUtils.js';
-import type { ConnectionOutcome, WalletOptionKind } from '../components/WalletConnectionUtils.js';
 
 type Props = {
-  platformCapabilities?: PlatformCapabilities | null;
-  connectionOutcome?: ConnectionOutcome | null;
-  isConnecting?: boolean;
-  onSelectWallet?: (kind: WalletOptionKind) => void;
-  onGoBack?: () => void;
+  vm: WalletConnectViewModel;
+  actions: WalletConnectActions;
 };
 
 function HeroAnimation() {
@@ -102,38 +98,83 @@ function FeatureRow({ title, description }: { title: string; description: string
   );
 }
 
-export function WalletConnectScreen({
-  platformCapabilities,
-  connectionOutcome,
-  isConnecting,
-  onSelectWallet,
-  onGoBack,
-}: Props): JSX.Element {
-  if (!platformCapabilities) {
-    return (
-      <View style={styles.loadingContainer}>
-        <ActivityIndicator color={colors.safe} />
-      </View>
-    );
+function severityBorderColor(severity: string) {
+  switch (severity) {
+    case 'error': return colors.breachAccent;
+    case 'warning': return colors.warn;
+    case 'success': return colors.safe;
+    default: return colors.border;
   }
+}
 
-  const vm = buildWalletConnectViewModel({
-    capabilities: platformCapabilities,
-    connectionOutcome: connectionOutcome ?? null,
-    isConnecting: isConnecting ?? false,
-  });
+function severityTextColor(severity: string) {
+  switch (severity) {
+    case 'error': return colors.breachAccent;
+    case 'warning': return colors.warn;
+    case 'success': return colors.safe;
+    default: return colors.textPrimary;
+  }
+}
 
+function renderSocialWebview(vm: WalletConnectViewModel, actions: WalletConnectActions) {
+  return (
+    <View style={styles.container}>
+      <View style={styles.contentContainer}>
+        <View style={styles.socialWarningBanner}>
+          <Text style={styles.socialWarningTitle}>
+            Social app browsers block wallet extensions.
+          </Text>
+          <Text style={styles.socialWarningText}>
+            Open this page in Safari or Chrome to connect your wallet.
+          </Text>
+        </View>
+
+        <TouchableOpacity
+          onPress={actions.onOpenInBrowser}
+          disabled={vm.socialEscapeAttempted}
+          style={[
+            styles.walletOptionButton,
+            { maxWidth: 320, width: '100%' },
+            vm.socialEscapeAttempted && { opacity: 0.4 },
+          ]}
+        >
+          <Text style={styles.walletOptionLabel}>Open in Browser</Text>
+        </TouchableOpacity>
+
+        <Text style={styles.deepLinkLabel}>Or open in a wallet browser:</Text>
+
+        <TouchableOpacity
+          onPress={actions.onOpenPhantom}
+          style={styles.deepLinkButton}
+        >
+          <Text style={{ color: '#ab9ff2', fontSize: 14, fontWeight: '600' }}>
+            Open in Phantom
+          </Text>
+        </TouchableOpacity>
+
+        <TouchableOpacity
+          onPress={actions.onOpenSolflare}
+          style={styles.deepLinkButton}
+        >
+          <Text style={{ color: '#fc8748', fontSize: 14, fontWeight: '600' }}>
+            Open in Solflare
+          </Text>
+        </TouchableOpacity>
+      </View>
+    </View>
+  );
+}
+
+function renderStandard(vm: WalletConnectViewModel, actions: WalletConnectActions) {
   return (
     <View style={styles.container}>
       <ScrollView
         style={styles.scrollView}
         contentContainerStyle={styles.contentContainer}
       >
-        {onGoBack ? (
-          <TouchableOpacity onPress={onGoBack} style={styles.backButton} accessibilityLabel="Back">
-            <Icon name="chevronLeft" size={20} color={colors.textBody} />
-          </TouchableOpacity>
-        ) : null}
+        <TouchableOpacity onPress={actions.onGoBack} style={styles.backButton} accessibilityLabel="Back">
+          <Icon name="chevronLeft" size={20} color={colors.textBody} />
+        </TouchableOpacity>
 
         <HeroAnimation />
 
@@ -146,31 +187,13 @@ export function WalletConnectScreen({
           <View
             style={[
               styles.outcomeBanner,
-              {
-                borderColor:
-                  vm.outcomeDisplay.severity === 'error'
-                    ? colors.breachAccent
-                    : vm.outcomeDisplay.severity === 'warning'
-                      ? colors.warn
-                      : vm.outcomeDisplay.severity === 'success'
-                        ? colors.safe
-                        : colors.border,
-              },
+              { borderColor: severityBorderColor(vm.outcomeDisplay.severity) },
             ]}
           >
             <Text
               style={[
                 styles.outcomeTitle,
-                {
-                  color:
-                    vm.outcomeDisplay.severity === 'error'
-                      ? colors.breachAccent
-                      : vm.outcomeDisplay.severity === 'warning'
-                        ? colors.warn
-                        : vm.outcomeDisplay.severity === 'success'
-                          ? colors.safe
-                          : colors.textPrimary,
-                },
+                { color: severityTextColor(vm.outcomeDisplay.severity) },
               ]}
             >
               {vm.outcomeDisplay.title}
@@ -185,27 +208,100 @@ export function WalletConnectScreen({
           <View
             style={[
               styles.outcomeBanner,
-              {
-                borderColor:
-                  vm.platformNotice.severity === 'warning'
-                    ? colors.warn
-                    : colors.breachAccent,
-              },
+              { borderColor: vm.platformNotice.severity === 'warning' ? colors.warn : colors.breachAccent },
             ]}
           >
             <Text
               style={[
                 styles.outcomeTitle,
-                {
-                  color:
-                    vm.platformNotice.severity === 'warning'
-                      ? colors.warn
-                      : colors.breachAccent,
-                },
+                { color: vm.platformNotice.severity === 'warning' ? colors.warn : colors.breachAccent },
               ]}
             >
               {vm.platformNotice.message}
             </Text>
+          </View>
+        ) : null}
+
+        {vm.nativeWalletAvailable && !vm.isConnecting ? (
+          <TouchableOpacity
+            onPress={actions.onSelectNative}
+            style={styles.walletOptionButton}
+          >
+            <Icon name="wallet" size={20} color={colors.textPrimary} />
+            <View style={styles.walletOptionText}>
+              <Text style={styles.walletOptionLabel}>Connect Mobile Wallet</Text>
+              <Text style={styles.walletOptionDescription}>
+                Sign transactions with your mobile wallet app.
+              </Text>
+            </View>
+          </TouchableOpacity>
+        ) : null}
+
+        {!vm.isConnecting && vm.discovery === 'discovering' ? (
+          <View style={styles.discoveryContainer}>
+            <ActivityIndicator size="small" color={colors.safe} />
+            <Text style={styles.discoveryText}>Detecting browser wallets...</Text>
+          </View>
+        ) : null}
+
+        {!vm.isConnecting && vm.discovery === 'ready' && vm.discoveredWallets.length > 0
+          ? vm.discoveredWallets.map((wallet) => (
+              <TouchableOpacity
+                key={wallet.id}
+                onPress={() => actions.onSelectDiscoveredWallet(wallet.id)}
+                style={styles.discoveredWalletButton}
+              >
+                <Icon name="wallet" size={20} color={colors.textPrimary} />
+                <Text style={styles.walletOptionLabel}>{wallet.name}</Text>
+              </TouchableOpacity>
+            ))
+          : null}
+
+        {!vm.isConnecting && vm.discovery === 'timed-out' ? (
+          <TouchableOpacity
+            onPress={actions.onConnectDefaultBrowser}
+            style={styles.walletOptionButton}
+          >
+            <Icon name="wallet" size={20} color={colors.textPrimary} />
+            <View style={styles.walletOptionText}>
+              <Text style={styles.walletOptionLabel}>Connect Browser Wallet</Text>
+              <Text style={styles.walletOptionDescription}>
+                Sign transactions with your browser wallet extension.
+              </Text>
+            </View>
+          </TouchableOpacity>
+        ) : null}
+
+        {!vm.isConnecting && vm.fallback === 'wallet-fallback' ? (
+          <View style={styles.fallbackContainer}>
+            <View style={[styles.outcomeBanner, { borderColor: colors.warn }]}>
+              <Text style={[styles.outcomeTitle, { color: colors.warn }]}>
+                No wallet extension detected in this browser.
+              </Text>
+            </View>
+            <TouchableOpacity onPress={actions.onOpenPhantom} style={styles.deepLinkButton}>
+              <Text style={{ color: '#ab9ff2', fontSize: 14, fontWeight: '600' }}>
+                Open in Phantom
+              </Text>
+            </TouchableOpacity>
+            <TouchableOpacity onPress={actions.onOpenSolflare} style={styles.deepLinkButton}>
+              <Text style={{ color: '#fc8748', fontSize: 14, fontWeight: '600' }}>
+                Open in Solflare
+              </Text>
+            </TouchableOpacity>
+          </View>
+        ) : null}
+
+        {!vm.isConnecting && vm.fallback === 'desktop-no-wallet' ? (
+          <View style={styles.fallbackContainer}>
+            <View style={[styles.outcomeBanner, { borderColor: colors.warn }]}>
+              <Text style={[styles.outcomeTitle, { color: colors.warn }]}>
+                No wallet extension detected.
+              </Text>
+              <Text style={styles.outcomeDetail}>
+                Install a Solana wallet extension like Phantom or Solflare, then refresh this page.
+              </Text>
+            </View>
           </View>
         ) : null}
 
@@ -214,34 +310,36 @@ export function WalletConnectScreen({
             <ActivityIndicator size="large" color={colors.safe} />
             <Text style={styles.connectingText}>Connecting...</Text>
           </View>
-        ) : (
-          <View style={styles.walletOptions}>
-            {vm.walletOptions.map((option) => (
-              <TouchableOpacity
-                key={option.kind}
-                onPress={() => onSelectWallet?.(option.kind)}
-                style={styles.walletOptionButton}
-              >
-                <Icon name="wallet" size={20} color={colors.textPrimary} />
-                <View style={styles.walletOptionText}>
-                  <Text style={styles.walletOptionLabel}>{option.label}</Text>
-                  <Text style={styles.walletOptionDescription}>
-                    {option.description}
-                  </Text>
-                </View>
-              </TouchableOpacity>
-            ))}
-          </View>
-        )}
+        ) : null}
 
         <View style={styles.featuresContainer}>
           {features.map((f) => (
             <FeatureRow key={f.title} title={f.title} description={f.description} />
           ))}
         </View>
+
+        <TouchableOpacity onPress={actions.onGoBack} style={{ marginTop: 16, padding: 12 }}>
+          <Text style={styles.goBackText}>Go Back</Text>
+        </TouchableOpacity>
       </ScrollView>
     </View>
   );
+}
+
+export function WalletConnectScreen({ vm, actions }: Props): JSX.Element {
+  switch (vm.screenState) {
+    case 'loading':
+      return (
+        <View style={styles.loadingContainer}>
+          <ActivityIndicator color={colors.safe} />
+          <Text style={{ color: colors.textBody }}>Loading...</Text>
+        </View>
+      );
+    case 'social-webview':
+      return renderSocialWebview(vm, actions);
+    case 'standard':
+      return renderStandard(vm, actions);
+  }
 }
 
 const styles = StyleSheet.create({
@@ -411,5 +509,77 @@ const styles = StyleSheet.create({
   featureDescription: {
     fontSize: 12,
     color: colors.textFaint,
+  },
+  socialWarningBanner: {
+    width: '100%',
+    maxWidth: 320,
+    padding: 12,
+    backgroundColor: '#422006',
+    borderRadius: 8,
+    borderWidth: 1,
+    borderColor: colors.warn,
+    marginBottom: 16,
+  },
+  socialWarningTitle: {
+    color: colors.warn,
+    fontSize: 14,
+    fontWeight: '600',
+  },
+  socialWarningText: {
+    color: colors.textBody,
+    fontSize: 13,
+    marginTop: 4,
+  },
+  deepLinkButton: {
+    padding: 12,
+    backgroundColor: colors.card,
+    borderRadius: 8,
+    marginBottom: 8,
+    borderWidth: 1,
+    borderColor: colors.border,
+  },
+  deepLinkLabel: {
+    color: colors.textFaint,
+    fontSize: 13,
+    marginBottom: 8,
+  },
+  discoveryContainer: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 12,
+    width: '100%',
+    maxWidth: 320,
+    padding: 16,
+    backgroundColor: colors.card,
+    borderRadius: 8,
+    marginBottom: 12,
+    borderWidth: 1,
+    borderColor: colors.border,
+  },
+  discoveryText: {
+    color: colors.textBody,
+    fontSize: 14,
+  },
+  discoveredWalletButton: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 12,
+    width: '100%',
+    maxWidth: 320,
+    padding: 16,
+    backgroundColor: colors.card,
+    borderRadius: 8,
+    marginBottom: 12,
+    borderWidth: 1,
+    borderColor: colors.border,
+  },
+  fallbackContainer: {
+    width: '100%',
+    maxWidth: 320,
+    marginTop: 16,
+  },
+  goBackText: {
+    color: colors.textFaint,
+    fontSize: 14,
   },
 });

--- a/packages/ui/src/screens/WalletConnectScreen.tsx
+++ b/packages/ui/src/screens/WalletConnectScreen.tsx
@@ -10,7 +10,7 @@ import {
 } from 'react-native';
 import { colors, typography } from '../design-system/index.js';
 import type { WalletConnectViewModel } from '../view-models/WalletConnectionViewModel.js';
-import type { WalletConnectActions, DiscoveredWallet } from '../components/WalletConnectionUtils.js';
+import type { WalletConnectActions } from '../components/WalletConnectionUtils.js';
 import { Icon } from '../components/Icon.js';
 
 type Props = {

--- a/packages/ui/src/screens/WalletConnectScreen.tsx
+++ b/packages/ui/src/screens/WalletConnectScreen.tsx
@@ -6,6 +6,7 @@ import {
   ActivityIndicator,
   ScrollView,
   Animated,
+  Image,
   StyleSheet,
 } from 'react-native';
 import { colors, typography } from '../design-system/index.js';
@@ -272,7 +273,11 @@ function renderStandard(vm: WalletConnectViewModel, actions: WalletConnectAction
                 onPress={() => actions.onSelectDiscoveredWallet(wallet.id)}
                 style={styles.discoveredWalletButton}
               >
-                <Icon name="wallet" size={20} color={colors.textPrimary} />
+                {wallet.icon ? (
+                  <Image source={{ uri: wallet.icon }} style={styles.walletIcon} />
+                ) : (
+                  <Icon name="wallet" size={20} color={colors.textPrimary} />
+                )}
                 <Text style={styles.walletOptionLabel}>{wallet.name}</Text>
               </TouchableOpacity>
             ))
@@ -593,6 +598,10 @@ const styles = StyleSheet.create({
     marginBottom: 12,
     borderWidth: 1,
     borderColor: colors.border,
+  },
+  walletIcon: {
+    width: 24,
+    height: 24,
   },
   fallbackContainer: {
     width: '100%',

--- a/packages/ui/src/screens/WalletConnectScreen.tsx
+++ b/packages/ui/src/screens/WalletConnectScreen.tsx
@@ -121,6 +121,10 @@ function renderSocialWebview(vm: WalletConnectViewModel, actions: WalletConnectA
   return (
     <View style={styles.container}>
       <View style={styles.contentContainer}>
+        <TouchableOpacity onPress={actions.onGoBack} style={styles.backButton} accessibilityLabel="Back">
+          <Icon name="chevronLeft" size={20} color={colors.textBody} />
+        </TouchableOpacity>
+
         {vm.outcomeDisplay ? (
           <View
             style={[
@@ -181,6 +185,10 @@ function renderSocialWebview(vm: WalletConnectViewModel, actions: WalletConnectA
           <Text style={{ color: '#fc8748', fontSize: 14, fontWeight: '600' }}>
             Open in Solflare
           </Text>
+        </TouchableOpacity>
+
+        <TouchableOpacity onPress={actions.onGoBack} style={{ marginTop: 16, padding: 12 }}>
+          <Text style={styles.goBackText}>Go Back</Text>
         </TouchableOpacity>
       </View>
     </View>

--- a/packages/ui/src/screens/WalletConnectScreen.tsx
+++ b/packages/ui/src/screens/WalletConnectScreen.tsx
@@ -120,6 +120,27 @@ function renderSocialWebview(vm: WalletConnectViewModel, actions: WalletConnectA
   return (
     <View style={styles.container}>
       <View style={styles.contentContainer}>
+        {vm.outcomeDisplay ? (
+          <View
+            style={[
+              styles.outcomeBanner,
+              { borderColor: severityBorderColor(vm.outcomeDisplay.severity) },
+            ]}
+          >
+            <Text
+              style={[
+                styles.outcomeTitle,
+                { color: severityTextColor(vm.outcomeDisplay.severity) },
+              ]}
+            >
+              {vm.outcomeDisplay.title}
+            </Text>
+            {vm.outcomeDisplay.detail ? (
+              <Text style={styles.outcomeDetail}>{vm.outcomeDisplay.detail}</Text>
+            ) : null}
+          </View>
+        ) : null}
+
         <View style={styles.socialWarningBanner}>
           <Text style={styles.socialWarningTitle}>
             Social app browsers block wallet extensions.

--- a/packages/ui/src/screens/WalletConnectScreen.tsx
+++ b/packages/ui/src/screens/WalletConnectScreen.tsx
@@ -237,14 +237,14 @@ function renderStandard(vm: WalletConnectViewModel, actions: WalletConnectAction
           </TouchableOpacity>
         ) : null}
 
-        {!vm.isConnecting && vm.discovery === 'discovering' ? (
+        {!vm.isConnecting && vm.browserWalletAvailable && vm.discovery === 'discovering' ? (
           <View style={styles.discoveryContainer}>
             <ActivityIndicator size="small" color={colors.safe} />
             <Text style={styles.discoveryText}>Detecting browser wallets...</Text>
           </View>
         ) : null}
 
-        {!vm.isConnecting && vm.discovery === 'ready' && vm.discoveredWallets.length > 0
+        {!vm.isConnecting && vm.browserWalletAvailable && vm.discovery === 'ready' && vm.discoveredWallets.length > 0
           ? vm.discoveredWallets.map((wallet) => (
               <TouchableOpacity
                 key={wallet.id}
@@ -257,7 +257,7 @@ function renderStandard(vm: WalletConnectViewModel, actions: WalletConnectAction
             ))
           : null}
 
-        {!vm.isConnecting && vm.discovery === 'timed-out' ? (
+        {!vm.isConnecting && vm.browserWalletAvailable && vm.discovery === 'timed-out' ? (
           <TouchableOpacity
             onPress={actions.onConnectDefaultBrowser}
             style={styles.walletOptionButton}

--- a/packages/ui/src/view-models/WalletConnectionViewModel.test.ts
+++ b/packages/ui/src/view-models/WalletConnectionViewModel.test.ts
@@ -141,6 +141,29 @@ describe('buildWalletConnectViewModel (extended)', () => {
     });
     expect(vm.isConnecting).toBe(true);
   });
+
+  it('passes through browserWalletAvailable from capabilities', () => {
+    const vm = buildWalletConnectViewModel({
+      ...baseExtendedParams,
+      platformCapabilities: makeCaps({ browserWalletAvailable: true }),
+      isConnecting: false,
+      connectionOutcome: null,
+    });
+    expect(vm.browserWalletAvailable).toBe(true);
+  });
+
+  it('defaults browserWalletAvailable to false when capabilities is null', () => {
+    const vm = buildWalletConnectViewModel({
+      platformCapabilities: null,
+      discovery: 'discovering',
+      discoveredWallets: [],
+      fallback: 'none',
+      socialEscapeAttempted: false,
+      isConnecting: false,
+      connectionOutcome: null,
+    });
+    expect(vm.browserWalletAvailable).toBe(false);
+  });
 });
 
 describe('buildWalletSettingsViewModel', () => {

--- a/packages/ui/src/view-models/WalletConnectionViewModel.test.ts
+++ b/packages/ui/src/view-models/WalletConnectionViewModel.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { buildWalletConnectViewModel, buildWalletSettingsViewModel } from './WalletConnectionViewModel.js';
 import type { PlatformCapabilities } from '../components/DegradedCapabilityBannerUtils.js';
-import type { ConnectionOutcome } from '../components/WalletConnectionUtils.js';
+import type { ConnectionOutcome, DiscoveredWallet } from '../components/WalletConnectionUtils.js';
 
 function makeCaps(overrides: Partial<PlatformCapabilities> = {}): PlatformCapabilities {
   return {
@@ -14,58 +14,130 @@ function makeCaps(overrides: Partial<PlatformCapabilities> = {}): PlatformCapabi
   };
 }
 
-describe('buildWalletConnectViewModel', () => {
-  it('shows native wallet option on React Native mobile', () => {
+const baseExtendedParams = {
+  discovery: 'ready' as const,
+  discoveredWallets: [] as DiscoveredWallet[],
+  fallback: 'none' as const,
+  socialEscapeAttempted: false,
+};
+
+describe('buildWalletConnectViewModel (extended)', () => {
+  it('returns loading screenState when platformCapabilities is null', () => {
     const vm = buildWalletConnectViewModel({
-      capabilities: makeCaps({ nativeWalletAvailable: true, nativePushAvailable: true }),
-      connectionOutcome: null,
+      platformCapabilities: null,
+      discovery: 'discovering',
+      discoveredWallets: [],
+      fallback: 'none',
+      socialEscapeAttempted: false,
       isConnecting: false,
+      connectionOutcome: null,
     });
-    expect(vm.walletOptions).toHaveLength(1);
-    expect(vm.walletOptions[0]!.kind).toBe('native');
+    expect(vm.screenState).toBe('loading');
+  });
+
+  it('returns social-webview screenState when fallback is social-webview', () => {
+    const vm = buildWalletConnectViewModel({
+      platformCapabilities: makeCaps(),
+      discovery: 'timed-out',
+      discoveredWallets: [],
+      fallback: 'social-webview',
+      socialEscapeAttempted: false,
+      isConnecting: false,
+      connectionOutcome: null,
+    });
+    expect(vm.screenState).toBe('social-webview');
+  });
+
+  it('returns standard screenState for normal wallet flow', () => {
+    const vm = buildWalletConnectViewModel({
+      platformCapabilities: makeCaps({ nativeWalletAvailable: true }),
+      discovery: 'ready',
+      discoveredWallets: [{ id: 'phantom', name: 'Phantom', icon: 'https://example.com/icon.png' }],
+      fallback: 'none',
+      socialEscapeAttempted: false,
+      isConnecting: false,
+      connectionOutcome: null,
+    });
+    expect(vm.screenState).toBe('standard');
+    expect(vm.nativeWalletAvailable).toBe(true);
+    expect(vm.discoveredWallets).toHaveLength(1);
+    expect(vm.discovery).toBe('ready');
+  });
+
+  it('passes through discovery and fallback states', () => {
+    const vm = buildWalletConnectViewModel({
+      platformCapabilities: makeCaps(),
+      discovery: 'discovering',
+      discoveredWallets: [],
+      fallback: 'desktop-no-wallet',
+      socialEscapeAttempted: false,
+      isConnecting: false,
+      connectionOutcome: null,
+    });
+    expect(vm.discovery).toBe('discovering');
+    expect(vm.fallback).toBe('desktop-no-wallet');
+  });
+
+  it('passes through socialEscapeAttempted', () => {
+    const vm = buildWalletConnectViewModel({
+      platformCapabilities: makeCaps(),
+      discovery: 'timed-out',
+      discoveredWallets: [],
+      fallback: 'social-webview',
+      socialEscapeAttempted: true,
+      isConnecting: false,
+      connectionOutcome: null,
+    });
+    expect(vm.socialEscapeAttempted).toBe(true);
+  });
+
+  it('maps connection outcome to outcome display', () => {
+    const vm = buildWalletConnectViewModel({
+      platformCapabilities: makeCaps({ nativeWalletAvailable: true }),
+      discovery: 'ready',
+      discoveredWallets: [],
+      fallback: 'none',
+      socialEscapeAttempted: false,
+      isConnecting: false,
+      connectionOutcome: { kind: 'failed', reason: 'timeout' },
+    });
+    expect(vm.outcomeDisplay).not.toBeNull();
+    expect(vm.outcomeDisplay!.severity).toBe('error');
+  });
+
+  it('computes platform notice', () => {
+    const vm = buildWalletConnectViewModel({
+      platformCapabilities: makeCaps({ isMobileWeb: true }),
+      discovery: 'timed-out',
+      discoveredWallets: [],
+      fallback: 'none',
+      socialEscapeAttempted: false,
+      isConnecting: false,
+      connectionOutcome: null,
+    });
+    expect(vm.platformNotice).not.toBeNull();
+    expect(vm.platformNotice!.message).toContain('mobile web');
+  });
+
+  it('shows native wallet as available when capability is set', () => {
+    const vm = buildWalletConnectViewModel({
+      ...baseExtendedParams,
+      platformCapabilities: makeCaps({ nativeWalletAvailable: true, nativePushAvailable: true }),
+      isConnecting: false,
+      connectionOutcome: null,
+    });
+    expect(vm.nativeWalletAvailable).toBe(true);
     expect(vm.platformNotice).toBeNull();
     expect(vm.outcomeDisplay).toBeNull();
     expect(vm.isConnecting).toBe(false);
   });
 
-  it('shows browser wallet option on desktop PWA', () => {
-    const vm = buildWalletConnectViewModel({
-      capabilities: makeCaps({ browserWalletAvailable: true, browserNotificationAvailable: true }),
-      connectionOutcome: null,
-      isConnecting: false,
-    });
-    expect(vm.walletOptions).toHaveLength(1);
-    expect(vm.walletOptions[0]!.kind).toBe('browser');
-  });
-
-  it('shows degraded notice for mobile web', () => {
-    const vm = buildWalletConnectViewModel({
-      capabilities: makeCaps({ isMobileWeb: true }),
-      connectionOutcome: null,
-      isConnecting: false,
-    });
-    expect(vm.walletOptions).toHaveLength(0);
-    expect(vm.platformNotice).not.toBeNull();
-    expect(vm.platformNotice!.message).toContain('mobile web');
-  });
-
-  it('includes connection outcome display when outcome provided', () => {
-    const outcome: ConnectionOutcome = { kind: 'failed', reason: 'timeout' };
-    const vm = buildWalletConnectViewModel({
-      capabilities: makeCaps({ nativeWalletAvailable: true }),
-      connectionOutcome: outcome,
-      isConnecting: false,
-    });
-    expect(vm.outcomeDisplay).not.toBeNull();
-    expect(vm.outcomeDisplay!.severity).toBe('error');
-    expect(vm.outcomeDisplay!.title).toBe('Connection Failed');
-  });
-
   it('passes through isConnecting state', () => {
     const vm = buildWalletConnectViewModel({
-      capabilities: makeCaps({ nativeWalletAvailable: true }),
-      connectionOutcome: null,
+      ...baseExtendedParams,
+      platformCapabilities: makeCaps({ nativeWalletAvailable: true }),
       isConnecting: true,
+      connectionOutcome: null,
     });
     expect(vm.isConnecting).toBe(true);
   });

--- a/packages/ui/src/view-models/WalletConnectionViewModel.test.ts
+++ b/packages/ui/src/view-models/WalletConnectionViewModel.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { buildWalletConnectViewModel, buildWalletSettingsViewModel } from './WalletConnectionViewModel.js';
 import type { PlatformCapabilities } from '../components/DegradedCapabilityBannerUtils.js';
-import type { ConnectionOutcome, DiscoveredWallet } from '../components/WalletConnectionUtils.js';
+import type { DiscoveredWallet } from '../components/WalletConnectionUtils.js';
 
 function makeCaps(overrides: Partial<PlatformCapabilities> = {}): PlatformCapabilities {
   return {

--- a/packages/ui/src/view-models/WalletConnectionViewModel.ts
+++ b/packages/ui/src/view-models/WalletConnectionViewModel.ts
@@ -20,6 +20,7 @@ import type {
 export type WalletConnectViewModel = {
   screenState: 'loading' | 'social-webview' | 'standard';
   nativeWalletAvailable: boolean;
+  browserWalletAvailable: boolean;
   discovery: WalletDiscoveryState;
   discoveredWallets: DiscoveredWallet[];
   fallback: FallbackState;
@@ -54,6 +55,7 @@ export function buildWalletConnectViewModel(params: {
   return {
     screenState,
     nativeWalletAvailable: caps.nativeWalletAvailable,
+    browserWalletAvailable: caps.browserWalletAvailable,
     discovery: params.discovery,
     discoveredWallets: params.discoveredWallets,
     fallback: params.fallback,

--- a/packages/ui/src/view-models/WalletConnectionViewModel.ts
+++ b/packages/ui/src/view-models/WalletConnectionViewModel.ts
@@ -1,40 +1,68 @@
 import type { PlatformCapabilities } from '../components/DegradedCapabilityBannerUtils.js';
 import {
-  buildWalletOptions,
   getConnectionOutcomeDisplay,
   buildConnectedWalletSummary,
   buildPlatformNotice,
 } from '../components/WalletConnectionUtils.js';
 import type {
-  WalletOption,
   ConnectionOutcome,
   ConnectionOutcomeDisplay,
   PlatformNotice,
   ConnectedWalletSummary,
   WalletOptionKind,
+  FallbackState,
+  WalletDiscoveryState,
+  DiscoveredWallet,
 } from '../components/WalletConnectionUtils.js';
 
 // --- Wallet Connect Screen ViewModel ---
 
 export type WalletConnectViewModel = {
-  walletOptions: WalletOption[];
-  platformNotice: PlatformNotice | null;
-  outcomeDisplay: ConnectionOutcomeDisplay | null;
+  screenState: 'loading' | 'social-webview' | 'standard';
+  nativeWalletAvailable: boolean;
+  discovery: WalletDiscoveryState;
+  discoveredWallets: DiscoveredWallet[];
+  fallback: FallbackState;
+  socialEscapeAttempted: boolean;
   isConnecting: boolean;
+  outcomeDisplay: ConnectionOutcomeDisplay | null;
+  platformNotice: PlatformNotice | null;
 };
 
 export function buildWalletConnectViewModel(params: {
-  capabilities: PlatformCapabilities;
-  connectionOutcome: ConnectionOutcome | null;
+  platformCapabilities: PlatformCapabilities | null;
+  discovery: WalletDiscoveryState;
+  discoveredWallets: DiscoveredWallet[];
+  fallback: FallbackState;
+  socialEscapeAttempted: boolean;
   isConnecting: boolean;
+  connectionOutcome: ConnectionOutcome | null;
 }): WalletConnectViewModel {
+  const caps = params.platformCapabilities ?? {
+    nativePushAvailable: false,
+    browserNotificationAvailable: false,
+    nativeWalletAvailable: false,
+    browserWalletAvailable: false,
+    isMobileWeb: false,
+  };
+
+  const screenState: WalletConnectViewModel['screenState'] =
+    !params.platformCapabilities ? 'loading'
+    : params.fallback === 'social-webview' ? 'social-webview'
+    : 'standard';
+
   return {
-    walletOptions: buildWalletOptions(params.capabilities),
-    platformNotice: buildPlatformNotice(params.capabilities),
+    screenState,
+    nativeWalletAvailable: caps.nativeWalletAvailable,
+    discovery: params.discovery,
+    discoveredWallets: params.discoveredWallets,
+    fallback: params.fallback,
+    socialEscapeAttempted: params.socialEscapeAttempted,
+    isConnecting: params.isConnecting,
     outcomeDisplay: params.connectionOutcome
       ? getConnectionOutcomeDisplay(params.connectionOutcome)
       : null,
-    isConnecting: params.isConnecting,
+    platformNotice: buildPlatformNotice(caps),
   };
 }
 


### PR DESCRIPTION
## Summary

Extracts all connect screen rendering from `apps/app/app/connect.tsx` into `packages/ui`, replacing the 522-line route file with a thin 187-line orchestrator that wires hooks, builds the view model, and delegates all rendering to `WalletConnectScreen`.

Closes #37

## Problem

`connect.tsx` was a 519-line route file that owned wallet discovery state, fallback detection, deep-link handling, connection outcome rendering, and all connect screen UI — violating the boundary rule that `apps/app` must not own screens or business logic.

## Approach

ViewModel-driven extraction: extend `buildWalletConnectViewModel` to produce a richer view model covering discovery state, fallback state, discovered wallets, and outcome display. The route shell computes platform-dependent state (fallback detection, wallet discovery) and passes it to the screen as pure data.

## Changes

| File | Change |
|------|--------|
| `WalletConnectionUtils.ts` | Add `FallbackState`, `WalletDiscoveryState`, `DiscoveredWallet`, `WalletConnectActions` types |
| `WalletConnectionViewModel.ts` | Replace old flat VM with extended type: `screenState`, `discovery`, `discoveredWallets`, `fallback`, `socialEscapeAttempted`, `outcomeDisplay`, `platformNotice` |
| `WalletConnectionViewModel.test.ts` | Rewrite tests for new builder signature (10 tests) |
| `WalletConnectScreen.tsx` | Full rewrite — renders from `{ vm, actions }` props with 3 screen states (loading/social-webview/standard), discovery states, fallback banners, deep links |
| `WalletConnectScreen.test.tsx` | Full rewrite — 19 component tests covering all states and action callbacks |
| `apps/app/app/connect.tsx` | 522 → 187 lines — thin shell: hooks, VM build, action callbacks, single `<WalletConnectScreen>` render |
| `packages/ui/src/index.ts` | Export new types |

## Verification

- 122/122 UI tests pass
- `pnpm boundaries` — no violations
- `pnpm build` — success
- `pnpm lint` — clean
- `pnpm --filter @clmm/app typecheck` — clean
- No dead `WalletOption`/`buildWalletOptions` imports in apps/app
- No inline JSX rendering in connect.tsx beyond `<WalletConnectScreen>`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Claude_Code-GLM_4-6366f1?logo=claude&logoColor=white)