### PR TITLE
feat(ui): redesign position detail S/R section with chips, tones, and notes

### DIFF
--- a/docs/solutions/database-issues/notification-events-migration-and-deliveredat-fix-2026-04-14.md
+++ b/docs/solutions/database-issues/notification-events-migration-and-deliveredat-fix-2026-04-14.md
@@ -36,8 +36,8 @@ PR #11 introduced a durable notification write path, but the database schema and
 - Recording delivery timing with `clock.now()` measured handler time, not provider delivery time.
 
 ## Solution
-- Add the missing migration and journal entry:
-  - `packages/adapters/drizzle/0006_daffy_malice.sql`
+- Add the missing migration and journal entry. The project later consolidated migrations into a single baseline (`0000_bitter_riptide`); the `notification_events` schema lives in `packages/adapters/src/outbound/storage/schema/notification-events.ts`.
+  - `packages/adapters/drizzle/0000_bitter_riptide.sql` (consolidated baseline)
   - `packages/adapters/drizzle/meta/_journal.json`
 - Preserve the adapter's timestamp in `NotificationDispatchJobHandler`:
 

--- a/docs/solutions/design-patterns/sr-levels-card-redesign-2026-04-26.md
+++ b/docs/solutions/design-patterns/sr-levels-card-redesign-2026-04-26.md
@@ -1,5 +1,5 @@
 ---
-title: "UI Component Extraction and View-Model Restructuring for S/R Levels Display"
+title: "S/R Levels Card Redesign v2: Grouped View-Models, Note Parsing, and Component Extraction"
 date: 2026-04-26
 category: design-patterns
 module: packages/ui
@@ -17,42 +17,216 @@ tags:
   - component-extraction
   - presentation-logic
   - design-system
+  - note-parsing
+  - grouped-levels
 ---
 
-# UI Component Extraction and View-Model Restructuring for S/R Levels Display
+# S/R Levels Card Redesign v2: Grouped View-Models, Note Parsing, and Component Extraction
 
 ## Context
 
-When redesigning the Support & Resistance (S/R) section on the Position Detail screen, the existing implementation was a simple text list with separate "Support" and "Resistance" subsection titles. The new design called for a card-based layout with:
+The Position Detail screen's Support & Resistance (S/R) levels section evolved from a simple flat list (v1) to a clustered card layout (v2). The v1 design used a unified `levels` array with tone computed from live price proximity (`breach` if crossed, `warn` if near, `safe` otherwise) and a simple `note` string per level. The v2 design required:
 
-- Tone-colored chips (`safe` / `warn` / `breach`) for each level
-- Contextual notes (e.g., "Range upper · your position")
-- Unified ascending sort across all levels (supports and resistances intermixed)
-- A freshness header ("AI · MCO · 2h ago")
+- Parsing structured metadata (source, timeframe, bias, setup type, trigger, invalidation) from free-text notes
+- Grouping levels that share identical `(rank, timeframe, notes)` metadata into clusters
+- Explicit tone rules: resistance levels always render as `breach` (red), support levels always as `safe` (green)
+- A separate Market Thesis summary rendered above the clusters
+- A group-based card layout with bias chips, trigger/invalidation labels, and metadata footers
 
-The initial approach rendered everything inline inside `PositionDetailScreen.tsx`, which quickly grew to ~90 lines of JSX and inline styles for this single subsection alone. This violated the repo's established pattern of keeping screens thin and delegating to focused presentational components.
+This guidance captures the v2 pattern: moving note parsing and grouping into the view-model, extracting a new `MarketThesisCard` component, redesigning `SrLevelsCard` to render groups, and keeping the screen component thin.
 
 ## Guidance
 
-### 1. Restructure the View-Model First
+### 1. Parse Unstructured Notes into Structured View-Model Fields
 
-Move all presentation logic into the view-model layer before touching the screen component. The view-model should output data in the exact shape the UI needs.
+Move note parsing into the view-model layer so components receive typed data instead of raw strings.
 
-**Before:**
+**`parseNotes(notes)`**
+
 ```typescript
-export type SrLevelsViewModelBlock = {
-  supportsSorted: Array<{ priceLabel: string; rankLabel?: string }>;
-  resistancesSorted: Array<{ priceLabel: string; rankLabel?: string }>;
-  freshnessLabel: string;
-  isStale: boolean;
+function parseNotes(notes: string) {
+  const sections = notes.split('|').map(s => s.trim());
+  const first = sections[0] ?? '';
+  const sourceMatch = first.match(/^([^,]+),\s*([^\.]+)\.\s*(.+)$/);
+  const source = sourceMatch?.[1]?.trim();
+  const timeframe = sourceMatch?.[2]?.trim();
+  const bias = sourceMatch?.[3]?.trim();
+  const setupType = first.includes('.')
+    ? first.split('.').pop()?.trim()
+    : undefined;
+
+  const trigger = sections
+    .find(s => s.startsWith('Trigger:'))
+    ?.replace('Trigger:', '')
+    .trim();
+  const invalidation = sections
+    .find(s => s.startsWith('Invalidation:'))
+    ?.replace('Invalidation:', '')
+    .trim();
+
+  const note = sections
+    .filter(s => !s.startsWith('Trigger:') && !s.startsWith('Invalidation:'))
+    .slice(1)
+    .join(' | ');
+
+  return { source, timeframe, bias, setupType, trigger, invalidation, note };
+}
+```
+
+**`SrLevelGroupViewModel`**
+
+```typescript
+export type SrLevelGroupViewModel = {
+  levels: SrLevelViewModel[];
+  note: string;
+  source?: string;
+  timeframe?: string;
+  bias?: string;
+  setupType?: string;
+  trigger?: string;
+  invalidation?: string;
 };
 ```
 
-**After:**
+### 2. Group Levels by Shared Metadata
+
+In the view-model builder, cluster levels that share identical `(rank, timeframe, notes)` metadata. Each cluster becomes one `SrLevelGroupViewModel`.
+
+```typescript
+const groups = Object.values(
+  levels.reduce((acc, level) => {
+    const key = `${level.rank}|${level.timeframe}|${level.notes}`;
+    if (!acc[key]) {
+      acc[key] = { levels: [], ...parseNotes(level.notes) };
+    }
+    acc[key].levels.push(level);
+    return acc;
+  }, {} as Record<string, SrLevelGroupViewModel>)
+);
+```
+
+### 3. Override Tone Explicitly by Level Type
+
+Do not derive tone from dynamic price proximity. In v2, tone is fixed by semantic role:
+
+- **Resistance levels:** always `breach` tone (red)
+- **Support levels:** always `safe` tone (green)
+
+Apply this in the view-model builder when mapping domain DTOs to view-models.
+
+### 4. Restructure the Top-Level Block
+
+`SrLevelsViewModelBlock` now carries grouped data and an optional market thesis summary:
+
+```typescript
+export type SrLevelsViewModelBlock = {
+  groups: SrLevelGroupViewModel[];
+  summary?: string;
+};
+```
+
+### 5. Extract Components to Keep the Screen Thin
+
+When a subsection exceeds ~30 lines or mixes presentation logic with rendering, extract dedicated presentational components.
+
+**`MarketThesisCard.tsx`** (NEW)
+
+Renders the `summary` text with an info icon above the S/R card.
+
+```tsx
+export function MarketThesisCard({ summary }: { summary: string }) {
+  return (
+    <View style={styles.container}>
+      <InfoIcon />
+      <Text style={styles.text}>{summary}</Text>
+    </View>
+  );
+}
+```
+
+**`SrLevelsCard.tsx`** (redesigned)
+
+Renders `groups`, not a flat `levels` array. Each group displays:
+- Bias chip (yellow)
+- "RESISTANCE CLUSTER" or "SUPPORT CLUSTER" label
+- Trigger section with red "Trigger" label
+- Invalidation section with green "Invalidation" label
+- Shared note at the bottom of the group
+- Metadata footer: `Source · TF · Setup`
+- Group background: `surfaceRecessed` with border
+
+```tsx
+type Props = {
+  srLevels?: SrLevelsViewModelBlock | undefined;
+};
+
+export function SrLevelsCard({ srLevels }: Props): JSX.Element {
+  if (!srLevels || srLevels.groups.length === 0) {
+    return <Text>No current MCO levels available</Text>;
+  }
+  return (
+    <View>
+      {srLevels.groups.map((group, i) => (
+        <View key={i} style={styles.group}>
+          <BiasChip bias={group.bias} />
+          <ClusterLabel kind={group.levels[0].kind} />
+          {group.trigger && <TriggerLabel text={group.trigger} />}
+          {group.invalidation && (
+            <InvalidationLabel text={group.invalidation} />
+          )}
+          <Text style={styles.note}>{group.note}</Text>
+          <MetaFooter
+            source={group.source}
+            timeframe={group.timeframe}
+            setupType={group.setupType}
+          />
+        </View>
+      ))}
+    </View>
+  );
+}
+```
+
+### 6. Keep the Screen Component an Orchestrator Only
+
+The screen should never transform data or contain inline presentation logic.
+
+```tsx
+// PositionDetailScreen.tsx
+{vm.srLevels ? (
+  <>
+    {vm.srLevels.summary ? (
+      <MarketThesisCard summary={vm.srLevels.summary} />
+    ) : null}
+    <SrLevelsCard srLevels={vm.srLevels} />
+  </>
+) : null}
+```
+
+## Why This Matters
+
+- **Testability:** View-model logic (parsing, grouping, tone assignment) is unit-testable in isolation. Components become pure render functions.
+- **Maintainability:** Screens stay readable. Changes to S/R rendering touch one component, not a 300+ line screen file.
+- **Type safety:** Structured fields (`trigger`, `invalidation`, `bias`) are typed, preventing silent breakage when note formats change.
+- **Separation of concerns:** The screen orchestrates layout order; the view-model shapes data; components render. No layer re-derives what another already computed.
+- **Design fidelity:** Grouped clusters, explicit tone overrides, and parsed metadata let the UI match complex designs without ad-hoc logic in JSX.
+
+## When to Apply
+
+- Redesigning a screen section with complex presentation logic
+- A screen component grows beyond ~30 lines for a single subsection
+- View-model data shape does not match the desired UI layout
+- Presentation logic (sorting, tone computation, note formatting) is mixed with rendering
+- Free-text backend data contains structured metadata that the UI needs to display explicitly
+
+## Examples
+
+### Before (v1 flat levels)
+
 ```typescript
 export type SrLevelViewModel = {
   kind: 'support' | 'resistance';
-  rawPrice: number; // for sorting
+  rawPrice: number;
   priceLabel: string;
   note: string;
   tone: 'safe' | 'warn' | 'breach';
@@ -65,119 +239,52 @@ export type SrLevelsViewModelBlock = {
 };
 ```
 
-Compute in the view-model builder:
-- **Tone** from price proximity and range bounds (`breach` if crossed, `warn` if near bound or within 5%, `safe` otherwise)
-- **Notes** from a fallback hierarchy: DTO `notes` → bound match → `rank` → empty
-- **Sorting** on raw numeric price before formatting
-
-### 2. Extract a Presentational Component
-
-When a screen section exceeds ~30 lines, extract it into a dedicated component in `packages/ui/src/components/`.
-
-**Keep the component focused:**
-- Accept the pre-computed view-model block as a prop
-- Handle both present and absent states
-- Keep tone-to-color mapping inside the component (not in the screen or design system)
-- Use `testID` attributes for testability
+### After (v2 grouped levels with parsed metadata)
 
 ```typescript
-// SrLevelsCard.tsx
-type Props = {
-  srLevels?: SrLevelsViewModelBlock | undefined;
+export type SrLevelGroupViewModel = {
+  levels: SrLevelViewModel[];
+  note: string;
+  source?: string;
+  timeframe?: string;
+  bias?: string;
+  setupType?: string;
+  trigger?: string;
+  invalidation?: string;
 };
 
-export function SrLevelsCard({ srLevels }: Props): JSX.Element {
-  if (!srLevels) {
-    return <Text>No current MCO levels available</Text>;
-  }
-  // render card with chips, prices, notes
-}
+export type SrLevelsViewModelBlock = {
+  groups: SrLevelGroupViewModel[];
+  summary?: string;
+};
 ```
 
-### 3. Keep the Screen Thin
+### Screen: Before and After
 
-The screen component should only orchestrate:
+**Before (v1):**
 
 ```tsx
-// PositionDetailScreen.tsx
 <SrLevelsCard srLevels={vm.srLevels} />
 ```
 
-No inline styles, no tone logic, no sorting — all of that lives in the view-model and the presentational component.
-
-## Why This Matters
-
-- **Testability:** View-model logic is unit-testable in isolation. Screen tests become focused integration tests.
-- **Reusability:** A dedicated component can be reused if the same pattern appears elsewhere (e.g., a regime screen).
-- **Maintainability:** Screens stay readable. Changes to S/R rendering touch one component, not a 300+ line screen file.
-- **Type safety:** The `exactOptionalPropertyTypes` TypeScript setting means optional props must explicitly allow `undefined`: `srLevels?: SrLevelsViewModelBlock | undefined`.
-
-## When to Apply
-
-- A screen subsection grows beyond ~30 lines of JSX/styles
-- Presentation logic (sorting, color mapping, note formatting) is mixed with rendering
-- The view-model outputs a shape that forces the screen to do data transformation
-- The same visual pattern might appear on multiple screens
-
-## Examples
-
-### Before (inline in screen, ~90 lines)
+**After (v2):**
 
 ```tsx
 {vm.srLevels ? (
-  <View style={{ marginTop: 4 }}>
-    <Text style={srStyles.sectionTitle}>Support & Resistance (MCO)</Text>
-    <Text style={srStyles.subsectionTitle}>Support</Text>
-    {vm.srLevels.supportsSorted.map((s, i) => (
-      <Text key={`s-${i}`} style={srStyles.levelRow}>
-        {s.priceLabel}{s.rankLabel ? ` (${s.rankLabel})` : ''}
-      </Text>
-    ))}
-    <Text style={srStyles.subsectionTitle}>Resistance</Text>
-    {/* ... more inline JSX ... */}
-  </View>
-) : (
-  <Text style={srStyles.muted}>No current MCO levels available</Text>
-)}
-```
-
-### After (thin screen, extracted component)
-
-```tsx
-// PositionDetailScreen.tsx — single line
-<SrLevelsCard srLevels={vm.srLevels} />
-
-// SrLevelsCard.tsx — focused presentational component
-export function SrLevelsCard({ srLevels }: Props): JSX.Element {
-  // ~90 lines of focused JSX, all S/R concerns in one place
-}
-```
-
-### View-Model: Computing Tone and Notes
-
-```typescript
-function computeLevelTone(
-  kind: 'support' | 'resistance',
-  levelPrice: number,
-  currentPrice: number,
-  lowerBound: number,
-  upperBound: number,
-): 'safe' | 'warn' | 'breach' {
-  if (kind === 'resistance') {
-    if (currentPrice > levelPrice) return 'breach';
-    if (isNearBound(levelPrice, upperBound)) return 'warn';
-    if (isWithinProximity(currentPrice, levelPrice)) return 'warn';
-    return 'safe';
-  }
-  if (currentPrice < levelPrice) return 'breach';
-  if (isNearBound(levelPrice, lowerBound)) return 'warn';
-  if (isWithinProximity(currentPrice, levelPrice)) return 'warn';
-  return 'safe';
-}
+  <>
+    {vm.srLevels.summary ? (
+      <MarketThesisCard summary={vm.srLevels.summary} />
+    ) : null}
+    <SrLevelsCard srLevels={vm.srLevels} />
+  </>
+) : null}
 ```
 
 ## Related
 
 - `packages/ui/src/screens/PositionDetailScreen.tsx`
 - `packages/ui/src/components/SrLevelsCard.tsx`
+- `packages/ui/src/components/MarketThesisCard.tsx`
 - `packages/ui/src/view-models/PositionDetailViewModel.ts`
+- `docs/architecture/repo-map.md`
+- `docs/architecture/domain-model.md`

--- a/docs/solutions/design-patterns/sr-levels-card-redesign-2026-04-26.md
+++ b/docs/solutions/design-patterns/sr-levels-card-redesign-2026-04-26.md
@@ -1,0 +1,183 @@
+---
+title: "UI Component Extraction and View-Model Restructuring for S/R Levels Display"
+date: 2026-04-26
+category: design-patterns
+module: packages/ui
+problem_type: design_pattern
+component: development_workflow
+severity: low
+applies_when:
+  - "Redesigning a screen section with complex presentation logic"
+  - "A screen component grows beyond ~30 lines for a single subsection"
+  - "View-model data shape does not match the desired UI layout"
+  - "Presentation logic (sorting, tone computation, note formatting) is mixed with rendering"
+tags:
+  - ui-redesign
+  - view-model
+  - component-extraction
+  - presentation-logic
+  - design-system
+---
+
+# UI Component Extraction and View-Model Restructuring for S/R Levels Display
+
+## Context
+
+When redesigning the Support & Resistance (S/R) section on the Position Detail screen, the existing implementation was a simple text list with separate "Support" and "Resistance" subsection titles. The new design called for a card-based layout with:
+
+- Tone-colored chips (`safe` / `warn` / `breach`) for each level
+- Contextual notes (e.g., "Range upper · your position")
+- Unified ascending sort across all levels (supports and resistances intermixed)
+- A freshness header ("AI · MCO · 2h ago")
+
+The initial approach rendered everything inline inside `PositionDetailScreen.tsx`, which quickly grew to ~90 lines of JSX and inline styles for this single subsection alone. This violated the repo's established pattern of keeping screens thin and delegating to focused presentational components.
+
+## Guidance
+
+### 1. Restructure the View-Model First
+
+Move all presentation logic into the view-model layer before touching the screen component. The view-model should output data in the exact shape the UI needs.
+
+**Before:**
+```typescript
+export type SrLevelsViewModelBlock = {
+  supportsSorted: Array<{ priceLabel: string; rankLabel?: string }>;
+  resistancesSorted: Array<{ priceLabel: string; rankLabel?: string }>;
+  freshnessLabel: string;
+  isStale: boolean;
+};
+```
+
+**After:**
+```typescript
+export type SrLevelViewModel = {
+  kind: 'support' | 'resistance';
+  rawPrice: number; // for sorting
+  priceLabel: string;
+  note: string;
+  tone: 'safe' | 'warn' | 'breach';
+};
+
+export type SrLevelsViewModelBlock = {
+  levels: SrLevelViewModel[];
+  freshnessLabel: string;
+  isStale: boolean;
+};
+```
+
+Compute in the view-model builder:
+- **Tone** from price proximity and range bounds (`breach` if crossed, `warn` if near bound or within 5%, `safe` otherwise)
+- **Notes** from a fallback hierarchy: DTO `notes` → bound match → `rank` → empty
+- **Sorting** on raw numeric price before formatting
+
+### 2. Extract a Presentational Component
+
+When a screen section exceeds ~30 lines, extract it into a dedicated component in `packages/ui/src/components/`.
+
+**Keep the component focused:**
+- Accept the pre-computed view-model block as a prop
+- Handle both present and absent states
+- Keep tone-to-color mapping inside the component (not in the screen or design system)
+- Use `testID` attributes for testability
+
+```typescript
+// SrLevelsCard.tsx
+type Props = {
+  srLevels?: SrLevelsViewModelBlock | undefined;
+};
+
+export function SrLevelsCard({ srLevels }: Props): JSX.Element {
+  if (!srLevels) {
+    return <Text>No current MCO levels available</Text>;
+  }
+  // render card with chips, prices, notes
+}
+```
+
+### 3. Keep the Screen Thin
+
+The screen component should only orchestrate:
+
+```tsx
+// PositionDetailScreen.tsx
+<SrLevelsCard srLevels={vm.srLevels} />
+```
+
+No inline styles, no tone logic, no sorting — all of that lives in the view-model and the presentational component.
+
+## Why This Matters
+
+- **Testability:** View-model logic is unit-testable in isolation. Screen tests become focused integration tests.
+- **Reusability:** A dedicated component can be reused if the same pattern appears elsewhere (e.g., a regime screen).
+- **Maintainability:** Screens stay readable. Changes to S/R rendering touch one component, not a 300+ line screen file.
+- **Type safety:** The `exactOptionalPropertyTypes` TypeScript setting means optional props must explicitly allow `undefined`: `srLevels?: SrLevelsViewModelBlock | undefined`.
+
+## When to Apply
+
+- A screen subsection grows beyond ~30 lines of JSX/styles
+- Presentation logic (sorting, color mapping, note formatting) is mixed with rendering
+- The view-model outputs a shape that forces the screen to do data transformation
+- The same visual pattern might appear on multiple screens
+
+## Examples
+
+### Before (inline in screen, ~90 lines)
+
+```tsx
+{vm.srLevels ? (
+  <View style={{ marginTop: 4 }}>
+    <Text style={srStyles.sectionTitle}>Support & Resistance (MCO)</Text>
+    <Text style={srStyles.subsectionTitle}>Support</Text>
+    {vm.srLevels.supportsSorted.map((s, i) => (
+      <Text key={`s-${i}`} style={srStyles.levelRow}>
+        {s.priceLabel}{s.rankLabel ? ` (${s.rankLabel})` : ''}
+      </Text>
+    ))}
+    <Text style={srStyles.subsectionTitle}>Resistance</Text>
+    {/* ... more inline JSX ... */}
+  </View>
+) : (
+  <Text style={srStyles.muted}>No current MCO levels available</Text>
+)}
+```
+
+### After (thin screen, extracted component)
+
+```tsx
+// PositionDetailScreen.tsx — single line
+<SrLevelsCard srLevels={vm.srLevels} />
+
+// SrLevelsCard.tsx — focused presentational component
+export function SrLevelsCard({ srLevels }: Props): JSX.Element {
+  // ~90 lines of focused JSX, all S/R concerns in one place
+}
+```
+
+### View-Model: Computing Tone and Notes
+
+```typescript
+function computeLevelTone(
+  kind: 'support' | 'resistance',
+  levelPrice: number,
+  currentPrice: number,
+  lowerBound: number,
+  upperBound: number,
+): 'safe' | 'warn' | 'breach' {
+  if (kind === 'resistance') {
+    if (currentPrice > levelPrice) return 'breach';
+    if (isNearBound(levelPrice, upperBound)) return 'warn';
+    if (isWithinProximity(currentPrice, levelPrice)) return 'warn';
+    return 'safe';
+  }
+  if (currentPrice < levelPrice) return 'breach';
+  if (isNearBound(levelPrice, lowerBound)) return 'warn';
+  if (isWithinProximity(currentPrice, levelPrice)) return 'warn';
+  return 'safe';
+}
+```
+
+## Related
+
+- `packages/ui/src/screens/PositionDetailScreen.tsx`
+- `packages/ui/src/components/SrLevelsCard.tsx`
+- `packages/ui/src/view-models/PositionDetailViewModel.ts`

--- a/docs/solutions/integration-issues/submitted-attempt-sweep-job-2026-04-23.md
+++ b/docs/solutions/integration-issues/submitted-attempt-sweep-job-2026-04-23.md
@@ -1,6 +1,20 @@
-# Submitted Attempt Sweep Job
+---
+title: "Submitted Attempt Sweep Job"
+date: "2026-04-23"
+category: integration-issues
+module: execution
+problem_type: integration_issue
+component: background_job
+severity: high
+symptoms:
+  - "Execution stuck in submitted state after reconciliation enqueue fails"
+  - "Orphaned attempts after worker process crash"
+root_cause: missing_workflow_step
+resolution_type: code_fix
+tags: [pg-boss, sweep-job, reconciliation, orphaned-attempts]
+---
 
-Date: 2026-04-23
+# Submitted Attempt Sweep Job
 
 ## Problem
 

--- a/docs/superpowers/plans/2026-04-26-position-detail-sr-redesign-v2.md
+++ b/docs/superpowers/plans/2026-04-26-position-detail-sr-redesign-v2.md
@@ -2,11 +2,28 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Redesign the Support & Resistance section with a separate Market Thesis card, grouped S/R levels with parsed shared notes, and resistance=red/support=green color scheme.
+**Goal:** Redesign the Support & Resistance section to match the updated `ScreenRegime` design: Market Thesis card above, grouped S/R levels with trigger/invalidation sections, parsed shared notes, and resistance=red/support=green colors.
 
-**Architecture:** The S/R view-model is restructured to parse notes into structured fields (source, timeframe, bias, setupType) and group levels by identical metadata. A new `MarketThesisCard` component renders above `SrLevelsCard`. The S/R card now shows grouped levels with subtle background containers and shared notes at the bottom of each group.
+**Architecture:** The S/R view-model parses notes into structured fields (source, timeframe, bias, setupType, trigger, invalidation) and groups levels by identical metadata. A new `MarketThesisCard` renders above `SrLevelsCard`. Each group shows levels, trigger/invalidation with prices, shared notes, and metadata footer.
 
 **Tech Stack:** React Native, TypeScript, Vitest, existing design system tokens.
+
+---
+
+## Note Format (Real Example)
+
+```
+"morecryptoonline swing, bearish. trend continuation | Trigger: break below 85 signals wave three down is underway | Invalidation: break above 88.30, shifting probabilities toward orange C-wave scenario | Support parsed from: \"79–81 (blue zone)\" | Raw support: 83 (Sunday low), 79–81 (blue zone) | Raw resistance: 86.37–88.30, 89.40 (green line)"
+```
+
+**Parsing rules:**
+1. Split by `|`
+2. First section: `source timeframe, bias. setupType`
+   - Split by last `.` → setupType after dot, rest before dot
+   - Before dot split by `,` → first part is `source timeframe` (split by space), second part is `bias`
+3. Other sections starting with `Trigger:` → trigger text (after colon)
+4. Other sections starting with `Invalidation:` → invalidation text (after colon)
+5. Remaining sections → joined with newlines as note body
 
 ---
 
@@ -14,22 +31,22 @@
 
 | File | Responsibility |
 |------|---------------|
-| `packages/ui/src/view-models/PositionDetailViewModel.ts` | Parse notes, group levels, tone override, expose summary |
+| `packages/ui/src/view-models/PositionDetailViewModel.ts` | Parse notes with trigger/invalidation, group levels, tone override |
 | `packages/ui/src/view-models/PositionDetailViewModel.test.ts` | Tests for parsing, grouping, tones |
-| `packages/ui/src/components/MarketThesisCard.tsx` | NEW — renders summary with info icon and metadata |
-| `packages/ui/src/components/SrLevelsCard.tsx` | Redesign — groups, no per-row notes, red resistance |
+| `packages/ui/src/components/MarketThesisCard.tsx` | NEW — renders summary with info icon |
+| `packages/ui/src/components/SrLevelsCard.tsx` | Redesign — groups with headers, triggers, invalidations, metadata |
 | `packages/ui/src/screens/PositionDetailScreen.tsx` | Render MarketThesisCard above SrLevelsCard |
 | `packages/ui/src/screens/PositionDetailScreen.test.tsx` | Update for new card structure |
 
 ---
 
-## Task 1: Restructure S/R View-Model with Note Parsing and Grouping
+## Task 1: Restructure S/R View-Model with Robust Note Parsing
 
 **Files:**
 - Modify: `packages/ui/src/view-models/PositionDetailViewModel.ts`
 - Modify: `packages/ui/src/view-models/PositionDetailViewModel.test.ts`
 
-- [ ] **Step 1: Update the SrLevelViewModel type**
+- [ ] **Step 1: Update SrLevelViewModel type**
 
 Remove `note` from `SrLevelViewModel`:
 
@@ -42,9 +59,7 @@ export type SrLevelViewModel = {
 };
 ```
 
-- [ ] **Step 2: Add new group and view-model types**
-
-Add these types after `SrLevelViewModel`:
+- [ ] **Step 2: Add group and view-model types**
 
 ```typescript
 export type SrLevelGroupViewModel = {
@@ -54,6 +69,8 @@ export type SrLevelGroupViewModel = {
   timeframe?: string;
   bias?: string;
   setupType?: string;
+  trigger?: string;
+  invalidation?: string;
 };
 
 export type SrLevelsViewModelBlock = {
@@ -64,9 +81,7 @@ export type SrLevelsViewModelBlock = {
 };
 ```
 
-- [ ] **Step 3: Add note parsing helper**
-
-Add this function above `toSrLevelsViewModelBlock`:
+- [ ] **Step 3: Add robust note parsing helper**
 
 ```typescript
 function parseNotes(notes: string | undefined): {
@@ -74,99 +89,133 @@ function parseNotes(notes: string | undefined): {
   timeframe?: string;
   bias?: string;
   setupType?: string;
+  trigger?: string;
+  invalidation?: string;
   remaining: string;
 } {
   if (!notes) {
     return { remaining: '' };
   }
 
-  const parts = notes.split('|');
+  const parts = notes.split('|').map((s) => s.trim()).filter(Boolean);
+  if (parts.length === 0) {
+    return { remaining: '' };
+  }
   if (parts.length === 1) {
+    return { remaining: parts[0] };
+  }
+
+  // Parse metadata from first section
+  const firstSection = parts[0];
+  const lastDotIndex = firstSection.lastIndexOf('.');
+  let source: string | undefined;
+  let timeframe: string | undefined;
+  let bias: string | undefined;
+  let setupType: string | undefined;
+
+  if (lastDotIndex > -1) {
+    setupType = firstSection.slice(lastDotIndex + 1).trim();
+    const beforeDot = firstSection.slice(0, lastDotIndex).trim();
+    const commaParts = beforeDot.split(',').map((s) => s.trim());
+    if (commaParts.length >= 2) {
+      bias = commaParts[commaParts.length - 1];
+      const sourceTimeframe = commaParts.slice(0, -1).join(',').trim();
+      const spaceParts = sourceTimeframe.split(/\s+/);
+      if (spaceParts.length >= 2) {
+        source = spaceParts[0];
+        timeframe = spaceParts.slice(1).join(' ');
+      } else {
+        source = sourceTimeframe;
+      }
+    } else {
+      const spaceParts = beforeDot.split(/\s+/);
+      if (spaceParts.length >= 2) {
+        source = spaceParts[0];
+        timeframe = spaceParts.slice(1).join(' ');
+      } else {
+        source = beforeDot;
+      }
+    }
+  } else {
+    // No dot — treat as raw string
     return { remaining: notes.trim() };
   }
 
-  const firstSection = parts[0].trim();
-  const remaining = parts.slice(1).join('\n').trim();
+  // Parse trigger and invalidation from remaining sections
+  let trigger: string | undefined;
+  let invalidation: string | undefined;
+  const noteParts: string[] = [];
 
-  // Parse: "source, timeframe, bias. setupType"
-  const commaParts = firstSection.split(',').map((s) => s.trim());
-  const source = commaParts[0];
-  const timeframe = commaParts[1];
-
-  // Bias and setupType are separated by period
-  const biasSetupPart = commaParts.slice(2).join(',').trim();
-  const dotIndex = biasSetupPart.indexOf('.');
-  const bias = dotIndex > -1 ? biasSetupPart.slice(0, dotIndex).trim() : biasSetupPart;
-  const setupType = dotIndex > -1 ? biasSetupPart.slice(dotIndex + 1).trim() : undefined;
+  for (let i = 1; i < parts.length; i++) {
+    const part = parts[i];
+    if (part.toLowerCase().startsWith('trigger:')) {
+      trigger = part.slice('trigger:'.length).trim();
+    } else if (part.toLowerCase().startsWith('invalidation:')) {
+      invalidation = part.slice('invalidation:'.length).trim();
+    } else {
+      noteParts.push(part);
+    }
+  }
 
   return {
     ...(source ? { source } : {}),
     ...(timeframe ? { timeframe } : {}),
     ...(bias ? { bias } : {}),
     ...(setupType ? { setupType } : {}),
-    remaining,
+    ...(trigger ? { trigger } : {}),
+    ...(invalidation ? { invalidation } : {}),
+    remaining: noteParts.join('\n'),
   };
 }
 ```
 
-- [ ] **Step 4: Add grouping helper**
+- [ ] **Step 4: Update grouping and tone logic**
 
-Add this function above `toSrLevelsViewModelBlock`:
-
-```typescript
-type GroupKey = string;
-
-function makeGroupKey(level: { rank?: string; timeframe?: string; notes?: string }): GroupKey {
-  return `${level.rank ?? ''}:${level.timeframe ?? ''}:${level.notes ?? ''}`;
-}
-```
-
-- [ ] **Step 5: Rewrite toSrLevelsViewModelBlock with grouping**
-
-Replace the existing `toSrLevelsViewModelBlock`:
+Replace `toSrLevelsViewModelBlock`:
 
 ```typescript
 function toSrLevelsViewModelBlock(
   block: NonNullable<PositionDetailDto['srLevels']>,
-  currentPrice: number,
-  lowerBound: number,
-  upperBound: number,
+  _currentPrice: number,
+  _lowerBound: number,
+  _upperBound: number,
   now: number,
 ): SrLevelsViewModelBlock {
   const { freshnessLabel, isStale } = computeFreshness(block.capturedAtUnixMs, now);
 
-  // Group raw levels by identical metadata
-  const rawGroups = new Map<string, { kind: 'support' | 'resistance'; items: typeof block.supports }>();
+  // Group raw levels by identical metadata (rank + timeframe + notes)
+  type RawItem = typeof block.supports[number] & { kind: 'support' | 'resistance' };
+  const rawGroups = new Map<string, RawItem[]>();
 
-  const addToGroup = (kind: 'support' | 'resistance', items: typeof block.supports) => {
+  const addItems = (kind: 'support' | 'resistance', items: typeof block.supports) => {
     for (const item of items) {
-      const key = makeGroupKey(item);
+      const key = `${item.rank ?? ''}:${item.timeframe ?? ''}:${item.notes ?? ''}`;
       const existing = rawGroups.get(key);
+      const itemWithKind = { ...item, kind };
       if (existing) {
-        existing.items.push(item);
+        existing.push(itemWithKind);
       } else {
-        rawGroups.set(key, { kind, items: [item] });
+        rawGroups.set(key, [itemWithKind]);
       }
     }
   };
 
-  addToGroup('support', block.supports);
-  addToGroup('resistance', block.resistances);
+  addItems('support', block.supports);
+  addItems('resistance', block.resistances);
 
   const groups: SrLevelGroupViewModel[] = [];
 
-  for (const [key, { kind, items }] of rawGroups) {
+  for (const [, items] of rawGroups) {
     const first = items[0];
     const parsed = parseNotes(first.notes);
 
     const levels = items.map((item) => ({
-      kind,
+      kind: item.kind,
       rawPrice: item.price,
       priceLabel: `$${item.price.toFixed(2)}`,
-      tone: kind === 'resistance' ? ('breach' as const) : ('safe' as const),
+      tone: item.kind === 'resistance' ? ('breach' as const) : ('safe' as const),
     }));
 
-    // Sort levels within group by price ascending
     levels.sort((a, b) => a.rawPrice - b.rawPrice);
 
     groups.push({
@@ -176,10 +225,11 @@ function toSrLevelsViewModelBlock(
       ...(parsed.timeframe ? { timeframe: parsed.timeframe } : {}),
       ...(parsed.bias ? { bias: parsed.bias } : {}),
       ...(parsed.setupType ? { setupType: parsed.setupType } : {}),
+      ...(parsed.trigger ? { trigger: parsed.trigger } : {}),
+      ...(parsed.invalidation ? { invalidation: parsed.invalidation } : {}),
     });
   }
 
-  // Sort groups by lowest price in each group
   groups.sort((a, b) => a.levels[0].rawPrice - b.levels[0].rawPrice);
 
   return {
@@ -191,262 +241,60 @@ function toSrLevelsViewModelBlock(
 }
 ```
 
-- [ ] **Step 6: Remove old computeLevelTone and computeLevelNote**
+- [ ] **Step 5: Remove unused helpers**
 
-These are no longer needed. Delete them.
+Delete: `computeLevelTone`, `computeLevelNote`, `isNearBound`, `isWithinProximity`, `BOUND_EPSILON`, `PROXIMITY_THRESHOLD`.
 
-- [ ] **Step 7: Remove isNearBound and isWithinProximity**
-
-These are no longer needed. Delete them.
-
-- [ ] **Step 8: Remove BOUND_EPSILON and PROXIMITY_THRESHOLD**
-
-These constants are no longer needed. Delete them.
-
-- [ ] **Step 9: Update view-model tests**
-
-Replace the test file contents:
+- [ ] **Step 6: Update tests**
 
 ```typescript
-import { describe, expect, it } from 'vitest';
-import type { PositionDetailDto } from '@clmm/application/public';
-import { buildPositionDetailViewModel } from './PositionDetailViewModel.js';
-
-function makeDto(overrides: Partial<PositionDetailDto> = {}): PositionDetailDto {
-  return {
-    positionId: 'position-1' as PositionDetailDto['positionId'],
-    poolId: 'pool-1' as PositionDetailDto['poolId'],
-    tokenPairLabel: 'SOL / USDC',
-    currentPrice: 150,
-    currentPriceLabel: 'USDC 150.00',
-    feeRateLabel: '10 bps',
-    rangeState: 'in-range',
-    rangeDistance: { belowLowerPercent: 0, aboveUpperPercent: 0 },
-    hasActionableTrigger: false,
-    monitoringStatus: 'active',
-    lowerBound: 100,
-    upperBound: 200,
-    lowerBoundLabel: 'USDC 100.00',
-    upperBoundLabel: 'USDC 200.00',
-    sqrtPrice: '123456',
-    unclaimedFees: {
-      feeOwedA: { raw: '100000000', decimals: 9, symbol: 'SOL', usdValue: 15 },
-      feeOwedB: { raw: '30000000', decimals: 6, symbol: 'USDC', usdValue: 30 },
-      totalUsd: 45,
-    },
-    unclaimedRewards: {
-      rewards: [],
-      totalUsd: 0,
-    },
-    positionLiquidity: '5000000000',
-    poolLiquidity: '2400000000',
-    poolDepthLabel: 'depth unavailable',
-    ...overrides,
-  };
-}
-
-function makeSrBlock(overrides: Partial<NonNullable<PositionDetailDto['srLevels']>> = {}): NonNullable<PositionDetailDto['srLevels']> {
-  return {
-    briefId: 'brief-1',
-    sourceRecordedAtIso: null,
-    summary: null,
-    capturedAtUnixMs: 1_000_000_000,
-    supports: [{ price: 90 }, { price: 110 }],
-    resistances: [{ price: 180 }, { price: 210 }],
-    ...overrides,
-  };
-}
-
-describe('buildPositionDetailViewModel srLevels', () => {
-  it('returns srLevels undefined when dto has no srLevels', () => {
-    const vm = buildPositionDetailViewModel(makeDto(), Date.now());
-    expect(vm.srLevels).toBeUndefined();
-  });
-
-  it('returns a populated srLevels block when dto.srLevels is present', () => {
-    const now = 2_000_000;
-    const vm = buildPositionDetailViewModel(
-      makeDto({ srLevels: makeSrBlock({ capturedAtUnixMs: 1_700_000 }) }),
-      now,
-    );
-    expect(vm.srLevels).toBeDefined();
-    expect(vm.srLevels!.groups.length).toBeGreaterThan(0);
-  });
-
-  it('computes freshness for 5 minutes ago', () => {
-    const now = 2_000_000;
-    const vm = buildPositionDetailViewModel(
-      makeDto({ srLevels: makeSrBlock({ capturedAtUnixMs: 1_700_000 }) }),
-      now,
-    );
-    expect(vm.srLevels?.freshnessLabel).toBe('AI · MCO · 5m ago');
-    expect(vm.srLevels?.isStale).toBe(false);
-  });
-
-  it('parses notes with pipe separator', () => {
-    const now = 200_000_000;
-    const vm = buildPositionDetailViewModel(
-      makeDto({
-        srLevels: makeSrBlock({
-          capturedAtUnixMs: now,
-          supports: [
-            { price: 90, notes: 'morecryptoonline, 4h, Bearish. swing | Break below $85 signals C-wave down.' },
-          ],
-          resistances: [],
-        }),
+// Add test for real notes format
+it('parses real notes format with trigger and invalidation', () => {
+  const now = 200_000_000;
+  const vm = buildPositionDetailViewModel(
+    makeDto({
+      srLevels: makeSrBlock({
+        capturedAtUnixMs: now,
+        supports: [{
+          price: 90,
+          notes: 'morecryptoonline swing, bearish. trend continuation | Trigger: break below 85 signals wave three down is underway | Invalidation: break above 88.30, shifting probabilities toward orange C-wave scenario | Support parsed from: "79–81 (blue zone)" | Raw support: 83 (Sunday low), 79–81 (blue zone)',
+        }],
+        resistances: [],
       }),
-      now,
-    );
-    const group = vm.srLevels!.groups[0]!;
-    expect(group.source).toBe('morecryptoonline');
-    expect(group.timeframe).toBe('4h');
-    expect(group.bias).toBe('Bearish');
-    expect(group.setupType).toBe('swing');
-    expect(group.note).toBe('Break below $85 signals C-wave down.');
-  });
-
-  it('returns raw notes when no pipe separator', () => {
-    const now = 200_000_000;
-    const vm = buildPositionDetailViewModel(
-      makeDto({
-        srLevels: makeSrBlock({
-          capturedAtUnixMs: now,
-          supports: [{ price: 90, notes: 'Primary support zone' }],
-          resistances: [],
-        }),
-      }),
-      now,
-    );
-    const group = vm.srLevels!.groups[0]!;
-    expect(group.note).toBe('Primary support zone');
-    expect(group.source).toBeUndefined();
-  });
-
-  it('groups levels with identical metadata', () => {
-    const now = 200_000_000;
-    const vm = buildPositionDetailViewModel(
-      makeDto({
-        srLevels: makeSrBlock({
-          capturedAtUnixMs: now,
-          supports: [
-            { price: 90, rank: 'S1', notes: 'source, 1h, Bullish. test | note body' },
-            { price: 110, rank: 'S1', notes: 'source, 1h, Bullish. test | note body' },
-          ],
-          resistances: [],
-        }),
-      }),
-      now,
-    );
-    expect(vm.srLevels!.groups.length).toBe(1);
-    expect(vm.srLevels!.groups[0]!.levels.length).toBe(2);
-  });
-
-  it('creates separate groups for different metadata', () => {
-    const now = 200_000_000;
-    const vm = buildPositionDetailViewModel(
-      makeDto({
-        srLevels: makeSrBlock({
-          capturedAtUnixMs: now,
-          supports: [
-            { price: 90, rank: 'S1', notes: 'note A' },
-            { price: 110, rank: 'S2', notes: 'note B' },
-          ],
-          resistances: [],
-        }),
-      }),
-      now,
-    );
-    expect(vm.srLevels!.groups.length).toBe(2);
-  });
-
-  it('marks resistance as breach tone (red)', () => {
-    const now = 200_000_000;
-    const vm = buildPositionDetailViewModel(
-      makeDto({
-        srLevels: makeSrBlock({
-          capturedAtUnixMs: now,
-          supports: [],
-          resistances: [{ price: 180 }],
-        }),
-      }),
-      now,
-    );
-    expect(vm.srLevels!.groups[0]!.levels[0]!.tone).toBe('breach');
-  });
-
-  it('marks support as safe tone (green)', () => {
-    const now = 200_000_000;
-    const vm = buildPositionDetailViewModel(
-      makeDto({
-        srLevels: makeSrBlock({
-          capturedAtUnixMs: now,
-          supports: [{ price: 90 }],
-          resistances: [],
-        }),
-      }),
-      now,
-    );
-    expect(vm.srLevels!.groups[0]!.levels[0]!.tone).toBe('safe');
-  });
-
-  it('passes summary through to view-model', () => {
-    const now = 200_000_000;
-    const vm = buildPositionDetailViewModel(
-      makeDto({
-        srLevels: makeSrBlock({
-          capturedAtUnixMs: now,
-          summary: 'Bearish swing, trend continuation.',
-        }),
-      }),
-      now,
-    );
-    expect(vm.srLevels!.summary).toBe('Bearish swing, trend continuation.');
-  });
-
-  it('sorts groups by lowest price ascending', () => {
-    const now = 200_000_000;
-    const vm = buildPositionDetailViewModel(
-      makeDto({
-        srLevels: makeSrBlock({
-          capturedAtUnixMs: now,
-          supports: [{ price: 130, notes: 'high' }],
-          resistances: [{ price: 80, notes: 'low' }],
-        }),
-      }),
-      now,
-    );
-    // Resistance at 80 should come before support at 130
-    expect(vm.srLevels!.groups[0]!.levels[0]!.priceLabel).toBe('$80.00');
-    expect(vm.srLevels!.groups[1]!.levels[0]!.priceLabel).toBe('$130.00');
-  });
+    }),
+    now,
+  );
+  const group = vm.srLevels!.groups[0]!;
+  expect(group.source).toBe('morecryptoonline');
+  expect(group.timeframe).toBe('swing');
+  expect(group.bias).toBe('bearish');
+  expect(group.setupType).toBe('trend continuation');
+  expect(group.trigger).toBe('break below 85 signals wave three down is underway');
+  expect(group.invalidation).toBe('break above 88.30, shifting probabilities toward orange C-wave scenario');
+  expect(group.note).toContain('Support parsed from:');
+  expect(group.note).toContain('Raw support:');
 });
 ```
 
-- [ ] **Step 10: Run view-model tests**
+- [ ] **Step 7: Run tests**
 
 ```bash
 cd /home/gpoontip/clmm-v2/packages/ui && npx vitest run src/view-models/PositionDetailViewModel.test.ts
 ```
 
-Expected: All tests pass.
-
-- [ ] **Step 11: Commit view-model changes**
+- [ ] **Step 8: Commit**
 
 ```bash
 git add packages/ui/src/view-models/PositionDetailViewModel.ts packages/ui/src/view-models/PositionDetailViewModel.test.ts
-git commit -m "feat: parse notes, group levels, add summary to S/R view-model"
+git commit -m "feat: parse notes with trigger/invalidation, group levels"
 ```
 
 ---
 
-## Task 2: Create MarketThesisCard Component
+## Task 2: Create MarketThesisCard
 
 **Files:**
 - Create: `packages/ui/src/components/MarketThesisCard.tsx`
-- Modify: `packages/ui/src/screens/PositionDetailScreen.tsx`
-- Modify: `packages/ui/src/screens/PositionDetailScreen.test.tsx`
-
-- [ ] **Step 1: Create MarketThesisCard.tsx**
 
 ```typescript
 import { View, Text } from 'react-native';
@@ -455,234 +303,55 @@ import { colors, typography } from '../design-system/index.js';
 function InfoIcon(): JSX.Element {
   return (
     <View style={{
-      width: 16,
-      height: 16,
-      borderRadius: 8,
-      borderWidth: 1,
-      borderColor: colors.textMuted,
-      justifyContent: 'center',
-      alignItems: 'center',
+      width: 16, height: 16, borderRadius: 8,
+      borderWidth: 1, borderColor: colors.textMuted,
+      justifyContent: 'center', alignItems: 'center',
     }}>
       <Text style={{
-        fontSize: 10,
-        color: colors.textMuted,
-        fontWeight: typography.fontWeight.semibold,
-        lineHeight: 14,
-      }}>
-        i
-      </Text>
+        fontSize: 10, color: colors.textMuted,
+        fontWeight: typography.fontWeight.semibold, lineHeight: 14,
+      }}>i</Text>
     </View>
   );
 }
 
-type Props = {
-  summary: string;
-  source?: string;
-  timeframe?: string;
-  bias?: string;
-  setupType?: string;
-};
+type Props = { summary: string };
 
-export function MarketThesisCard({ summary, source, timeframe, bias, setupType }: Props): JSX.Element {
+export function MarketThesisCard({ summary }: Props): JSX.Element {
   return (
     <View style={{
-      marginTop: 14,
-      padding: 16,
+      marginTop: 14, padding: 16,
       backgroundColor: colors.surface,
-      borderRadius: 8,
-      borderWidth: 1,
-      borderColor: colors.border,
+      borderRadius: 8, borderWidth: 1, borderColor: colors.border,
     }}>
-      {/* Header */}
-      <View style={{
-        flexDirection: 'row',
-        alignItems: 'center',
-        gap: 8,
-        marginBottom: 12,
-      }}>
+      <View style={{ flexDirection: 'row', alignItems: 'center', gap: 8, marginBottom: 12 }}>
         <InfoIcon />
         <Text style={{
-          color: colors.textSecondary,
-          fontSize: typography.fontSize.micro,
+          color: colors.textSecondary, fontSize: typography.fontSize.micro,
           fontWeight: typography.fontWeight.semibold,
-          letterSpacing: 0.08,
-          textTransform: 'uppercase',
-        }}>
-          Market Thesis
-        </Text>
-        {bias ? (
-          <View style={{
-            height: 22,
-            paddingHorizontal: 8,
-            borderRadius: 999,
-            borderWidth: 1,
-            borderColor: 'rgba(244,201,122,0.30)',
-            justifyContent: 'center',
-            alignItems: 'center',
-          }}>
-            <Text style={{
-              fontSize: typography.fontSize.micro,
-              color: colors.warn,
-              fontWeight: typography.fontWeight.semibold,
-            }}>
-              {bias}
-            </Text>
-          </View>
-        ) : null}
+          letterSpacing: 0.08, textTransform: 'uppercase',
+        }}>Market Thesis</Text>
       </View>
-
-      {/* Summary text */}
       <Text style={{
-        color: colors.text,
-        fontSize: typography.fontSize.sm,
+        color: colors.text, fontSize: typography.fontSize.sm,
         lineHeight: typography.lineHeight.normal * typography.fontSize.sm,
-      }}>
-        {summary}
-      </Text>
-
-      {/* Metadata */}
-      <View style={{ marginTop: 12 }}>
-        {source ? (
-          <Text style={{
-            fontSize: typography.fontSize.micro,
-            color: colors.textMuted,
-          }}>
-            Source · {source}
-          </Text>
-        ) : null}
-        {timeframe ? (
-          <Text style={{
-            fontSize: typography.fontSize.micro,
-            color: colors.textMuted,
-          }}>
-            Timeframe · {timeframe}
-          </Text>
-        ) : null}
-        {setupType ? (
-          <Text style={{
-            fontSize: typography.fontSize.micro,
-            color: colors.textMuted,
-          }}>
-            Setup · {setupType}
-          </Text>
-        ) : null}
-      </View>
+        fontWeight: typography.fontWeight.medium,
+      }}>{summary}</Text>
     </View>
   );
 }
 ```
 
-- [ ] **Step 2: Update PositionDetailScreen to render MarketThesisCard**
-
-Find where `SrLevelsCard` is rendered and add `MarketThesisCard` above it:
-
-```typescript
-import { MarketThesisCard } from '../components/MarketThesisCard.js';
-```
-
-Then in the JSX, replace:
-```tsx
-<SrLevelsCard srLevels={vm.srLevels} />
-```
-
-With:
-```tsx
-{vm.srLevels?.summary ? (
-  <MarketThesisCard
-    summary={vm.srLevels.summary}
-    source={vm.srLevels.groups[0]?.source}
-    timeframe={vm.srLevels.groups[0]?.timeframe}
-    bias={vm.srLevels.groups[0]?.bias}
-    setupType={vm.srLevels.groups[0]?.setupType}
-  />
-) : null}
-<SrLevelsCard srLevels={vm.srLevels} />
-```
-
-- [ ] **Step 3: Add MarketThesisCard test**
-
-In `PositionDetailScreen.test.tsx`, add:
-
-```typescript
-  it('renders Market Thesis card when summary is present', () => {
-    const now = Date.now();
-    vi.spyOn(Date, 'now').mockReturnValue(now);
-
-    render(
-      <PositionDetailScreen
-        position={makePosition({
-          srLevels: {
-            briefId: 'brief-1',
-            sourceRecordedAtIso: null,
-            summary: 'Bearish swing, trend continuation.',
-            capturedAtUnixMs: now,
-            supports: [{ price: 90 }],
-            resistances: [],
-          },
-        })}
-      />,
-    );
-
-    expect(screen.getByText('Market Thesis')).toBeTruthy();
-    expect(screen.getByText('Bearish swing, trend continuation.')).toBeTruthy();
-
-    vi.restoreAllMocks();
-  });
-
-  it('does not render Market Thesis card when summary is absent', () => {
-    const now = Date.now();
-    vi.spyOn(Date, 'now').mockReturnValue(now);
-
-    render(
-      <PositionDetailScreen
-        position={makePosition({
-          srLevels: makeSrBlock(now),
-        })}
-      />,
-    );
-
-    expect(screen.queryByText('Market Thesis')).toBeNull();
-
-    vi.restoreAllMocks();
-  });
-```
-
-- [ ] **Step 4: Run screen tests**
-
-```bash
-cd /home/gpoontip/clmm-v2/packages/ui && npx vitest run src/screens/PositionDetailScreen.test.tsx
-```
-
-Expected: All tests pass.
-
-- [ ] **Step 5: Commit**
-
-```bash
-git add packages/ui/src/components/MarketThesisCard.tsx packages/ui/src/screens/PositionDetailScreen.tsx packages/ui/src/screens/PositionDetailScreen.test.tsx
-git commit -m "feat: add MarketThesisCard component with summary and metadata"
-```
+Commit: `feat: add MarketThesisCard component`
 
 ---
 
-## Task 3: Redesign SrLevelsCard with Groups and Colors
+## Task 3: Redesign SrLevelsCard
 
 **Files:**
 - Modify: `packages/ui/src/components/SrLevelsCard.tsx`
-- Modify: `packages/ui/src/screens/PositionDetailScreen.test.tsx`
 
-- [ ] **Step 1: Update toneColors mapping**
-
-Keep the mapping but resistance will always use `breach`:
-
-```typescript
-const toneColors = {
-  safe: { text: colors.safe, border: 'rgba(158,236,209,0.30)' },
-  warn: { text: colors.warn, border: 'rgba(244,201,122,0.30)' },
-  breach: { text: colors.breachAccent, border: 'rgba(245,148,132,0.30)' },
-} as const;
-```
-
-- [ ] **Step 2: Replace SrLevelsCard with grouped design**
+**Design per updated screens-b.jsx:**
 
 ```typescript
 import { View, Text } from 'react-native';
@@ -690,23 +359,30 @@ import { colors, typography } from '../design-system/index.js';
 import type { SrLevelsViewModelBlock } from '../view-models/PositionDetailViewModel.js';
 
 const toneColors = {
-  safe: { text: colors.safe, border: 'rgba(158,236,209,0.30)' },
-  warn: { text: colors.warn, border: 'rgba(244,201,122,0.30)' },
-  breach: { text: colors.breachAccent, border: 'rgba(245,148,132,0.30)' },
+  safe: { text: colors.safe, border: 'rgba(158,236,209,0.30)', bg: 'rgba(158,236,209,0.08)' },
+  warn: { text: colors.warn, border: 'rgba(244,201,122,0.30)', bg: 'rgba(244,201,122,0.08)' },
+  breach: { text: colors.breachAccent, border: 'rgba(245,148,132,0.30)', bg: 'rgba(245,148,132,0.08)' },
 } as const;
 
-type Props = {
-  srLevels?: SrLevelsViewModelBlock | undefined;
-};
+function TriggerInvalidationSection({ label, text, labelColor }: { label: string; text: string; labelColor: string }): JSX.Element {
+  return (
+    <View style={{ marginTop: 10, paddingTop: 10, borderTopWidth: 1, borderTopColor: colors.border }}>
+      <Text style={{ fontSize: typography.fontSize.micro, color: labelColor, fontWeight: typography.fontWeight.semibold }}>
+        {label}
+      </Text>
+      <Text style={{ fontSize: typography.fontSize.micro, color: colors.textMuted, lineHeight: 16, marginTop: 2 }}>
+        {text}
+      </Text>
+    </View>
+  );
+}
+
+type Props = { srLevels?: SrLevelsViewModelBlock | undefined };
 
 export function SrLevelsCard({ srLevels }: Props): JSX.Element {
   if (!srLevels) {
     return (
-      <Text style={{
-        color: colors.textSecondary,
-        fontSize: typography.fontSize.sm,
-        marginTop: 16,
-      }}>
+      <Text style={{ color: colors.textSecondary, fontSize: typography.fontSize.sm, marginTop: 16 }}>
         No current MCO levels available
       </Text>
     );
@@ -714,104 +390,121 @@ export function SrLevelsCard({ srLevels }: Props): JSX.Element {
 
   return (
     <View style={{
-      marginTop: 14,
-      padding: 16,
+      marginTop: 14, padding: 16,
       backgroundColor: colors.surface,
-      borderRadius: 8,
-      borderWidth: 1,
-      borderColor: colors.border,
+      borderRadius: 8, borderWidth: 1, borderColor: colors.border,
     }}>
       {/* Header */}
-      <View style={{
-        flexDirection: 'row',
-        justifyContent: 'space-between',
-        alignItems: 'center',
-        marginBottom: 10,
-      }}>
-        <Text style={{
-          color: colors.textSecondary,
-          fontSize: typography.fontSize.sm,
-          fontWeight: typography.fontWeight.medium,
-        }}>
+      <View style={{ flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center', marginBottom: 12 }}>
+        <Text style={{ color: colors.textSecondary, fontSize: typography.fontSize.sm, fontWeight: typography.fontWeight.medium }}>
           Support & Resistance
         </Text>
-        <Text style={{
-          fontSize: typography.fontSize.micro,
-          color: colors.textMuted,
-        }}>
+        <Text style={{ fontSize: typography.fontSize.micro, color: colors.textMuted }}>
           {srLevels.freshnessLabel}
         </Text>
       </View>
 
       {/* Groups */}
-      {srLevels.groups.map((group, groupIndex) => (
-        <View
-          key={`sr-group-${groupIndex}`}
-          testID={`sr-group-${groupIndex}`}
-          style={{
-            backgroundColor: colors.surfaceRecessed,
-            borderRadius: 6,
-            padding: 12,
-            marginBottom: groupIndex < srLevels.groups.length - 1 ? 8 : 0,
-          }}
-        >
-          {/* Levels in group */}
-          {group.levels.map((level, levelIndex) => {
-            const tone = toneColors[level.tone];
+      {srLevels.groups.map((group, gi) => (
+        <View key={`sr-group-${gi}`} testID={`sr-group-${gi}`} style={{
+          backgroundColor: colors.surfaceRecessed,
+          borderRadius: 10, padding: 14,
+          marginTop: gi === 0 ? 0 : 10,
+          borderWidth: 1, borderColor: colors.border,
+        }}>
+          {/* Group header: bias pill + cluster label */}
+          <View style={{ flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center', marginBottom: 10 }}>
+            {group.bias ? (
+              <View style={{
+                height: 22, paddingHorizontal: 10,
+                borderRadius: 999, borderWidth: 1,
+                borderColor: 'rgba(244,201,122,0.30)',
+                justifyContent: 'center', alignItems: 'center',
+              }}>
+                <Text style={{
+                  fontSize: typography.fontSize.micro, color: colors.warn,
+                  fontWeight: typography.fontWeight.semibold,
+                }}>{group.bias}</Text>
+              </View>
+            ) : <View />}
+            <Text style={{
+              fontSize: typography.fontSize.micro, color: colors.textMuted,
+              textTransform: 'uppercase', letterSpacing: 0.06,
+            }}>
+              {group.levels[0]?.kind === 'resistance' ? 'Resistance Cluster' : 'Support Cluster'}
+            </Text>
+          </View>
+
+          {/* Levels */}
+          {group.levels.map((lv, li) => {
+            const tone = toneColors[lv.tone];
             return (
-              <View
-                key={`sr-level-${groupIndex}-${levelIndex}`}
-                testID={`sr-level-${groupIndex}-${levelIndex}`}
-                style={{
-                  flexDirection: 'row',
-                  alignItems: 'center',
-                  justifyContent: 'space-between',
-                  paddingVertical: levelIndex === 0 ? 0 : 8,
-                  borderTopWidth: levelIndex === 0 ? 0 : 1,
-                  borderTopColor: colors.border,
-                }}
-              >
+              <View key={`sr-level-${gi}-${li}`} testID={`sr-level-${gi}-${li}`} style={{
+                flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between',
+                paddingVertical: li === 0 ? 0 : 8,
+                borderTopWidth: li === 0 ? 0 : 1,
+                borderTopColor: colors.border,
+              }}>
                 <View style={{ flexDirection: 'row', alignItems: 'center', gap: 10 }}>
                   <View style={{
-                    height: 22,
-                    paddingHorizontal: 8,
-                    borderRadius: 999,
-                    borderWidth: 1,
-                    borderColor: tone.border,
-                    justifyContent: 'center',
-                    alignItems: 'center',
+                    height: 22, paddingHorizontal: 8,
+                    borderRadius: 999, borderWidth: 1,
+                    borderColor: tone.border, backgroundColor: tone.bg,
+                    justifyContent: 'center', alignItems: 'center',
                   }}>
                     <Text style={{
-                      fontSize: typography.fontSize.micro,
-                      color: tone.text,
+                      fontSize: typography.fontSize.micro, color: tone.text,
                       fontWeight: typography.fontWeight.semibold,
-                    }}>
-                      {level.kind === 'resistance' ? 'Resist' : 'Support'}
-                    </Text>
+                    }}>{lv.kind === 'resistance' ? 'Resist' : 'Support'}</Text>
                   </View>
                   <Text style={{
-                    fontFamily: typography.fontFamily.mono,
-                    fontSize: typography.fontSize.sm,
-                    fontWeight: typography.fontWeight.semibold,
-                    color: colors.text,
-                  }}>
-                    {level.priceLabel}
-                  </Text>
+                    fontFamily: typography.fontFamily.mono, fontSize: typography.fontSize.sm,
+                    fontWeight: typography.fontWeight.semibold, color: colors.text,
+                  }}>{lv.priceLabel}</Text>
                 </View>
               </View>
             );
           })}
 
-          {/* Group note */}
+          {/* Trigger / Invalidation */}
+          {group.trigger ? (
+            <TriggerInvalidationSection label="Trigger" text={group.trigger} labelColor={colors.breachAccent} />
+          ) : null}
+          {group.invalidation ? (
+            <TriggerInvalidationSection label="Invalidation" text={group.invalidation} labelColor={colors.safe} />
+          ) : null}
+
+          {/* Shared note */}
           {group.note ? (
-            <Text style={{
-              fontSize: typography.fontSize.micro,
-              color: colors.textMuted,
-              marginTop: 8,
-              lineHeight: 16,
+            <View style={{ marginTop: 10, paddingTop: 10, borderTopWidth: 1, borderTopColor: colors.border }}>
+              <Text style={{ fontSize: typography.fontSize.micro, color: colors.textMuted, lineHeight: 16 }}>
+                {group.note}
+              </Text>
+            </View>
+          ) : null}
+
+          {/* Metadata footer */}
+          {(group.source || group.timeframe || group.setupType) ? (
+            <View style={{
+              flexDirection: 'row', flexWrap: 'wrap', gap: '4px 14px',
+              marginTop: 10, paddingTop: 10, borderTopWidth: 1, borderTopColor: colors.border,
             }}>
-              {group.note}
-            </Text>
+              {group.source ? (
+                <Text style={{ fontSize: typography.fontSize.micro, color: colors.textMuted, textTransform: 'uppercase', letterSpacing: 0.04 }}>
+                  Source · <Text style={{ color: colors.textSecondary }}>{group.source}</Text>
+                </Text>
+              ) : null}
+              {group.timeframe ? (
+                <Text style={{ fontSize: typography.fontSize.micro, color: colors.textMuted, textTransform: 'uppercase', letterSpacing: 0.04 }}>
+                  TF · <Text style={{ color: colors.textSecondary }}>{group.timeframe}</Text>
+                </Text>
+              ) : null}
+              {group.setupType ? (
+                <Text style={{ fontSize: typography.fontSize.micro, color: colors.textMuted, textTransform: 'uppercase', letterSpacing: 0.04 }}>
+                  Setup · <Text style={{ color: colors.textSecondary }}>{group.setupType}</Text>
+                </Text>
+              ) : null}
+            </View>
           ) : null}
         </View>
       ))}
@@ -820,226 +513,45 @@ export function SrLevelsCard({ srLevels }: Props): JSX.Element {
 }
 ```
 
-- [ ] **Step 3: Update screen tests for new structure**
-
-Update existing tests in `PositionDetailScreen.test.tsx`:
-
-Replace `renders support and resistance section as a card`:
-```typescript
-  it('renders support and resistance section as a card when srLevels is present', () => {
-    const now = Date.now();
-    vi.spyOn(Date, 'now').mockReturnValue(now);
-
-    render(
-      <PositionDetailScreen
-        position={makePosition({
-          srLevels: makeSrBlock(now),
-        })}
-      />,
-    );
-
-    expect(screen.getByText('Support & Resistance')).toBeTruthy();
-    expect(screen.getByText('AI · MCO · 1m ago')).toBeTruthy();
-    expect(screen.getByTestId('sr-group-0')).toBeTruthy();
-
-    vi.restoreAllMocks();
-  });
-```
-
-Replace `renders level chips with correct labels`:
-```typescript
-  it('renders level chips with correct labels and colors', () => {
-    const now = Date.now();
-    vi.spyOn(Date, 'now').mockReturnValue(now);
-
-    render(
-      <PositionDetailScreen
-        position={makePosition({
-          srLevels: {
-            briefId: 'brief-1',
-            sourceRecordedAtIso: null,
-            summary: null,
-            capturedAtUnixMs: now,
-            supports: [{ price: 90 }],
-            resistances: [{ price: 180 }],
-          },
-        })}
-      />,
-    );
-
-    expect(screen.getByText('Support')).toBeTruthy();
-    expect(screen.getByText('Resist')).toBeTruthy();
-    expect(screen.getByText('$90.00')).toBeTruthy();
-    expect(screen.getByText('$180.00')).toBeTruthy();
-
-    vi.restoreAllMocks();
-  });
-```
-
-Replace `renders resistance-only levels`:
-```typescript
-  it('renders resistance-only levels correctly', () => {
-    const now = Date.now();
-    vi.spyOn(Date, 'now').mockReturnValue(now);
-
-    render(
-      <PositionDetailScreen
-        position={makePosition({
-          srLevels: {
-            briefId: 'brief-1',
-            sourceRecordedAtIso: null,
-            summary: null,
-            capturedAtUnixMs: now,
-            supports: [],
-            resistances: [{ price: 180 }, { price: 210 }],
-          },
-        })}
-      />,
-    );
-
-    expect(screen.getByText('Support & Resistance')).toBeTruthy();
-    expect(screen.getAllByText('Resist')).toHaveLength(2);
-    expect(screen.getByText('$180.00')).toBeTruthy();
-    expect(screen.getByText('$210.00')).toBeTruthy();
-
-    vi.restoreAllMocks();
-  });
-```
-
-Replace `renders support-only levels`:
-```typescript
-  it('renders support-only levels correctly', () => {
-    const now = Date.now();
-    vi.spyOn(Date, 'now').mockReturnValue(now);
-
-    render(
-      <PositionDetailScreen
-        position={makePosition({
-          srLevels: {
-            briefId: 'brief-1',
-            sourceRecordedAtIso: null,
-            summary: null,
-            capturedAtUnixMs: now,
-            supports: [{ price: 90 }, { price: 110 }],
-            resistances: [],
-          },
-        })}
-      />,
-    );
-
-    expect(screen.getByText('Support & Resistance')).toBeTruthy();
-    expect(screen.getAllByText('Support')).toHaveLength(2);
-    expect(screen.getByText('$90.00')).toBeTruthy();
-    expect(screen.getByText('$110.00')).toBeTruthy();
-
-    vi.restoreAllMocks();
-  });
-```
-
-Replace `renders empty levels`:
-```typescript
-  it('renders empty groups message when both supports and resistances are empty', () => {
-    const now = Date.now();
-    vi.spyOn(Date, 'now').mockReturnValue(now);
-
-    render(
-      <PositionDetailScreen
-        position={makePosition({
-          srLevels: {
-            briefId: 'brief-1',
-            sourceRecordedAtIso: null,
-            summary: null,
-            capturedAtUnixMs: now,
-            supports: [],
-            resistances: [],
-          },
-        })}
-      />,
-    );
-
-    expect(screen.getByText('Support & Resistance')).toBeTruthy();
-    expect(screen.queryByTestId('sr-group-0')).toBeNull();
-
-    vi.restoreAllMocks();
-  });
-```
-
-- [ ] **Step 4: Run screen tests**
-
-```bash
-cd /home/gpoontip/clmm-v2/packages/ui && npx vitest run src/screens/PositionDetailScreen.test.tsx
-```
-
-Expected: All tests pass.
-
-- [ ] **Step 5: Commit**
-
-```bash
-git add packages/ui/src/components/SrLevelsCard.tsx packages/ui/src/screens/PositionDetailScreen.test.tsx
-git commit -m "feat: redesign SrLevelsCard with groups, shared notes, resistance=red"
-```
+Commit: `feat: redesign SrLevelsCard with groups, triggers, invalidations`
 
 ---
 
-## Task 4: Verify Cross-Package Build and Boundaries
+## Task 4: Update Screen and Tests
 
 **Files:**
-- (no file changes — verification only)
+- Modify: `packages/ui/src/screens/PositionDetailScreen.tsx`
+- Modify: `packages/ui/src/screens/PositionDetailScreen.test.tsx`
 
-- [ ] **Step 1: Run UI package build**
+**Screen changes:**
+- Import `MarketThesisCard`
+- Render `<MarketThesisCard summary={vm.srLevels.summary} />` when summary present
+- Keep `<SrLevelsCard srLevels={vm.srLevels} />`
 
-```bash
-cd /home/gpoontip/clmm-v2 && pnpm --filter @clmm/ui build
-```
-
-Expected: Build succeeds with no TypeScript errors.
-
-- [ ] **Step 2: Run UI package tests**
-
-```bash
-cd /home/gpoontip/clmm-v2 && pnpm --filter @clmm/ui test
-```
-
-Expected: All tests pass.
-
-- [ ] **Step 3: Run boundary check**
-
-```bash
-cd /home/gpoontip/clmm-v2 && pnpm boundaries
-```
-
-Expected: No boundary violations introduced.
-
-- [ ] **Step 4: Commit if clean**
-
-If all checks pass, the work is complete.
+**Test updates:** Update assertions to match new structure (testIDs, group rendering, etc.)
 
 ---
 
-## Spec Coverage Checklist
+## Task 5: Verify
 
-| Design Element | Implementation Location |
-|---------------|------------------------|
-| Market Thesis card above S/R card | `PositionDetailScreen.tsx` + `MarketThesisCard.tsx` |
+- `pnpm --filter @clmm/ui build`
+- `pnpm --filter @clmm/ui test`
+- `pnpm boundaries`
+
+---
+
+## Spec Coverage
+
+| Design Element | Location |
+|---------------|----------|
+| Market Thesis card | `MarketThesisCard.tsx` |
 | Info icon (circle with i) | `MarketThesisCard.tsx` |
-| Bias as chip in Market Thesis | `MarketThesisCard.tsx` |
-| Summary text rendering | `MarketThesisCard.tsx` |
-| Source/timeframe/setupType metadata | `MarketThesisCard.tsx` |
-| Notes parsed by pipe separator | `PositionDetailViewModel.ts` — `parseNotes` |
-| First section: source, timeframe, bias, setupType | `PositionDetailViewModel.ts` — `parseNotes` |
-| Remaining sections: line breaks | `PositionDetailViewModel.ts` — `parseNotes` |
-| Raw notes when no pipe | `PositionDetailViewModel.ts` — `parseNotes` |
-| Levels grouped by identical metadata | `PositionDetailViewModel.ts` — `makeGroupKey` + grouping |
-| Group shared note at bottom | `SrLevelsCard.tsx` |
-| Group subtle background (surfaceRecessed) | `SrLevelsCard.tsx` |
-| Resistance = red (breach tone) | `PositionDetailViewModel.ts` — tone override |
-| Support = green (safe tone) | `PositionDetailViewModel.ts` — tone override |
-| Yellow (warn) exists but unused | `SrLevelsCard.tsx` — toneColors mapping |
-| No per-row notes | Removed from `SrLevelsCard.tsx` |
-
-## Placeholder Scan
-
-- No "TBD", "TODO", or "implement later" strings.
-- All helper functions have exact implementations.
-- All test code is complete and runnable.
-- All file paths are exact and repo-relative.
+| Group header: bias chip + cluster label | `SrLevelsCard.tsx` |
+| Trigger section with red label | `SrLevelsCard.tsx` |
+| Invalidation section with green label | `SrLevelsCard.tsx` |
+| Shared note at bottom of group | `SrLevelsCard.tsx` |
+| Metadata footer (source/TF/setup) | `SrLevelsCard.tsx` |
+| Resistance = red, Support = green | `PositionDetailViewModel.ts` tone override |
+| Note parsing: source/timeframe/bias/setupType | `PositionDetailViewModel.ts` |
+| Note parsing: trigger/invalidation | `PositionDetailViewModel.ts` |
+| Level grouping by identical metadata | `PositionDetailViewModel.ts` |

--- a/docs/superpowers/plans/2026-04-26-position-detail-sr-redesign-v2.md
+++ b/docs/superpowers/plans/2026-04-26-position-detail-sr-redesign-v2.md
@@ -1,0 +1,1045 @@
+# Position Detail S/R Section Redesign v2 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Redesign the Support & Resistance section with a separate Market Thesis card, grouped S/R levels with parsed shared notes, and resistance=red/support=green color scheme.
+
+**Architecture:** The S/R view-model is restructured to parse notes into structured fields (source, timeframe, bias, setupType) and group levels by identical metadata. A new `MarketThesisCard` component renders above `SrLevelsCard`. The S/R card now shows grouped levels with subtle background containers and shared notes at the bottom of each group.
+
+**Tech Stack:** React Native, TypeScript, Vitest, existing design system tokens.
+
+---
+
+## File Structure
+
+| File | Responsibility |
+|------|---------------|
+| `packages/ui/src/view-models/PositionDetailViewModel.ts` | Parse notes, group levels, tone override, expose summary |
+| `packages/ui/src/view-models/PositionDetailViewModel.test.ts` | Tests for parsing, grouping, tones |
+| `packages/ui/src/components/MarketThesisCard.tsx` | NEW — renders summary with info icon and metadata |
+| `packages/ui/src/components/SrLevelsCard.tsx` | Redesign — groups, no per-row notes, red resistance |
+| `packages/ui/src/screens/PositionDetailScreen.tsx` | Render MarketThesisCard above SrLevelsCard |
+| `packages/ui/src/screens/PositionDetailScreen.test.tsx` | Update for new card structure |
+
+---
+
+## Task 1: Restructure S/R View-Model with Note Parsing and Grouping
+
+**Files:**
+- Modify: `packages/ui/src/view-models/PositionDetailViewModel.ts`
+- Modify: `packages/ui/src/view-models/PositionDetailViewModel.test.ts`
+
+- [ ] **Step 1: Update the SrLevelViewModel type**
+
+Remove `note` from `SrLevelViewModel`:
+
+```typescript
+export type SrLevelViewModel = {
+  kind: 'support' | 'resistance';
+  rawPrice: number;
+  priceLabel: string;
+  tone: 'safe' | 'warn' | 'breach';
+};
+```
+
+- [ ] **Step 2: Add new group and view-model types**
+
+Add these types after `SrLevelViewModel`:
+
+```typescript
+export type SrLevelGroupViewModel = {
+  levels: SrLevelViewModel[];
+  note: string;
+  source?: string;
+  timeframe?: string;
+  bias?: string;
+  setupType?: string;
+};
+
+export type SrLevelsViewModelBlock = {
+  summary?: string;
+  groups: SrLevelGroupViewModel[];
+  freshnessLabel: string;
+  isStale: boolean;
+};
+```
+
+- [ ] **Step 3: Add note parsing helper**
+
+Add this function above `toSrLevelsViewModelBlock`:
+
+```typescript
+function parseNotes(notes: string | undefined): {
+  source?: string;
+  timeframe?: string;
+  bias?: string;
+  setupType?: string;
+  remaining: string;
+} {
+  if (!notes) {
+    return { remaining: '' };
+  }
+
+  const parts = notes.split('|');
+  if (parts.length === 1) {
+    return { remaining: notes.trim() };
+  }
+
+  const firstSection = parts[0].trim();
+  const remaining = parts.slice(1).join('\n').trim();
+
+  // Parse: "source, timeframe, bias. setupType"
+  const commaParts = firstSection.split(',').map((s) => s.trim());
+  const source = commaParts[0];
+  const timeframe = commaParts[1];
+
+  // Bias and setupType are separated by period
+  const biasSetupPart = commaParts.slice(2).join(',').trim();
+  const dotIndex = biasSetupPart.indexOf('.');
+  const bias = dotIndex > -1 ? biasSetupPart.slice(0, dotIndex).trim() : biasSetupPart;
+  const setupType = dotIndex > -1 ? biasSetupPart.slice(dotIndex + 1).trim() : undefined;
+
+  return {
+    ...(source ? { source } : {}),
+    ...(timeframe ? { timeframe } : {}),
+    ...(bias ? { bias } : {}),
+    ...(setupType ? { setupType } : {}),
+    remaining,
+  };
+}
+```
+
+- [ ] **Step 4: Add grouping helper**
+
+Add this function above `toSrLevelsViewModelBlock`:
+
+```typescript
+type GroupKey = string;
+
+function makeGroupKey(level: { rank?: string; timeframe?: string; notes?: string }): GroupKey {
+  return `${level.rank ?? ''}:${level.timeframe ?? ''}:${level.notes ?? ''}`;
+}
+```
+
+- [ ] **Step 5: Rewrite toSrLevelsViewModelBlock with grouping**
+
+Replace the existing `toSrLevelsViewModelBlock`:
+
+```typescript
+function toSrLevelsViewModelBlock(
+  block: NonNullable<PositionDetailDto['srLevels']>,
+  currentPrice: number,
+  lowerBound: number,
+  upperBound: number,
+  now: number,
+): SrLevelsViewModelBlock {
+  const { freshnessLabel, isStale } = computeFreshness(block.capturedAtUnixMs, now);
+
+  // Group raw levels by identical metadata
+  const rawGroups = new Map<string, { kind: 'support' | 'resistance'; items: typeof block.supports }>();
+
+  const addToGroup = (kind: 'support' | 'resistance', items: typeof block.supports) => {
+    for (const item of items) {
+      const key = makeGroupKey(item);
+      const existing = rawGroups.get(key);
+      if (existing) {
+        existing.items.push(item);
+      } else {
+        rawGroups.set(key, { kind, items: [item] });
+      }
+    }
+  };
+
+  addToGroup('support', block.supports);
+  addToGroup('resistance', block.resistances);
+
+  const groups: SrLevelGroupViewModel[] = [];
+
+  for (const [key, { kind, items }] of rawGroups) {
+    const first = items[0];
+    const parsed = parseNotes(first.notes);
+
+    const levels = items.map((item) => ({
+      kind,
+      rawPrice: item.price,
+      priceLabel: `$${item.price.toFixed(2)}`,
+      tone: kind === 'resistance' ? ('breach' as const) : ('safe' as const),
+    }));
+
+    // Sort levels within group by price ascending
+    levels.sort((a, b) => a.rawPrice - b.rawPrice);
+
+    groups.push({
+      levels,
+      note: parsed.remaining,
+      ...(parsed.source ? { source: parsed.source } : {}),
+      ...(parsed.timeframe ? { timeframe: parsed.timeframe } : {}),
+      ...(parsed.bias ? { bias: parsed.bias } : {}),
+      ...(parsed.setupType ? { setupType: parsed.setupType } : {}),
+    });
+  }
+
+  // Sort groups by lowest price in each group
+  groups.sort((a, b) => a.levels[0].rawPrice - b.levels[0].rawPrice);
+
+  return {
+    summary: block.summary ?? undefined,
+    groups,
+    freshnessLabel,
+    isStale,
+  };
+}
+```
+
+- [ ] **Step 6: Remove old computeLevelTone and computeLevelNote**
+
+These are no longer needed. Delete them.
+
+- [ ] **Step 7: Remove isNearBound and isWithinProximity**
+
+These are no longer needed. Delete them.
+
+- [ ] **Step 8: Remove BOUND_EPSILON and PROXIMITY_THRESHOLD**
+
+These constants are no longer needed. Delete them.
+
+- [ ] **Step 9: Update view-model tests**
+
+Replace the test file contents:
+
+```typescript
+import { describe, expect, it } from 'vitest';
+import type { PositionDetailDto } from '@clmm/application/public';
+import { buildPositionDetailViewModel } from './PositionDetailViewModel.js';
+
+function makeDto(overrides: Partial<PositionDetailDto> = {}): PositionDetailDto {
+  return {
+    positionId: 'position-1' as PositionDetailDto['positionId'],
+    poolId: 'pool-1' as PositionDetailDto['poolId'],
+    tokenPairLabel: 'SOL / USDC',
+    currentPrice: 150,
+    currentPriceLabel: 'USDC 150.00',
+    feeRateLabel: '10 bps',
+    rangeState: 'in-range',
+    rangeDistance: { belowLowerPercent: 0, aboveUpperPercent: 0 },
+    hasActionableTrigger: false,
+    monitoringStatus: 'active',
+    lowerBound: 100,
+    upperBound: 200,
+    lowerBoundLabel: 'USDC 100.00',
+    upperBoundLabel: 'USDC 200.00',
+    sqrtPrice: '123456',
+    unclaimedFees: {
+      feeOwedA: { raw: '100000000', decimals: 9, symbol: 'SOL', usdValue: 15 },
+      feeOwedB: { raw: '30000000', decimals: 6, symbol: 'USDC', usdValue: 30 },
+      totalUsd: 45,
+    },
+    unclaimedRewards: {
+      rewards: [],
+      totalUsd: 0,
+    },
+    positionLiquidity: '5000000000',
+    poolLiquidity: '2400000000',
+    poolDepthLabel: 'depth unavailable',
+    ...overrides,
+  };
+}
+
+function makeSrBlock(overrides: Partial<NonNullable<PositionDetailDto['srLevels']>> = {}): NonNullable<PositionDetailDto['srLevels']> {
+  return {
+    briefId: 'brief-1',
+    sourceRecordedAtIso: null,
+    summary: null,
+    capturedAtUnixMs: 1_000_000_000,
+    supports: [{ price: 90 }, { price: 110 }],
+    resistances: [{ price: 180 }, { price: 210 }],
+    ...overrides,
+  };
+}
+
+describe('buildPositionDetailViewModel srLevels', () => {
+  it('returns srLevels undefined when dto has no srLevels', () => {
+    const vm = buildPositionDetailViewModel(makeDto(), Date.now());
+    expect(vm.srLevels).toBeUndefined();
+  });
+
+  it('returns a populated srLevels block when dto.srLevels is present', () => {
+    const now = 2_000_000;
+    const vm = buildPositionDetailViewModel(
+      makeDto({ srLevels: makeSrBlock({ capturedAtUnixMs: 1_700_000 }) }),
+      now,
+    );
+    expect(vm.srLevels).toBeDefined();
+    expect(vm.srLevels!.groups.length).toBeGreaterThan(0);
+  });
+
+  it('computes freshness for 5 minutes ago', () => {
+    const now = 2_000_000;
+    const vm = buildPositionDetailViewModel(
+      makeDto({ srLevels: makeSrBlock({ capturedAtUnixMs: 1_700_000 }) }),
+      now,
+    );
+    expect(vm.srLevels?.freshnessLabel).toBe('AI · MCO · 5m ago');
+    expect(vm.srLevels?.isStale).toBe(false);
+  });
+
+  it('parses notes with pipe separator', () => {
+    const now = 200_000_000;
+    const vm = buildPositionDetailViewModel(
+      makeDto({
+        srLevels: makeSrBlock({
+          capturedAtUnixMs: now,
+          supports: [
+            { price: 90, notes: 'morecryptoonline, 4h, Bearish. swing | Break below $85 signals C-wave down.' },
+          ],
+          resistances: [],
+        }),
+      }),
+      now,
+    );
+    const group = vm.srLevels!.groups[0]!;
+    expect(group.source).toBe('morecryptoonline');
+    expect(group.timeframe).toBe('4h');
+    expect(group.bias).toBe('Bearish');
+    expect(group.setupType).toBe('swing');
+    expect(group.note).toBe('Break below $85 signals C-wave down.');
+  });
+
+  it('returns raw notes when no pipe separator', () => {
+    const now = 200_000_000;
+    const vm = buildPositionDetailViewModel(
+      makeDto({
+        srLevels: makeSrBlock({
+          capturedAtUnixMs: now,
+          supports: [{ price: 90, notes: 'Primary support zone' }],
+          resistances: [],
+        }),
+      }),
+      now,
+    );
+    const group = vm.srLevels!.groups[0]!;
+    expect(group.note).toBe('Primary support zone');
+    expect(group.source).toBeUndefined();
+  });
+
+  it('groups levels with identical metadata', () => {
+    const now = 200_000_000;
+    const vm = buildPositionDetailViewModel(
+      makeDto({
+        srLevels: makeSrBlock({
+          capturedAtUnixMs: now,
+          supports: [
+            { price: 90, rank: 'S1', notes: 'source, 1h, Bullish. test | note body' },
+            { price: 110, rank: 'S1', notes: 'source, 1h, Bullish. test | note body' },
+          ],
+          resistances: [],
+        }),
+      }),
+      now,
+    );
+    expect(vm.srLevels!.groups.length).toBe(1);
+    expect(vm.srLevels!.groups[0]!.levels.length).toBe(2);
+  });
+
+  it('creates separate groups for different metadata', () => {
+    const now = 200_000_000;
+    const vm = buildPositionDetailViewModel(
+      makeDto({
+        srLevels: makeSrBlock({
+          capturedAtUnixMs: now,
+          supports: [
+            { price: 90, rank: 'S1', notes: 'note A' },
+            { price: 110, rank: 'S2', notes: 'note B' },
+          ],
+          resistances: [],
+        }),
+      }),
+      now,
+    );
+    expect(vm.srLevels!.groups.length).toBe(2);
+  });
+
+  it('marks resistance as breach tone (red)', () => {
+    const now = 200_000_000;
+    const vm = buildPositionDetailViewModel(
+      makeDto({
+        srLevels: makeSrBlock({
+          capturedAtUnixMs: now,
+          supports: [],
+          resistances: [{ price: 180 }],
+        }),
+      }),
+      now,
+    );
+    expect(vm.srLevels!.groups[0]!.levels[0]!.tone).toBe('breach');
+  });
+
+  it('marks support as safe tone (green)', () => {
+    const now = 200_000_000;
+    const vm = buildPositionDetailViewModel(
+      makeDto({
+        srLevels: makeSrBlock({
+          capturedAtUnixMs: now,
+          supports: [{ price: 90 }],
+          resistances: [],
+        }),
+      }),
+      now,
+    );
+    expect(vm.srLevels!.groups[0]!.levels[0]!.tone).toBe('safe');
+  });
+
+  it('passes summary through to view-model', () => {
+    const now = 200_000_000;
+    const vm = buildPositionDetailViewModel(
+      makeDto({
+        srLevels: makeSrBlock({
+          capturedAtUnixMs: now,
+          summary: 'Bearish swing, trend continuation.',
+        }),
+      }),
+      now,
+    );
+    expect(vm.srLevels!.summary).toBe('Bearish swing, trend continuation.');
+  });
+
+  it('sorts groups by lowest price ascending', () => {
+    const now = 200_000_000;
+    const vm = buildPositionDetailViewModel(
+      makeDto({
+        srLevels: makeSrBlock({
+          capturedAtUnixMs: now,
+          supports: [{ price: 130, notes: 'high' }],
+          resistances: [{ price: 80, notes: 'low' }],
+        }),
+      }),
+      now,
+    );
+    // Resistance at 80 should come before support at 130
+    expect(vm.srLevels!.groups[0]!.levels[0]!.priceLabel).toBe('$80.00');
+    expect(vm.srLevels!.groups[1]!.levels[0]!.priceLabel).toBe('$130.00');
+  });
+});
+```
+
+- [ ] **Step 10: Run view-model tests**
+
+```bash
+cd /home/gpoontip/clmm-v2/packages/ui && npx vitest run src/view-models/PositionDetailViewModel.test.ts
+```
+
+Expected: All tests pass.
+
+- [ ] **Step 11: Commit view-model changes**
+
+```bash
+git add packages/ui/src/view-models/PositionDetailViewModel.ts packages/ui/src/view-models/PositionDetailViewModel.test.ts
+git commit -m "feat: parse notes, group levels, add summary to S/R view-model"
+```
+
+---
+
+## Task 2: Create MarketThesisCard Component
+
+**Files:**
+- Create: `packages/ui/src/components/MarketThesisCard.tsx`
+- Modify: `packages/ui/src/screens/PositionDetailScreen.tsx`
+- Modify: `packages/ui/src/screens/PositionDetailScreen.test.tsx`
+
+- [ ] **Step 1: Create MarketThesisCard.tsx**
+
+```typescript
+import { View, Text } from 'react-native';
+import { colors, typography } from '../design-system/index.js';
+
+function InfoIcon(): JSX.Element {
+  return (
+    <View style={{
+      width: 16,
+      height: 16,
+      borderRadius: 8,
+      borderWidth: 1,
+      borderColor: colors.textMuted,
+      justifyContent: 'center',
+      alignItems: 'center',
+    }}>
+      <Text style={{
+        fontSize: 10,
+        color: colors.textMuted,
+        fontWeight: typography.fontWeight.semibold,
+        lineHeight: 14,
+      }}>
+        i
+      </Text>
+    </View>
+  );
+}
+
+type Props = {
+  summary: string;
+  source?: string;
+  timeframe?: string;
+  bias?: string;
+  setupType?: string;
+};
+
+export function MarketThesisCard({ summary, source, timeframe, bias, setupType }: Props): JSX.Element {
+  return (
+    <View style={{
+      marginTop: 14,
+      padding: 16,
+      backgroundColor: colors.surface,
+      borderRadius: 8,
+      borderWidth: 1,
+      borderColor: colors.border,
+    }}>
+      {/* Header */}
+      <View style={{
+        flexDirection: 'row',
+        alignItems: 'center',
+        gap: 8,
+        marginBottom: 12,
+      }}>
+        <InfoIcon />
+        <Text style={{
+          color: colors.textSecondary,
+          fontSize: typography.fontSize.micro,
+          fontWeight: typography.fontWeight.semibold,
+          letterSpacing: 0.08,
+          textTransform: 'uppercase',
+        }}>
+          Market Thesis
+        </Text>
+        {bias ? (
+          <View style={{
+            height: 22,
+            paddingHorizontal: 8,
+            borderRadius: 999,
+            borderWidth: 1,
+            borderColor: 'rgba(244,201,122,0.30)',
+            justifyContent: 'center',
+            alignItems: 'center',
+          }}>
+            <Text style={{
+              fontSize: typography.fontSize.micro,
+              color: colors.warn,
+              fontWeight: typography.fontWeight.semibold,
+            }}>
+              {bias}
+            </Text>
+          </View>
+        ) : null}
+      </View>
+
+      {/* Summary text */}
+      <Text style={{
+        color: colors.text,
+        fontSize: typography.fontSize.sm,
+        lineHeight: typography.lineHeight.normal * typography.fontSize.sm,
+      }}>
+        {summary}
+      </Text>
+
+      {/* Metadata */}
+      <View style={{ marginTop: 12 }}>
+        {source ? (
+          <Text style={{
+            fontSize: typography.fontSize.micro,
+            color: colors.textMuted,
+          }}>
+            Source · {source}
+          </Text>
+        ) : null}
+        {timeframe ? (
+          <Text style={{
+            fontSize: typography.fontSize.micro,
+            color: colors.textMuted,
+          }}>
+            Timeframe · {timeframe}
+          </Text>
+        ) : null}
+        {setupType ? (
+          <Text style={{
+            fontSize: typography.fontSize.micro,
+            color: colors.textMuted,
+          }}>
+            Setup · {setupType}
+          </Text>
+        ) : null}
+      </View>
+    </View>
+  );
+}
+```
+
+- [ ] **Step 2: Update PositionDetailScreen to render MarketThesisCard**
+
+Find where `SrLevelsCard` is rendered and add `MarketThesisCard` above it:
+
+```typescript
+import { MarketThesisCard } from '../components/MarketThesisCard.js';
+```
+
+Then in the JSX, replace:
+```tsx
+<SrLevelsCard srLevels={vm.srLevels} />
+```
+
+With:
+```tsx
+{vm.srLevels?.summary ? (
+  <MarketThesisCard
+    summary={vm.srLevels.summary}
+    source={vm.srLevels.groups[0]?.source}
+    timeframe={vm.srLevels.groups[0]?.timeframe}
+    bias={vm.srLevels.groups[0]?.bias}
+    setupType={vm.srLevels.groups[0]?.setupType}
+  />
+) : null}
+<SrLevelsCard srLevels={vm.srLevels} />
+```
+
+- [ ] **Step 3: Add MarketThesisCard test**
+
+In `PositionDetailScreen.test.tsx`, add:
+
+```typescript
+  it('renders Market Thesis card when summary is present', () => {
+    const now = Date.now();
+    vi.spyOn(Date, 'now').mockReturnValue(now);
+
+    render(
+      <PositionDetailScreen
+        position={makePosition({
+          srLevels: {
+            briefId: 'brief-1',
+            sourceRecordedAtIso: null,
+            summary: 'Bearish swing, trend continuation.',
+            capturedAtUnixMs: now,
+            supports: [{ price: 90 }],
+            resistances: [],
+          },
+        })}
+      />,
+    );
+
+    expect(screen.getByText('Market Thesis')).toBeTruthy();
+    expect(screen.getByText('Bearish swing, trend continuation.')).toBeTruthy();
+
+    vi.restoreAllMocks();
+  });
+
+  it('does not render Market Thesis card when summary is absent', () => {
+    const now = Date.now();
+    vi.spyOn(Date, 'now').mockReturnValue(now);
+
+    render(
+      <PositionDetailScreen
+        position={makePosition({
+          srLevels: makeSrBlock(now),
+        })}
+      />,
+    );
+
+    expect(screen.queryByText('Market Thesis')).toBeNull();
+
+    vi.restoreAllMocks();
+  });
+```
+
+- [ ] **Step 4: Run screen tests**
+
+```bash
+cd /home/gpoontip/clmm-v2/packages/ui && npx vitest run src/screens/PositionDetailScreen.test.tsx
+```
+
+Expected: All tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/ui/src/components/MarketThesisCard.tsx packages/ui/src/screens/PositionDetailScreen.tsx packages/ui/src/screens/PositionDetailScreen.test.tsx
+git commit -m "feat: add MarketThesisCard component with summary and metadata"
+```
+
+---
+
+## Task 3: Redesign SrLevelsCard with Groups and Colors
+
+**Files:**
+- Modify: `packages/ui/src/components/SrLevelsCard.tsx`
+- Modify: `packages/ui/src/screens/PositionDetailScreen.test.tsx`
+
+- [ ] **Step 1: Update toneColors mapping**
+
+Keep the mapping but resistance will always use `breach`:
+
+```typescript
+const toneColors = {
+  safe: { text: colors.safe, border: 'rgba(158,236,209,0.30)' },
+  warn: { text: colors.warn, border: 'rgba(244,201,122,0.30)' },
+  breach: { text: colors.breachAccent, border: 'rgba(245,148,132,0.30)' },
+} as const;
+```
+
+- [ ] **Step 2: Replace SrLevelsCard with grouped design**
+
+```typescript
+import { View, Text } from 'react-native';
+import { colors, typography } from '../design-system/index.js';
+import type { SrLevelsViewModelBlock } from '../view-models/PositionDetailViewModel.js';
+
+const toneColors = {
+  safe: { text: colors.safe, border: 'rgba(158,236,209,0.30)' },
+  warn: { text: colors.warn, border: 'rgba(244,201,122,0.30)' },
+  breach: { text: colors.breachAccent, border: 'rgba(245,148,132,0.30)' },
+} as const;
+
+type Props = {
+  srLevels?: SrLevelsViewModelBlock | undefined;
+};
+
+export function SrLevelsCard({ srLevels }: Props): JSX.Element {
+  if (!srLevels) {
+    return (
+      <Text style={{
+        color: colors.textSecondary,
+        fontSize: typography.fontSize.sm,
+        marginTop: 16,
+      }}>
+        No current MCO levels available
+      </Text>
+    );
+  }
+
+  return (
+    <View style={{
+      marginTop: 14,
+      padding: 16,
+      backgroundColor: colors.surface,
+      borderRadius: 8,
+      borderWidth: 1,
+      borderColor: colors.border,
+    }}>
+      {/* Header */}
+      <View style={{
+        flexDirection: 'row',
+        justifyContent: 'space-between',
+        alignItems: 'center',
+        marginBottom: 10,
+      }}>
+        <Text style={{
+          color: colors.textSecondary,
+          fontSize: typography.fontSize.sm,
+          fontWeight: typography.fontWeight.medium,
+        }}>
+          Support & Resistance
+        </Text>
+        <Text style={{
+          fontSize: typography.fontSize.micro,
+          color: colors.textMuted,
+        }}>
+          {srLevels.freshnessLabel}
+        </Text>
+      </View>
+
+      {/* Groups */}
+      {srLevels.groups.map((group, groupIndex) => (
+        <View
+          key={`sr-group-${groupIndex}`}
+          testID={`sr-group-${groupIndex}`}
+          style={{
+            backgroundColor: colors.surfaceRecessed,
+            borderRadius: 6,
+            padding: 12,
+            marginBottom: groupIndex < srLevels.groups.length - 1 ? 8 : 0,
+          }}
+        >
+          {/* Levels in group */}
+          {group.levels.map((level, levelIndex) => {
+            const tone = toneColors[level.tone];
+            return (
+              <View
+                key={`sr-level-${groupIndex}-${levelIndex}`}
+                testID={`sr-level-${groupIndex}-${levelIndex}`}
+                style={{
+                  flexDirection: 'row',
+                  alignItems: 'center',
+                  justifyContent: 'space-between',
+                  paddingVertical: levelIndex === 0 ? 0 : 8,
+                  borderTopWidth: levelIndex === 0 ? 0 : 1,
+                  borderTopColor: colors.border,
+                }}
+              >
+                <View style={{ flexDirection: 'row', alignItems: 'center', gap: 10 }}>
+                  <View style={{
+                    height: 22,
+                    paddingHorizontal: 8,
+                    borderRadius: 999,
+                    borderWidth: 1,
+                    borderColor: tone.border,
+                    justifyContent: 'center',
+                    alignItems: 'center',
+                  }}>
+                    <Text style={{
+                      fontSize: typography.fontSize.micro,
+                      color: tone.text,
+                      fontWeight: typography.fontWeight.semibold,
+                    }}>
+                      {level.kind === 'resistance' ? 'Resist' : 'Support'}
+                    </Text>
+                  </View>
+                  <Text style={{
+                    fontFamily: typography.fontFamily.mono,
+                    fontSize: typography.fontSize.sm,
+                    fontWeight: typography.fontWeight.semibold,
+                    color: colors.text,
+                  }}>
+                    {level.priceLabel}
+                  </Text>
+                </View>
+              </View>
+            );
+          })}
+
+          {/* Group note */}
+          {group.note ? (
+            <Text style={{
+              fontSize: typography.fontSize.micro,
+              color: colors.textMuted,
+              marginTop: 8,
+              lineHeight: 16,
+            }}>
+              {group.note}
+            </Text>
+          ) : null}
+        </View>
+      ))}
+    </View>
+  );
+}
+```
+
+- [ ] **Step 3: Update screen tests for new structure**
+
+Update existing tests in `PositionDetailScreen.test.tsx`:
+
+Replace `renders support and resistance section as a card`:
+```typescript
+  it('renders support and resistance section as a card when srLevels is present', () => {
+    const now = Date.now();
+    vi.spyOn(Date, 'now').mockReturnValue(now);
+
+    render(
+      <PositionDetailScreen
+        position={makePosition({
+          srLevels: makeSrBlock(now),
+        })}
+      />,
+    );
+
+    expect(screen.getByText('Support & Resistance')).toBeTruthy();
+    expect(screen.getByText('AI · MCO · 1m ago')).toBeTruthy();
+    expect(screen.getByTestId('sr-group-0')).toBeTruthy();
+
+    vi.restoreAllMocks();
+  });
+```
+
+Replace `renders level chips with correct labels`:
+```typescript
+  it('renders level chips with correct labels and colors', () => {
+    const now = Date.now();
+    vi.spyOn(Date, 'now').mockReturnValue(now);
+
+    render(
+      <PositionDetailScreen
+        position={makePosition({
+          srLevels: {
+            briefId: 'brief-1',
+            sourceRecordedAtIso: null,
+            summary: null,
+            capturedAtUnixMs: now,
+            supports: [{ price: 90 }],
+            resistances: [{ price: 180 }],
+          },
+        })}
+      />,
+    );
+
+    expect(screen.getByText('Support')).toBeTruthy();
+    expect(screen.getByText('Resist')).toBeTruthy();
+    expect(screen.getByText('$90.00')).toBeTruthy();
+    expect(screen.getByText('$180.00')).toBeTruthy();
+
+    vi.restoreAllMocks();
+  });
+```
+
+Replace `renders resistance-only levels`:
+```typescript
+  it('renders resistance-only levels correctly', () => {
+    const now = Date.now();
+    vi.spyOn(Date, 'now').mockReturnValue(now);
+
+    render(
+      <PositionDetailScreen
+        position={makePosition({
+          srLevels: {
+            briefId: 'brief-1',
+            sourceRecordedAtIso: null,
+            summary: null,
+            capturedAtUnixMs: now,
+            supports: [],
+            resistances: [{ price: 180 }, { price: 210 }],
+          },
+        })}
+      />,
+    );
+
+    expect(screen.getByText('Support & Resistance')).toBeTruthy();
+    expect(screen.getAllByText('Resist')).toHaveLength(2);
+    expect(screen.getByText('$180.00')).toBeTruthy();
+    expect(screen.getByText('$210.00')).toBeTruthy();
+
+    vi.restoreAllMocks();
+  });
+```
+
+Replace `renders support-only levels`:
+```typescript
+  it('renders support-only levels correctly', () => {
+    const now = Date.now();
+    vi.spyOn(Date, 'now').mockReturnValue(now);
+
+    render(
+      <PositionDetailScreen
+        position={makePosition({
+          srLevels: {
+            briefId: 'brief-1',
+            sourceRecordedAtIso: null,
+            summary: null,
+            capturedAtUnixMs: now,
+            supports: [{ price: 90 }, { price: 110 }],
+            resistances: [],
+          },
+        })}
+      />,
+    );
+
+    expect(screen.getByText('Support & Resistance')).toBeTruthy();
+    expect(screen.getAllByText('Support')).toHaveLength(2);
+    expect(screen.getByText('$90.00')).toBeTruthy();
+    expect(screen.getByText('$110.00')).toBeTruthy();
+
+    vi.restoreAllMocks();
+  });
+```
+
+Replace `renders empty levels`:
+```typescript
+  it('renders empty groups message when both supports and resistances are empty', () => {
+    const now = Date.now();
+    vi.spyOn(Date, 'now').mockReturnValue(now);
+
+    render(
+      <PositionDetailScreen
+        position={makePosition({
+          srLevels: {
+            briefId: 'brief-1',
+            sourceRecordedAtIso: null,
+            summary: null,
+            capturedAtUnixMs: now,
+            supports: [],
+            resistances: [],
+          },
+        })}
+      />,
+    );
+
+    expect(screen.getByText('Support & Resistance')).toBeTruthy();
+    expect(screen.queryByTestId('sr-group-0')).toBeNull();
+
+    vi.restoreAllMocks();
+  });
+```
+
+- [ ] **Step 4: Run screen tests**
+
+```bash
+cd /home/gpoontip/clmm-v2/packages/ui && npx vitest run src/screens/PositionDetailScreen.test.tsx
+```
+
+Expected: All tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/ui/src/components/SrLevelsCard.tsx packages/ui/src/screens/PositionDetailScreen.test.tsx
+git commit -m "feat: redesign SrLevelsCard with groups, shared notes, resistance=red"
+```
+
+---
+
+## Task 4: Verify Cross-Package Build and Boundaries
+
+**Files:**
+- (no file changes — verification only)
+
+- [ ] **Step 1: Run UI package build**
+
+```bash
+cd /home/gpoontip/clmm-v2 && pnpm --filter @clmm/ui build
+```
+
+Expected: Build succeeds with no TypeScript errors.
+
+- [ ] **Step 2: Run UI package tests**
+
+```bash
+cd /home/gpoontip/clmm-v2 && pnpm --filter @clmm/ui test
+```
+
+Expected: All tests pass.
+
+- [ ] **Step 3: Run boundary check**
+
+```bash
+cd /home/gpoontip/clmm-v2 && pnpm boundaries
+```
+
+Expected: No boundary violations introduced.
+
+- [ ] **Step 4: Commit if clean**
+
+If all checks pass, the work is complete.
+
+---
+
+## Spec Coverage Checklist
+
+| Design Element | Implementation Location |
+|---------------|------------------------|
+| Market Thesis card above S/R card | `PositionDetailScreen.tsx` + `MarketThesisCard.tsx` |
+| Info icon (circle with i) | `MarketThesisCard.tsx` |
+| Bias as chip in Market Thesis | `MarketThesisCard.tsx` |
+| Summary text rendering | `MarketThesisCard.tsx` |
+| Source/timeframe/setupType metadata | `MarketThesisCard.tsx` |
+| Notes parsed by pipe separator | `PositionDetailViewModel.ts` — `parseNotes` |
+| First section: source, timeframe, bias, setupType | `PositionDetailViewModel.ts` — `parseNotes` |
+| Remaining sections: line breaks | `PositionDetailViewModel.ts` — `parseNotes` |
+| Raw notes when no pipe | `PositionDetailViewModel.ts` — `parseNotes` |
+| Levels grouped by identical metadata | `PositionDetailViewModel.ts` — `makeGroupKey` + grouping |
+| Group shared note at bottom | `SrLevelsCard.tsx` |
+| Group subtle background (surfaceRecessed) | `SrLevelsCard.tsx` |
+| Resistance = red (breach tone) | `PositionDetailViewModel.ts` — tone override |
+| Support = green (safe tone) | `PositionDetailViewModel.ts` — tone override |
+| Yellow (warn) exists but unused | `SrLevelsCard.tsx` — toneColors mapping |
+| No per-row notes | Removed from `SrLevelsCard.tsx` |
+
+## Placeholder Scan
+
+- No "TBD", "TODO", or "implement later" strings.
+- All helper functions have exact implementations.
+- All test code is complete and runnable.
+- All file paths are exact and repo-relative.

--- a/docs/superpowers/plans/2026-04-26-position-detail-sr-redesign.md
+++ b/docs/superpowers/plans/2026-04-26-position-detail-sr-redesign.md
@@ -1,0 +1,739 @@
+# Position Detail S/R Section Redesign Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Redesign the Support & Resistance section on the Position Detail screen to match the `ScreenRegime` design from `design/screens-b.jsx`, with unified level rows, tone-colored chips, contextual notes, and a card-based layout.
+
+**Architecture:** The S/R view-model currently splits supports and resistances into separate sorted arrays with simple price labels. We will restructure it into a single unified `levels` array where each level carries its rendered `kind` (Support/Resist), `priceLabel`, contextual `note`, and semantic `tone` (safe/warn/breach). The screen will render these as a card with a header and per-row chip+price+note layout. Tone and notes are computed in the view-model builder from the position's current price, range bounds, and level metadata.
+
+**Tech Stack:** React Native (via React DOM renderer in tests), TypeScript, Vitest, `@testing-library/react`, existing design system tokens (`colors`, `typography`).
+
+---
+
+## File Structure
+
+| File | Responsibility |
+|------|---------------|
+| `packages/ui/src/view-models/PositionDetailViewModel.ts` | Build the S/R view-model block: compute tones, notes, freshness, and sort levels into a unified array. |
+| `packages/ui/src/view-models/PositionDetailViewModel.test.ts` | Unit tests for the view-model builder, including tone and note logic. |
+| `packages/ui/src/screens/PositionDetailScreen.tsx` | Render the redesigned S/R card section with chips, prices, notes, and freshness header. |
+| `packages/ui/src/screens/PositionDetailScreen.test.tsx` | Screen tests asserting the new S/R card structure and content. |
+
+---
+
+## Task 1: Restructure S/R View-Model with Tone, Notes, and Unified Levels
+
+**Files:**
+- Modify: `packages/ui/src/view-models/PositionDetailViewModel.ts`
+- Modify: `packages/ui/src/view-models/PositionDetailViewModel.test.ts`
+
+- [ ] **Step 1: Update the `SrLevelsViewModelBlock` type**
+
+Replace the existing type with the new unified structure:
+
+```typescript
+export type SrLevelViewModel = {
+  kind: 'support' | 'resistance';
+  priceLabel: string;
+  note: string;
+  tone: 'safe' | 'warn' | 'breach';
+};
+
+export type SrLevelsViewModelBlock = {
+  levels: SrLevelViewModel[];
+  freshnessLabel: string;
+  isStale: boolean;
+};
+```
+
+- [ ] **Step 2: Add helper functions for tone and note computation**
+
+Add these helpers above `toSrLevelsViewModelBlock`:
+
+```typescript
+const BOUND_EPSILON = 0.01;
+const PROXIMITY_THRESHOLD = 0.05; // 5%
+
+function isNearBound(price: number, bound: number): boolean {
+  return Math.abs(price - bound) <= BOUND_EPSILON;
+}
+
+function isWithinProximity(currentPrice: number, levelPrice: number): boolean {
+  if (levelPrice === 0) return false;
+  return Math.abs(currentPrice - levelPrice) / levelPrice <= PROXIMITY_THRESHOLD;
+}
+
+function computeLevelTone(
+  kind: 'support' | 'resistance',
+  levelPrice: number,
+  currentPrice: number,
+  lowerBound: number,
+  upperBound: number,
+): 'safe' | 'warn' | 'breach' {
+  if (kind === 'resistance') {
+    if (currentPrice > levelPrice) return 'breach';
+    if (isNearBound(levelPrice, upperBound)) return 'warn';
+    if (isWithinProximity(currentPrice, levelPrice)) return 'warn';
+    return 'safe';
+  }
+  // support
+  if (currentPrice < levelPrice) return 'breach';
+  if (isNearBound(levelPrice, lowerBound)) return 'warn';
+  if (isWithinProximity(currentPrice, levelPrice)) return 'warn';
+  return 'safe';
+}
+
+function computeLevelNote(
+  level: { price: number; rank?: string; notes?: string },
+  lowerBound: number,
+  upperBound: number,
+): string {
+  if (level.notes) return level.notes;
+  if (isNearBound(level.price, lowerBound)) return 'Range lower · your position';
+  if (isNearBound(level.price, upperBound)) return 'Range upper · your position';
+  if (level.rank) return level.rank;
+  return '';
+}
+```
+
+- [ ] **Step 3: Rewrite `toSrLevelsViewModelBlock`**
+
+Replace the existing `toSrLevelsViewModelBlock` function with:
+
+```typescript
+function toSrLevelsViewModelBlock(
+  block: NonNullable<PositionDetailDto['srLevels']>,
+  currentPrice: number,
+  lowerBound: number,
+  upperBound: number,
+  now: number,
+): SrLevelsViewModelBlock {
+  const { freshnessLabel, isStale } = computeFreshness(block.capturedAtUnixMs, now);
+
+  const supportLevels: SrLevelViewModel[] = block.supports.map((s) => ({
+    kind: 'support',
+    priceLabel: `$${s.price.toFixed(2)}`,
+    note: computeLevelNote(s, lowerBound, upperBound),
+    tone: computeLevelTone('support', s.price, currentPrice, lowerBound, upperBound),
+  }));
+
+  const resistanceLevels: SrLevelViewModel[] = block.resistances.map((r) => ({
+    kind: 'resistance',
+    priceLabel: `$${r.price.toFixed(2)}`,
+    note: computeLevelNote(r, lowerBound, upperBound),
+    tone: computeLevelTone('resistance', r.price, currentPrice, lowerBound, upperBound),
+  }));
+
+  // Sort all levels by price ascending
+  const levels = [...supportLevels, ...resistanceLevels].sort(
+    (a, b) => parseFloat(a.priceLabel.slice(1)) - parseFloat(b.priceLabel.slice(1)),
+  );
+
+  return { levels, freshnessLabel, isStale };
+}
+```
+
+- [ ] **Step 4: Update `computeFreshness` to match design label format**
+
+Replace the `computeFreshness` function:
+
+```typescript
+function computeFreshness(capturedAtUnixMs: number, now: number): { freshnessLabel: string; isStale: boolean } {
+  const ageMs = now - capturedAtUnixMs;
+  if (ageMs < 3600000) {
+    const minutes = Math.max(1, Math.round(ageMs / 60000));
+    return { freshnessLabel: `AI · MCO · ${minutes}m ago`, isStale: false };
+  }
+  const hours = Math.round(ageMs / 3600000);
+  if (ageMs < 172800000) {
+    return { freshnessLabel: `AI · MCO · ${hours}h ago`, isStale: false };
+  }
+  return { freshnessLabel: `AI · MCO · ${hours}h ago · stale`, isStale: true };
+}
+```
+
+- [ ] **Step 5: Update the `buildPositionDetailViewModel` call site**
+
+Find the line:
+```typescript
+const srLevelsVm = dto.srLevels
+  ? toSrLevelsViewModelBlock(dto.srLevels, now)
+  : undefined;
+```
+
+Replace with:
+```typescript
+const srLevelsVm = dto.srLevels
+  ? toSrLevelsViewModelBlock(dto.srLevels, dto.currentPrice, dto.lowerBound, dto.upperBound, now)
+  : undefined;
+```
+
+- [ ] **Step 6: Update view-model tests**
+
+Replace the contents of `packages/ui/src/view-models/PositionDetailViewModel.test.ts` (from line 50 onwards) with updated tests for the new shape:
+
+```typescript
+describe('buildPositionDetailViewModel srLevels', () => {
+  it('returns srLevels undefined when dto has no srLevels', () => {
+    const vm = buildPositionDetailViewModel(makeDto(), Date.now());
+    expect(vm.srLevels).toBeUndefined();
+  });
+
+  it('returns a populated srLevels block when dto.srLevels is present', () => {
+    const now = 2_000_000;
+    const vm = buildPositionDetailViewModel(
+      makeDto({ srLevels: makeSrBlock({ capturedAtUnixMs: 1_700_000 }) }),
+      now,
+    );
+    expect(vm.srLevels).toBeDefined();
+    expect(vm.srLevels!.levels.length).toBeGreaterThan(0);
+  });
+
+  it('computes freshness for 5 minutes ago', () => {
+    const now = 2_000_000;
+    const vm = buildPositionDetailViewModel(
+      makeDto({ srLevels: makeSrBlock({ capturedAtUnixMs: 1_700_000 }) }),
+      now,
+    );
+    expect(vm.srLevels?.freshnessLabel).toBe('AI · MCO · 5m ago');
+    expect(vm.srLevels?.isStale).toBe(false);
+  });
+
+  it('computes freshness for 3 hours ago', () => {
+    const now = 20_000_000;
+    const vm = buildPositionDetailViewModel(
+      makeDto({ srLevels: makeSrBlock({ capturedAtUnixMs: 9_200_000 }) }),
+      now,
+    );
+    expect(vm.srLevels?.freshnessLabel).toBe('AI · MCO · 3h ago');
+    expect(vm.srLevels?.isStale).toBe(false);
+  });
+
+  it('computes freshness for 49 hours ago (stale)', () => {
+    const now = 200_000_000;
+    const vm = buildPositionDetailViewModel(
+      makeDto({ srLevels: makeSrBlock({ capturedAtUnixMs: 23_600_000 }) }),
+      now,
+    );
+    expect(vm.srLevels?.freshnessLabel).toBe('AI · MCO · 49h ago · stale');
+    expect(vm.srLevels?.isStale).toBe(true);
+  });
+
+  it('sorts all levels ascending by price', () => {
+    const now = 200_000_000;
+    const vm = buildPositionDetailViewModel(
+      makeDto({
+        currentPrice: 150,
+        lowerBound: 100,
+        upperBound: 200,
+        srLevels: makeSrBlock({
+          capturedAtUnixMs: now,
+          supports: [{ price: 130 }, { price: 90 }],
+          resistances: [{ price: 180 }, { price: 210 }],
+        }),
+      }),
+      now,
+    );
+    const prices = vm.srLevels!.levels.map((l) => l.priceLabel);
+    expect(prices).toEqual(['$90.00', '$130.00', '$180.00', '$210.00']);
+  });
+
+  it('assigns support and resistance kinds correctly', () => {
+    const now = 200_000_000;
+    const vm = buildPositionDetailViewModel(
+      makeDto({
+        currentPrice: 150,
+        lowerBound: 100,
+        upperBound: 200,
+        srLevels: makeSrBlock({
+          capturedAtUnixMs: now,
+          supports: [{ price: 110 }],
+          resistances: [{ price: 190 }],
+        }),
+      }),
+      now,
+    );
+    expect(vm.srLevels!.levels[0]!.kind).toBe('support');
+    expect(vm.srLevels!.levels[1]!.kind).toBe('resistance');
+  });
+
+  it('uses DTO notes when available', () => {
+    const now = 200_000_000;
+    const vm = buildPositionDetailViewModel(
+      makeDto({
+        currentPrice: 150,
+        lowerBound: 100,
+        upperBound: 200,
+        srLevels: makeSrBlock({
+          capturedAtUnixMs: now,
+          supports: [{ price: 110, notes: 'Primary · 30d pivot' }],
+          resistances: [],
+        }),
+      }),
+      now,
+    );
+    expect(vm.srLevels!.levels[0]!.note).toBe('Primary · 30d pivot');
+  });
+
+  it('falls back to range-bound note for lower bound match', () => {
+    const now = 200_000_000;
+    const vm = buildPositionDetailViewModel(
+      makeDto({
+        currentPrice: 150,
+        lowerBound: 110,
+        upperBound: 200,
+        srLevels: makeSrBlock({
+          capturedAtUnixMs: now,
+          supports: [{ price: 110 }],
+          resistances: [],
+        }),
+      }),
+      now,
+    );
+    expect(vm.srLevels!.levels[0]!.note).toBe('Range lower · your position');
+  });
+
+  it('falls back to range-bound note for upper bound match', () => {
+    const now = 200_000_000;
+    const vm = buildPositionDetailViewModel(
+      makeDto({
+        currentPrice: 150,
+        lowerBound: 100,
+        upperBound: 190,
+        srLevels: makeSrBlock({
+          capturedAtUnixMs: now,
+          supports: [],
+          resistances: [{ price: 190 }],
+        }),
+      }),
+      now,
+    );
+    expect(vm.srLevels!.levels[0]!.note).toBe('Range upper · your position');
+  });
+
+  it('falls back to rank label when no notes or bound match', () => {
+    const now = 200_000_000;
+    const vm = buildPositionDetailViewModel(
+      makeDto({
+        currentPrice: 150,
+        lowerBound: 100,
+        upperBound: 200,
+        srLevels: makeSrBlock({
+          capturedAtUnixMs: now,
+          supports: [{ price: 110, rank: 'S1' }],
+          resistances: [],
+        }),
+      }),
+      now,
+    );
+    expect(vm.srLevels!.levels[0]!.note).toBe('S1');
+  });
+
+  it('marks breached resistance as breach tone when price is above it', () => {
+    const now = 200_000_000;
+    const vm = buildPositionDetailViewModel(
+      makeDto({
+        currentPrice: 220,
+        lowerBound: 100,
+        upperBound: 200,
+        srLevels: makeSrBlock({
+          capturedAtUnixMs: now,
+          supports: [],
+          resistances: [{ price: 210 }],
+        }),
+      }),
+      now,
+    );
+    expect(vm.srLevels!.levels[0]!.tone).toBe('breach');
+  });
+
+  it('marks unbreached resistance near upper bound as warn tone', () => {
+    const now = 200_000_000;
+    const vm = buildPositionDetailViewModel(
+      makeDto({
+        currentPrice: 150,
+        lowerBound: 100,
+        upperBound: 200,
+        srLevels: makeSrBlock({
+          capturedAtUnixMs: now,
+          supports: [],
+          resistances: [{ price: 200 }],
+        }),
+      }),
+      now,
+    );
+    expect(vm.srLevels!.levels[0]!.tone).toBe('warn');
+  });
+
+  it('marks distant safe resistance as safe tone', () => {
+    const now = 200_000_000;
+    const vm = buildPositionDetailViewModel(
+      makeDto({
+        currentPrice: 150,
+        lowerBound: 100,
+        upperBound: 200,
+        srLevels: makeSrBlock({
+          capturedAtUnixMs: now,
+          supports: [],
+          resistances: [{ price: 500 }],
+        }),
+      }),
+      now,
+    );
+    expect(vm.srLevels!.levels[0]!.tone).toBe('safe');
+  });
+});
+```
+
+- [ ] **Step 7: Run view-model tests**
+
+Run:
+```bash
+cd /home/gpoontip/clmm-v2/packages/ui && npx vitest run src/view-models/PositionDetailViewModel.test.ts
+```
+
+Expected: All tests pass.
+
+- [ ] **Step 8: Commit view-model changes**
+
+```bash
+git add packages/ui/src/view-models/PositionDetailViewModel.ts packages/ui/src/view-models/PositionDetailViewModel.test.ts
+git commit -m "feat: restructure S/R view-model with tone, notes, and unified levels"
+```
+
+---
+
+## Task 2: Redesign S/R Card in PositionDetailScreen
+
+**Files:**
+- Modify: `packages/ui/src/screens/PositionDetailScreen.tsx`
+- Modify: `packages/ui/src/screens/PositionDetailScreen.test.tsx`
+
+- [ ] **Step 1: Add tone-to-color mapping helper in the screen file**
+
+At the top of `PositionDetailScreen.tsx`, after the imports, add:
+
+```typescript
+const toneColors = {
+  safe: { text: colors.safe, border: 'rgba(158,236,209,0.30)' },
+  warn: { text: colors.warn, border: 'rgba(244,201,122,0.30)' },
+  breach: { text: colors.breachAccent, border: 'rgba(245,148,132,0.30)' },
+} as const;
+```
+
+- [ ] **Step 2: Replace the old S/R section rendering**
+
+Find and remove the entire old S/R block (lines 297–320 in the current file):
+
+```tsx
+{vm.srLevels ? (
+  <View style={{ marginTop: 4 }}>
+    <Text style={srStyles.sectionTitle}>
+      Support & Resistance (MCO)
+    </Text>
+    <Text style={srStyles.subsectionTitle}>Support</Text>
+    {vm.srLevels.supportsSorted.map((s, i) => (
+      <Text key={`s-${i}`} testID={`sr-support-${i}`} style={srStyles.levelRow}>
+        {s.priceLabel}{s.rankLabel ? ` (${s.rankLabel})` : ''}
+      </Text>
+    ))}
+    <Text style={srStyles.subsectionTitle}>Resistance</Text>
+    {vm.srLevels.resistancesSorted.map((r, i) => (
+      <Text key={`r-${i}`} testID={`sr-resistance-${i}`} style={srStyles.levelRow}>
+        {r.priceLabel}{r.rankLabel ? ` (${r.rankLabel})` : ''}
+      </Text>
+    ))}
+    <Text testID="sr-freshness" style={vm.srLevels.isStale ? srStyles.staleLabel : srStyles.freshnessLabel}>
+      {vm.srLevels.freshnessLabel}
+    </Text>
+  </View>
+) : (
+  <Text style={srStyles.muted}>No current MCO levels available</Text>
+)}
+```
+
+Replace it with the new card-based S/R section:
+
+```tsx
+{vm.srLevels ? (
+  <View style={{
+    marginTop: 14,
+    padding: 16,
+    backgroundColor: colors.surface,
+    borderRadius: 8,
+    borderWidth: 1,
+    borderColor: colors.border,
+  }}>
+    <View style={{
+      flexDirection: 'row',
+      justifyContent: 'space-between',
+      alignItems: 'center',
+      marginBottom: 10,
+    }}>
+      <Text style={{
+        color: colors.textSecondary,
+        fontSize: typography.fontSize.sm,
+        fontWeight: typography.fontWeight.medium,
+      }}>
+        Support & Resistance
+      </Text>
+      <Text style={{
+        fontSize: typography.fontSize.micro,
+        color: colors.textMuted,
+      }}>
+        {vm.srLevels.freshnessLabel}
+      </Text>
+    </View>
+
+    {vm.srLevels.levels.map((level, i) => {
+      const tone = toneColors[level.tone];
+      return (
+        <View
+          key={`sr-level-${i}`}
+          testID={`sr-level-${i}`}
+          style={{
+            flexDirection: 'row',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+            paddingVertical: 10,
+            borderTopWidth: i === 0 ? 0 : 1,
+            borderTopColor: colors.border,
+          }}
+        >
+          <View style={{ flexDirection: 'row', alignItems: 'center', gap: 10 }}>
+            <View style={{
+              height: 22,
+              paddingHorizontal: 8,
+              borderRadius: 999,
+              borderWidth: 1,
+              borderColor: tone.border,
+              justifyContent: 'center',
+              alignItems: 'center',
+            }}>
+              <Text style={{
+                fontSize: typography.fontSize.micro,
+                color: tone.text,
+                fontWeight: typography.fontWeight.semibold,
+              }}>
+                {level.kind === 'resistance' ? 'Resist' : 'Support'}
+              </Text>
+            </View>
+            <Text style={{
+              fontFamily: typography.fontFamily.mono,
+              fontSize: typography.fontSize.sm,
+              fontWeight: typography.fontWeight.semibold,
+              color: colors.text,
+            }}>
+              {level.priceLabel}
+            </Text>
+          </View>
+          {level.note ? (
+            <Text style={{
+              fontSize: typography.fontSize.micro,
+              color: colors.textMuted,
+              textAlign: 'right',
+              maxWidth: 150,
+            }}>
+              {level.note}
+            </Text>
+          ) : null}
+        </View>
+      );
+    })}
+  </View>
+) : (
+  <Text style={{
+    color: colors.textSecondary,
+    fontSize: typography.fontSize.sm,
+    marginTop: 16,
+  }}>
+    No current MCO levels available
+  </Text>
+)}
+```
+
+- [ ] **Step 3: Remove the old `srStyles` object**
+
+Since the new section uses inline styles, delete the entire `srStyles` object (lines 16–51 in the current file).
+
+- [ ] **Step 4: Update screen tests**
+
+Replace the S/R-related tests in `packages/ui/src/screens/PositionDetailScreen.test.tsx` with tests matching the new structure.
+
+Replace the test block from line 76 to 116 with:
+
+```typescript
+  it('renders support and resistance section as a card when srLevels is present', () => {
+    const now = Date.now();
+    vi.spyOn(Date, 'now').mockReturnValue(now);
+
+    render(
+      <PositionDetailScreen
+        position={makePosition({
+          srLevels: makeSrBlock(now),
+        })}
+      />,
+    );
+
+    expect(screen.getByText('Support & Resistance')).toBeTruthy();
+    expect(screen.getByText('AI · MCO · 0m ago')).toBeTruthy();
+    expect(screen.getByTestId('sr-level-0')).toBeTruthy();
+    expect(screen.getByTestId('sr-level-1')).toBeTruthy();
+
+    vi.restoreAllMocks();
+  });
+
+  it('renders level chips with correct labels', () => {
+    const now = Date.now();
+    vi.spyOn(Date, 'now').mockReturnValue(now);
+
+    render(
+      <PositionDetailScreen
+        position={makePosition({
+          srLevels: {
+            briefId: 'brief-1',
+            sourceRecordedAtIso: null,
+            summary: null,
+            capturedAtUnixMs: now,
+            supports: [{ price: 90 }],
+            resistances: [{ price: 180 }],
+          },
+        })}
+      />,
+    );
+
+    expect(screen.getByText('Support')).toBeTruthy();
+    expect(screen.getByText('Resist')).toBeTruthy();
+    expect(screen.getByText('$90.00')).toBeTruthy();
+    expect(screen.getByText('$180.00')).toBeTruthy();
+
+    vi.restoreAllMocks();
+  });
+```
+
+Replace the stale test (lines 100–116) with:
+
+```typescript
+  it('renders stale freshness label in the card header when isStale is true', () => {
+    const now = 200_000_000;
+    vi.spyOn(Date, 'now').mockReturnValue(now);
+
+    render(
+      <PositionDetailScreen
+        position={makePosition({
+          srLevels: makeSrBlock(now - 200_000_000),
+        })}
+      />,
+    );
+
+    expect(screen.getByText(/stale/)).toBeTruthy();
+
+    vi.restoreAllMocks();
+  });
+```
+
+Update the test at line 143 ("renders resistance section when supports is empty"):
+
+```typescript
+  it('renders resistance-only levels correctly', () => {
+    const now = Date.now();
+    vi.spyOn(Date, 'now').mockReturnValue(now);
+
+    render(
+      <PositionDetailScreen
+        position={makePosition({
+          srLevels: {
+            briefId: 'brief-1',
+            sourceRecordedAtIso: null,
+            summary: null,
+            capturedAtUnixMs: now,
+            supports: [],
+            resistances: [{ price: 180 }, { price: 210 }],
+          },
+        })}
+      />,
+    );
+
+    expect(screen.getByText('Support & Resistance')).toBeTruthy();
+    expect(screen.getByText('Resist')).toBeTruthy();
+    expect(screen.getByText('$180.00')).toBeTruthy();
+    expect(screen.getByText('$210.00')).toBeTruthy();
+
+    vi.restoreAllMocks();
+  });
+```
+
+- [ ] **Step 5: Run screen tests**
+
+Run:
+```bash
+cd /home/gpoontip/clmm-v2/packages/ui && npx vitest run src/screens/PositionDetailScreen.test.tsx
+```
+
+Expected: All tests pass.
+
+- [ ] **Step 6: Commit screen changes**
+
+```bash
+git add packages/ui/src/screens/PositionDetailScreen.tsx packages/ui/src/screens/PositionDetailScreen.test.tsx
+git commit -m "feat: redesign S/R section with chips, tones, notes, and card layout"
+```
+
+---
+
+## Task 3: Verify Cross-Package Build and Boundaries
+
+**Files:**
+- (no file changes — verification only)
+
+- [ ] **Step 1: Run UI package build**
+
+```bash
+cd /home/gpoontip/clmm-v2 && pnpm --filter @clmm/ui build
+```
+
+Expected: Build succeeds with no TypeScript errors.
+
+- [ ] **Step 2: Run UI package tests**
+
+```bash
+cd /home/gpoontip/clmm-v2 && pnpm --filter @clmm/ui test
+```
+
+Expected: All tests pass.
+
+- [ ] **Step 3: Run boundary check**
+
+```bash
+cd /home/gpoontip/clmm-v2 && pnpm boundaries
+```
+
+Expected: No boundary violations introduced.
+
+- [ ] **Step 4: Commit if clean**
+
+If all checks pass, the work is complete. No additional commit needed unless fixes were required.
+
+---
+
+## Spec Coverage Checklist
+
+| Design Element | Implementation Location |
+|---------------|------------------------|
+| Card container with border/background | `PositionDetailScreen.tsx` — View wrapper with `surface`, `border` |
+| Header row: "Support & Resistance" left, freshness right | `PositionDetailScreen.tsx` — flex row with label and freshness text |
+| Per-row chip: "Resist" / "Support" with tone-colored border/text | `PositionDetailScreen.tsx` — inner View with dynamic border/text color |
+| Per-row price in monospace, semibold | `PositionDetailScreen.tsx` — Text with `fontFamily.mono` |
+| Per-row contextual note on the right | `PositionDetailScreen.tsx` — conditional right-side Text |
+| Unified ascending sort (supports + resistances mixed) | `PositionDetailViewModel.ts` — combined sort in `toSrLevelsViewModelBlock` |
+| Tone computation (safe/warn/breach) from price proximity and range bounds | `PositionDetailViewModel.ts` — `computeLevelTone` helper |
+| Note computation: DTO notes → bound match → rank fallback | `PositionDetailViewModel.ts` — `computeLevelNote` helper |
+| Freshness format: "AI · MCO · Xh ago" | `PositionDetailViewModel.ts` — updated `computeFreshness` |
+| No old "Support" / "Resistance" subsection titles | Removed from screen |
+
+## Placeholder Scan
+
+- No "TBD", "TODO", or "implement later" strings.
+- All helper functions have exact implementations.
+- All test code is complete and runnable.
+- All file paths are exact and repo-relative.

--- a/packages/ui/src/components/MarketThesisCard.tsx
+++ b/packages/ui/src/components/MarketThesisCard.tsx
@@ -1,0 +1,68 @@
+import { View, Text } from 'react-native';
+import { colors, typography } from '../design-system/index.js';
+
+function InfoIcon(): JSX.Element {
+  return (
+    <View style={{
+      width: 16,
+      height: 16,
+      borderRadius: 8,
+      borderWidth: 1,
+      borderColor: colors.textMuted,
+      justifyContent: 'center',
+      alignItems: 'center',
+    }}>
+      <Text style={{
+        fontSize: 10,
+        color: colors.textMuted,
+        fontWeight: typography.fontWeight.semibold,
+        lineHeight: 14,
+      }}>
+        i
+      </Text>
+    </View>
+  );
+}
+
+type Props = {
+  summary: string;
+};
+
+export function MarketThesisCard({ summary }: Props): JSX.Element {
+  return (
+    <View style={{
+      marginTop: 14,
+      padding: 16,
+      backgroundColor: colors.surface,
+      borderRadius: 8,
+      borderWidth: 1,
+      borderColor: colors.border,
+    }}>
+      <View style={{
+        flexDirection: 'row',
+        alignItems: 'center',
+        gap: 8,
+        marginBottom: 12,
+      }}>
+        <InfoIcon />
+        <Text style={{
+          color: colors.textSecondary,
+          fontSize: typography.fontSize.micro,
+          fontWeight: typography.fontWeight.semibold,
+          letterSpacing: 0.08,
+          textTransform: 'uppercase',
+        }}>
+          Market Thesis
+        </Text>
+      </View>
+      <Text style={{
+        color: colors.text,
+        fontSize: typography.fontSize.sm,
+        lineHeight: typography.lineHeight.normal * typography.fontSize.sm,
+        fontWeight: typography.fontWeight.medium,
+      }}>
+        {summary}
+      </Text>
+    </View>
+  );
+}

--- a/packages/ui/src/components/SrLevelsCard.tsx
+++ b/packages/ui/src/components/SrLevelsCard.tsx
@@ -9,7 +9,7 @@ const toneColors = {
 } as const;
 
 type Props = {
-  srLevels?: SrLevelsViewModelBlock;
+  srLevels?: SrLevelsViewModelBlock | undefined;
 };
 
 export function SrLevelsCard({ srLevels }: Props): JSX.Element {

--- a/packages/ui/src/components/SrLevelsCard.tsx
+++ b/packages/ui/src/components/SrLevelsCard.tsx
@@ -20,47 +20,6 @@ const toneColors = {
   },
 } as const;
 
-function TriggerInvalidationSection({
-  label,
-  text,
-  labelColor,
-}: {
-  label: string;
-  text: string;
-  labelColor: string;
-}): JSX.Element {
-  return (
-    <View
-      style={{
-        marginTop: 10,
-        paddingTop: 10,
-        borderTopWidth: 1,
-        borderTopColor: colors.border,
-      }}
-    >
-      <Text
-        style={{
-          fontSize: typography.fontSize.micro,
-          color: labelColor,
-          fontWeight: typography.fontWeight.semibold,
-        }}
-      >
-        {label}
-      </Text>
-      <Text
-        style={{
-          fontSize: typography.fontSize.micro,
-          color: colors.textMuted,
-          lineHeight: 16,
-          marginTop: 2,
-        }}
-      >
-        {text}
-      </Text>
-    </View>
-  );
-}
-
 type Props = {
   srLevels?: SrLevelsViewModelBlock | undefined;
 };
@@ -133,53 +92,49 @@ export function SrLevelsCard({ srLevels }: Props): JSX.Element {
             borderColor: colors.border,
           }}
         >
-          {/* Group header: bias pill + cluster label */}
-          <View
-            style={{
-              flexDirection: 'row',
-              justifyContent: 'space-between',
-              alignItems: 'center',
-              marginBottom: 10,
-            }}
-          >
-            {group.bias ? (
+          {/* Group header: bias pill */}
+          {group.bias ? (
+            <View
+              style={{
+                flexDirection: 'row',
+                alignItems: 'center',
+                marginBottom: 10,
+              }}
+            >
               <View
                 style={{
+                  flexDirection: 'row',
+                  alignItems: 'center',
                   height: 22,
                   paddingHorizontal: 10,
                   borderRadius: 999,
                   borderWidth: 1,
                   borderColor: 'rgba(244,201,122,0.30)',
-                  justifyContent: 'center',
-                  alignItems: 'center',
+                  backgroundColor: 'rgba(244,201,122,0.08)',
+                  gap: 6,
                 }}
               >
+                <View
+                  style={{
+                    width: 5,
+                    height: 5,
+                    borderRadius: 2.5,
+                    backgroundColor: colors.warn,
+                  }}
+                />
                 <Text
                   style={{
                     fontSize: typography.fontSize.micro,
                     color: colors.warn,
                     fontWeight: typography.fontWeight.semibold,
+                    textTransform: 'capitalize',
                   }}
                 >
                   {group.bias}
                 </Text>
               </View>
-            ) : (
-              <View />
-            )}
-            <Text
-              style={{
-                fontSize: typography.fontSize.micro,
-                color: colors.textMuted,
-                textTransform: 'uppercase',
-                letterSpacing: 0.06,
-              }}
-            >
-              {group.levels[0]?.kind === 'resistance'
-                ? 'Resistance Cluster'
-                : 'Support Cluster'}
-            </Text>
-          </View>
+            </View>
+          ) : null}
 
           {/* Levels */}
           {group.levels.map((lv, li) => {
@@ -241,43 +196,35 @@ export function SrLevelsCard({ srLevels }: Props): JSX.Element {
             );
           })}
 
-          {/* Trigger */}
-          {group.trigger ? (
-            <TriggerInvalidationSection
-              label="Trigger"
-              text={group.trigger}
-              labelColor={colors.breachAccent}
-            />
-          ) : null}
-
-          {/* Invalidation */}
-          {group.invalidation ? (
-            <TriggerInvalidationSection
-              label="Invalidation"
-              text={group.invalidation}
-              labelColor={colors.safe}
-            />
-          ) : null}
-
-          {/* Shared note */}
-          {group.note ? (
+          {/* Trigger / Invalidation */}
+          {(group.trigger || group.invalidation) ? (
             <View
               style={{
                 marginTop: 10,
                 paddingTop: 10,
                 borderTopWidth: 1,
                 borderTopColor: colors.border,
+                gap: 4,
               }}
             >
-              <Text
-                style={{
-                  fontSize: typography.fontSize.micro,
-                  color: colors.textMuted,
-                  lineHeight: 16,
-                }}
-              >
-                {group.note}
-              </Text>
+              {group.trigger ? (
+                <Text style={{ fontSize: typography.fontSize.xs, lineHeight: 18 }}>
+                  <Text style={{ color: colors.breachAccent, fontWeight: typography.fontWeight.semibold }}>
+                    Trigger
+                  </Text>
+                  <Text style={{ color: colors.textMuted }}> · </Text>
+                  <Text style={{ color: colors.textSecondary }}>{group.trigger}</Text>
+                </Text>
+              ) : null}
+              {group.invalidation ? (
+                <Text style={{ fontSize: typography.fontSize.xs, lineHeight: 18 }}>
+                  <Text style={{ color: colors.safe, fontWeight: typography.fontWeight.semibold }}>
+                    Invalidation
+                  </Text>
+                  <Text style={{ color: colors.textMuted }}> · </Text>
+                  <Text style={{ color: colors.textSecondary }}>{group.invalidation}</Text>
+                </Text>
+              ) : null}
             </View>
           ) : null}
 

--- a/packages/ui/src/components/SrLevelsCard.tsx
+++ b/packages/ui/src/components/SrLevelsCard.tsx
@@ -1,0 +1,115 @@
+import { View, Text } from 'react-native';
+import { colors, typography } from '../design-system/index.js';
+import type { SrLevelsViewModelBlock } from '../view-models/PositionDetailViewModel.js';
+
+const toneColors = {
+  safe: { text: colors.safe, border: 'rgba(158,236,209,0.30)' },
+  warn: { text: colors.warn, border: 'rgba(244,201,122,0.30)' },
+  breach: { text: colors.breachAccent, border: 'rgba(245,148,132,0.30)' },
+} as const;
+
+type Props = {
+  srLevels?: SrLevelsViewModelBlock;
+};
+
+export function SrLevelsCard({ srLevels }: Props): JSX.Element {
+  if (!srLevels) {
+    return (
+      <Text style={{
+        color: colors.textSecondary,
+        fontSize: typography.fontSize.sm,
+        marginTop: 16,
+      }}>
+        No current MCO levels available
+      </Text>
+    );
+  }
+
+  return (
+    <View style={{
+      marginTop: 14,
+      padding: 16,
+      backgroundColor: colors.surface,
+      borderRadius: 8,
+      borderWidth: 1,
+      borderColor: colors.border,
+    }}>
+      <View style={{
+        flexDirection: 'row',
+        justifyContent: 'space-between',
+        alignItems: 'center',
+        marginBottom: 10,
+      }}>
+        <Text style={{
+          color: colors.textSecondary,
+          fontSize: typography.fontSize.sm,
+          fontWeight: typography.fontWeight.medium,
+        }}>
+          Support & Resistance
+        </Text>
+        <Text style={{
+          fontSize: typography.fontSize.micro,
+          color: colors.textMuted,
+        }}>
+          {srLevels.freshnessLabel}
+        </Text>
+      </View>
+
+      {srLevels.levels.map((level, i) => {
+        const tone = toneColors[level.tone];
+        return (
+          <View
+            key={`sr-level-${i}`}
+            testID={`sr-level-${i}`}
+            style={{
+              flexDirection: 'row',
+              alignItems: 'center',
+              justifyContent: 'space-between',
+              paddingVertical: 10,
+              borderTopWidth: i === 0 ? 0 : 1,
+              borderTopColor: colors.border,
+            }}
+          >
+            <View style={{ flexDirection: 'row', alignItems: 'center', gap: 10 }}>
+              <View style={{
+                height: 22,
+                paddingHorizontal: 8,
+                borderRadius: 999,
+                borderWidth: 1,
+                borderColor: tone.border,
+                justifyContent: 'center',
+                alignItems: 'center',
+              }}>
+                <Text style={{
+                  fontSize: typography.fontSize.micro,
+                  color: tone.text,
+                  fontWeight: typography.fontWeight.semibold,
+                }}>
+                  {level.kind === 'resistance' ? 'Resist' : 'Support'}
+                </Text>
+              </View>
+              <Text style={{
+                fontFamily: typography.fontFamily.mono,
+                fontSize: typography.fontSize.sm,
+                fontWeight: typography.fontWeight.semibold,
+                color: colors.text,
+              }}>
+                {level.priceLabel}
+              </Text>
+            </View>
+            {level.note ? (
+              <Text style={{
+                fontSize: typography.fontSize.micro,
+                color: colors.textMuted,
+                textAlign: 'right',
+                maxWidth: 150,
+              }}>
+                {level.note}
+              </Text>
+            ) : null}
+          </View>
+        );
+      })}
+    </View>
+  );
+}

--- a/packages/ui/src/components/SrLevelsCard.tsx
+++ b/packages/ui/src/components/SrLevelsCard.tsx
@@ -147,8 +147,8 @@ export function SrLevelsCard({ srLevels }: Props): JSX.Element {
                   flexDirection: 'row',
                   alignItems: 'center',
                   justifyContent: 'space-between',
-                  paddingVertical: li === 0 ? 0 : 8,
-                  borderTopWidth: li === 0 ? 0 : 1,
+                  paddingVertical: 8,
+                  borderTopWidth: 1,
                   borderTopColor: colors.border,
                 }}
               >

--- a/packages/ui/src/components/SrLevelsCard.tsx
+++ b/packages/ui/src/components/SrLevelsCard.tsx
@@ -3,10 +3,63 @@ import { colors, typography } from '../design-system/index.js';
 import type { SrLevelsViewModelBlock } from '../view-models/PositionDetailViewModel.js';
 
 const toneColors = {
-  safe: { text: colors.safe, border: 'rgba(158,236,209,0.30)' },
-  warn: { text: colors.warn, border: 'rgba(244,201,122,0.30)' },
-  breach: { text: colors.breachAccent, border: 'rgba(245,148,132,0.30)' },
+  safe: {
+    text: colors.safe,
+    border: 'rgba(158,236,209,0.30)',
+    bg: 'rgba(158,236,209,0.08)',
+  },
+  warn: {
+    text: colors.warn,
+    border: 'rgba(244,201,122,0.30)',
+    bg: 'rgba(244,201,122,0.08)',
+  },
+  breach: {
+    text: colors.breachAccent,
+    border: 'rgba(245,148,132,0.30)',
+    bg: 'rgba(245,148,132,0.08)',
+  },
 } as const;
+
+function TriggerInvalidationSection({
+  label,
+  text,
+  labelColor,
+}: {
+  label: string;
+  text: string;
+  labelColor: string;
+}): JSX.Element {
+  return (
+    <View
+      style={{
+        marginTop: 10,
+        paddingTop: 10,
+        borderTopWidth: 1,
+        borderTopColor: colors.border,
+      }}
+    >
+      <Text
+        style={{
+          fontSize: typography.fontSize.micro,
+          color: labelColor,
+          fontWeight: typography.fontWeight.semibold,
+        }}
+      >
+        {label}
+      </Text>
+      <Text
+        style={{
+          fontSize: typography.fontSize.micro,
+          color: colors.textMuted,
+          lineHeight: 16,
+          marginTop: 2,
+        }}
+      >
+        {text}
+      </Text>
+    </View>
+  );
+}
 
 type Props = {
   srLevels?: SrLevelsViewModelBlock | undefined;
@@ -15,101 +68,281 @@ type Props = {
 export function SrLevelsCard({ srLevels }: Props): JSX.Element {
   if (!srLevels) {
     return (
-      <Text style={{
-        color: colors.textSecondary,
-        fontSize: typography.fontSize.sm,
-        marginTop: 16,
-      }}>
+      <Text
+        style={{
+          color: colors.textSecondary,
+          fontSize: typography.fontSize.sm,
+          marginTop: 16,
+        }}
+      >
         No current MCO levels available
       </Text>
     );
   }
 
   return (
-    <View style={{
-      marginTop: 14,
-      padding: 16,
-      backgroundColor: colors.surface,
-      borderRadius: 8,
-      borderWidth: 1,
-      borderColor: colors.border,
-    }}>
-      <View style={{
-        flexDirection: 'row',
-        justifyContent: 'space-between',
-        alignItems: 'center',
-        marginBottom: 10,
-      }}>
-        <Text style={{
-          color: colors.textSecondary,
-          fontSize: typography.fontSize.sm,
-          fontWeight: typography.fontWeight.medium,
-        }}>
+    <View
+      style={{
+        marginTop: 14,
+        padding: 16,
+        backgroundColor: colors.surface,
+        borderRadius: 8,
+        borderWidth: 1,
+        borderColor: colors.border,
+      }}
+    >
+      {/* Header */}
+      <View
+        style={{
+          flexDirection: 'row',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+          marginBottom: 12,
+        }}
+      >
+        <Text
+          style={{
+            color: colors.textSecondary,
+            fontSize: typography.fontSize.sm,
+            fontWeight: typography.fontWeight.medium,
+          }}
+        >
           Support & Resistance
         </Text>
-        <Text style={{
-          fontSize: typography.fontSize.micro,
-          color: colors.textMuted,
-        }}>
+        <Text
+          style={{
+            fontSize: typography.fontSize.micro,
+            color: colors.textMuted,
+          }}
+        >
           {srLevels.freshnessLabel}
         </Text>
       </View>
 
-      {srLevels.levels.map((level, i) => {
-        const tone = toneColors[level.tone];
-        return (
+      {/* Groups */}
+      {srLevels.groups.map((group, gi) => (
+        <View
+          key={`sr-group-${gi}`}
+          testID={`sr-group-${gi}`}
+          style={{
+            backgroundColor: colors.surfaceRecessed,
+            borderRadius: 10,
+            padding: 14,
+            marginTop: gi === 0 ? 0 : 10,
+            borderWidth: 1,
+            borderColor: colors.border,
+          }}
+        >
+          {/* Group header: bias pill + cluster label */}
           <View
-            key={`sr-level-${i}`}
-            testID={`sr-level-${i}`}
             style={{
               flexDirection: 'row',
-              alignItems: 'center',
               justifyContent: 'space-between',
-              paddingVertical: 10,
-              borderTopWidth: i === 0 ? 0 : 1,
-              borderTopColor: colors.border,
+              alignItems: 'center',
+              marginBottom: 10,
             }}
           >
-            <View style={{ flexDirection: 'row', alignItems: 'center', gap: 10 }}>
-              <View style={{
-                height: 22,
-                paddingHorizontal: 8,
-                borderRadius: 999,
-                borderWidth: 1,
-                borderColor: tone.border,
-                justifyContent: 'center',
-                alignItems: 'center',
-              }}>
-                <Text style={{
-                  fontSize: typography.fontSize.micro,
-                  color: tone.text,
-                  fontWeight: typography.fontWeight.semibold,
-                }}>
-                  {level.kind === 'resistance' ? 'Resist' : 'Support'}
+            {group.bias ? (
+              <View
+                style={{
+                  height: 22,
+                  paddingHorizontal: 10,
+                  borderRadius: 999,
+                  borderWidth: 1,
+                  borderColor: 'rgba(244,201,122,0.30)',
+                  justifyContent: 'center',
+                  alignItems: 'center',
+                }}
+              >
+                <Text
+                  style={{
+                    fontSize: typography.fontSize.micro,
+                    color: colors.warn,
+                    fontWeight: typography.fontWeight.semibold,
+                  }}
+                >
+                  {group.bias}
                 </Text>
               </View>
-              <Text style={{
-                fontFamily: typography.fontFamily.mono,
-                fontSize: typography.fontSize.sm,
-                fontWeight: typography.fontWeight.semibold,
-                color: colors.text,
-              }}>
-                {level.priceLabel}
-              </Text>
-            </View>
-            {level.note ? (
-              <Text style={{
+            ) : (
+              <View />
+            )}
+            <Text
+              style={{
                 fontSize: typography.fontSize.micro,
                 color: colors.textMuted,
-                textAlign: 'right',
-                maxWidth: 150,
-              }}>
-                {level.note}
-              </Text>
-            ) : null}
+                textTransform: 'uppercase',
+                letterSpacing: 0.06,
+              }}
+            >
+              {group.levels[0]?.kind === 'resistance'
+                ? 'Resistance Cluster'
+                : 'Support Cluster'}
+            </Text>
           </View>
-        );
-      })}
+
+          {/* Levels */}
+          {group.levels.map((lv, li) => {
+            const tone = toneColors[lv.tone];
+            return (
+              <View
+                key={`sr-level-${gi}-${li}`}
+                testID={`sr-level-${gi}-${li}`}
+                style={{
+                  flexDirection: 'row',
+                  alignItems: 'center',
+                  justifyContent: 'space-between',
+                  paddingVertical: li === 0 ? 0 : 8,
+                  borderTopWidth: li === 0 ? 0 : 1,
+                  borderTopColor: colors.border,
+                }}
+              >
+                <View
+                  style={{
+                    flexDirection: 'row',
+                    alignItems: 'center',
+                    gap: 10,
+                  }}
+                >
+                  <View
+                    style={{
+                      height: 22,
+                      paddingHorizontal: 8,
+                      borderRadius: 999,
+                      borderWidth: 1,
+                      borderColor: tone.border,
+                      backgroundColor: tone.bg,
+                      justifyContent: 'center',
+                      alignItems: 'center',
+                    }}
+                  >
+                    <Text
+                      style={{
+                        fontSize: typography.fontSize.micro,
+                        color: tone.text,
+                        fontWeight: typography.fontWeight.semibold,
+                      }}
+                    >
+                      {lv.kind === 'resistance' ? 'Resist' : 'Support'}
+                    </Text>
+                  </View>
+                  <Text
+                    style={{
+                      fontFamily: typography.fontFamily.mono,
+                      fontSize: typography.fontSize.sm,
+                      fontWeight: typography.fontWeight.semibold,
+                      color: colors.text,
+                    }}
+                  >
+                    {lv.priceLabel}
+                  </Text>
+                </View>
+              </View>
+            );
+          })}
+
+          {/* Trigger */}
+          {group.trigger ? (
+            <TriggerInvalidationSection
+              label="Trigger"
+              text={group.trigger}
+              labelColor={colors.breachAccent}
+            />
+          ) : null}
+
+          {/* Invalidation */}
+          {group.invalidation ? (
+            <TriggerInvalidationSection
+              label="Invalidation"
+              text={group.invalidation}
+              labelColor={colors.safe}
+            />
+          ) : null}
+
+          {/* Shared note */}
+          {group.note ? (
+            <View
+              style={{
+                marginTop: 10,
+                paddingTop: 10,
+                borderTopWidth: 1,
+                borderTopColor: colors.border,
+              }}
+            >
+              <Text
+                style={{
+                  fontSize: typography.fontSize.micro,
+                  color: colors.textMuted,
+                  lineHeight: 16,
+                }}
+              >
+                {group.note}
+              </Text>
+            </View>
+          ) : null}
+
+          {/* Metadata footer */}
+          {(group.source || group.timeframe || group.setupType) ? (
+            <View
+              style={{
+                flexDirection: 'row',
+                flexWrap: 'wrap',
+                gap: '4px 14px',
+                marginTop: 10,
+                paddingTop: 10,
+                borderTopWidth: 1,
+                borderTopColor: colors.border,
+              }}
+            >
+              {group.source ? (
+                <Text
+                  style={{
+                    fontSize: typography.fontSize.micro,
+                    color: colors.textMuted,
+                    textTransform: 'uppercase',
+                    letterSpacing: 0.04,
+                  }}
+                >
+                  Source ·{' '}
+                  <Text style={{ color: colors.textSecondary }}>
+                    {group.source}
+                  </Text>
+                </Text>
+              ) : null}
+              {group.timeframe ? (
+                <Text
+                  style={{
+                    fontSize: typography.fontSize.micro,
+                    color: colors.textMuted,
+                    textTransform: 'uppercase',
+                    letterSpacing: 0.04,
+                  }}
+                >
+                  TF ·{' '}
+                  <Text style={{ color: colors.textSecondary }}>
+                    {group.timeframe}
+                  </Text>
+                </Text>
+              ) : null}
+              {group.setupType ? (
+                <Text
+                  style={{
+                    fontSize: typography.fontSize.micro,
+                    color: colors.textMuted,
+                    textTransform: 'uppercase',
+                    letterSpacing: 0.04,
+                  }}
+                >
+                  Setup ·{' '}
+                  <Text style={{ color: colors.textSecondary }}>
+                    {group.setupType}
+                  </Text>
+                </Text>
+              ) : null}
+            </View>
+          ) : null}
+        </View>
+      ))}
     </View>
   );
 }

--- a/packages/ui/src/screens/PositionDetailScreen.test.tsx
+++ b/packages/ui/src/screens/PositionDetailScreen.test.tsx
@@ -188,4 +188,56 @@ describe('PositionDetailScreen', () => {
 
     vi.restoreAllMocks();
   });
+
+  it('renders support-only levels correctly', () => {
+    const now = Date.now();
+    vi.spyOn(Date, 'now').mockReturnValue(now);
+
+    render(
+      <PositionDetailScreen
+        position={makePosition({
+          srLevels: {
+            briefId: 'brief-1',
+            sourceRecordedAtIso: null,
+            summary: null,
+            capturedAtUnixMs: now,
+            supports: [{ price: 90 }, { price: 110 }],
+            resistances: [],
+          },
+        })}
+      />,
+    );
+
+    expect(screen.getByText('Support & Resistance')).toBeTruthy();
+    expect(screen.getAllByText('Support')).toHaveLength(2);
+    expect(screen.getByText('$90.00')).toBeTruthy();
+    expect(screen.getByText('$110.00')).toBeTruthy();
+
+    vi.restoreAllMocks();
+  });
+
+  it('renders empty levels message when both supports and resistances are empty', () => {
+    const now = Date.now();
+    vi.spyOn(Date, 'now').mockReturnValue(now);
+
+    render(
+      <PositionDetailScreen
+        position={makePosition({
+          srLevels: {
+            briefId: 'brief-1',
+            sourceRecordedAtIso: null,
+            summary: null,
+            capturedAtUnixMs: now,
+            supports: [],
+            resistances: [],
+          },
+        })}
+      />,
+    );
+
+    expect(screen.getByText('Support & Resistance')).toBeTruthy();
+    expect(screen.queryByTestId('sr-level-0')).toBeNull();
+
+    vi.restoreAllMocks();
+  });
 });

--- a/packages/ui/src/screens/PositionDetailScreen.test.tsx
+++ b/packages/ui/src/screens/PositionDetailScreen.test.tsx
@@ -73,6 +73,48 @@ describe('PositionDetailScreen', () => {
     expect(onViewPreview).toHaveBeenCalledWith('trigger-1');
   });
 
+  it('renders Market Thesis card when summary is present', () => {
+    const now = Date.now();
+    vi.spyOn(Date, 'now').mockReturnValue(now);
+
+    render(
+      <PositionDetailScreen
+        position={makePosition({
+          srLevels: {
+            briefId: 'brief-1',
+            sourceRecordedAtIso: null,
+            summary: 'Bearish swing, trend continuation.',
+            capturedAtUnixMs: now,
+            supports: [{ price: 90 }],
+            resistances: [],
+          },
+        })}
+      />,
+    );
+
+    expect(screen.getByText('Market Thesis')).toBeTruthy();
+    expect(screen.getByText('Bearish swing, trend continuation.')).toBeTruthy();
+
+    vi.restoreAllMocks();
+  });
+
+  it('does not render Market Thesis card when summary is absent', () => {
+    const now = Date.now();
+    vi.spyOn(Date, 'now').mockReturnValue(now);
+
+    render(
+      <PositionDetailScreen
+        position={makePosition({
+          srLevels: makeSrBlock(now),
+        })}
+      />,
+    );
+
+    expect(screen.queryByText('Market Thesis')).toBeNull();
+
+    vi.restoreAllMocks();
+  });
+
   it('renders support and resistance section as a card when srLevels is present', () => {
     const now = Date.now();
     vi.spyOn(Date, 'now').mockReturnValue(now);
@@ -87,8 +129,7 @@ describe('PositionDetailScreen', () => {
 
     expect(screen.getByText('Support & Resistance')).toBeTruthy();
     expect(screen.getByText('AI · MCO · 1m ago')).toBeTruthy();
-    expect(screen.getByTestId('sr-level-0')).toBeTruthy();
-    expect(screen.getByTestId('sr-level-1')).toBeTruthy();
+    expect(screen.getByTestId('sr-group-0')).toBeTruthy();
 
     vi.restoreAllMocks();
   });
@@ -216,7 +257,7 @@ describe('PositionDetailScreen', () => {
     vi.restoreAllMocks();
   });
 
-  it('renders empty levels message when both supports and resistances are empty', () => {
+  it('renders empty groups message when both supports and resistances are empty', () => {
     const now = Date.now();
     vi.spyOn(Date, 'now').mockReturnValue(now);
 
@@ -236,7 +277,7 @@ describe('PositionDetailScreen', () => {
     );
 
     expect(screen.getByText('Support & Resistance')).toBeTruthy();
-    expect(screen.queryByTestId('sr-level-0')).toBeNull();
+    expect(screen.queryByTestId('sr-group-0')).toBeNull();
 
     vi.restoreAllMocks();
   });

--- a/packages/ui/src/screens/PositionDetailScreen.test.tsx
+++ b/packages/ui/src/screens/PositionDetailScreen.test.tsx
@@ -73,7 +73,7 @@ describe('PositionDetailScreen', () => {
     expect(onViewPreview).toHaveBeenCalledWith('trigger-1');
   });
 
-  it('renders support and resistance section when srLevels is present', () => {
+  it('renders support and resistance section as a card when srLevels is present', () => {
     const now = Date.now();
     vi.spyOn(Date, 'now').mockReturnValue(now);
 
@@ -85,19 +85,42 @@ describe('PositionDetailScreen', () => {
       />,
     );
 
-    expect(screen.getByText('Support & Resistance (MCO)')).toBeTruthy();
-    expect(screen.getByText('Support')).toBeTruthy();
-    expect(screen.getByText('Resistance')).toBeTruthy();
-    expect(screen.getByText('$90.00')).toBeTruthy();
-    expect(screen.getByText('$110.00 (S1)')).toBeTruthy();
-    expect(screen.getByText('$180.00')).toBeTruthy();
-    expect(screen.getByText('$210.00')).toBeTruthy();
-    expect(screen.getByTestId('sr-freshness')).toBeTruthy();
+    expect(screen.getByText('Support & Resistance')).toBeTruthy();
+    expect(screen.getByText('AI · MCO · 1m ago')).toBeTruthy();
+    expect(screen.getByTestId('sr-level-0')).toBeTruthy();
+    expect(screen.getByTestId('sr-level-1')).toBeTruthy();
 
     vi.restoreAllMocks();
   });
 
-  it('renders stale freshness label when isStale is true', () => {
+  it('renders level chips with correct labels', () => {
+    const now = Date.now();
+    vi.spyOn(Date, 'now').mockReturnValue(now);
+
+    render(
+      <PositionDetailScreen
+        position={makePosition({
+          srLevels: {
+            briefId: 'brief-1',
+            sourceRecordedAtIso: null,
+            summary: null,
+            capturedAtUnixMs: now,
+            supports: [{ price: 90 }],
+            resistances: [{ price: 180 }],
+          },
+        })}
+      />,
+    );
+
+    expect(screen.getByText('Support')).toBeTruthy();
+    expect(screen.getByText('Resist')).toBeTruthy();
+    expect(screen.getByText('$90.00')).toBeTruthy();
+    expect(screen.getByText('$180.00')).toBeTruthy();
+
+    vi.restoreAllMocks();
+  });
+
+  it('renders stale freshness label in the card header when isStale is true', () => {
     const now = 200_000_000;
     vi.spyOn(Date, 'now').mockReturnValue(now);
 
@@ -109,8 +132,7 @@ describe('PositionDetailScreen', () => {
       />,
     );
 
-    const freshness = screen.getByTestId('sr-freshness');
-    expect(freshness.textContent).toContain('stale');
+    expect(screen.getByText(/stale/)).toBeTruthy();
 
     vi.restoreAllMocks();
   });
@@ -140,7 +162,7 @@ describe('PositionDetailScreen', () => {
     expect(screen.getByText('No current MCO levels available')).toBeTruthy();
   });
 
-  it('renders resistance section when supports is empty but resistances are present', () => {
+  it('renders resistance-only levels correctly', () => {
     const now = Date.now();
     vi.spyOn(Date, 'now').mockReturnValue(now);
 
@@ -159,9 +181,8 @@ describe('PositionDetailScreen', () => {
       />,
     );
 
-    expect(screen.getByText('Support & Resistance (MCO)')).toBeTruthy();
-    expect(screen.getByText('Support')).toBeTruthy();
-    expect(screen.getByText('Resistance')).toBeTruthy();
+    expect(screen.getByText('Support & Resistance')).toBeTruthy();
+    expect(screen.getAllByText('Resist')).toHaveLength(2);
     expect(screen.getByText('$180.00')).toBeTruthy();
     expect(screen.getByText('$210.00')).toBeTruthy();
 

--- a/packages/ui/src/screens/PositionDetailScreen.tsx
+++ b/packages/ui/src/screens/PositionDetailScreen.tsx
@@ -7,47 +7,16 @@ import { presentPositionDetail } from '../presenters/PositionDetailPresenter.js'
 import { RangeStatusBadge } from '../components/RangeStatusBadge.js';
 import { DirectionalPolicyCard } from '../components/DirectionalPolicyCard.js';
 
+const toneColors = {
+  safe: { text: colors.safe, border: 'rgba(158,236,209,0.30)' },
+  warn: { text: colors.warn, border: 'rgba(244,201,122,0.30)' },
+  breach: { text: colors.breachAccent, border: 'rgba(245,148,132,0.30)' },
+} as const;
+
 type Props = {
   position?: PositionDetailDto;
   onViewPreview?: (triggerId: string) => void;
   now?: number;
-};
-
-const srStyles = {
-  sectionTitle: {
-    color: colors.text,
-    fontSize: typography.fontSize.base,
-    fontWeight: typography.fontWeight.semibold,
-    marginTop: 20,
-    marginBottom: 8,
-  },
-  subsectionTitle: {
-    color: colors.textSecondary,
-    fontSize: typography.fontSize.sm,
-    fontWeight: typography.fontWeight.medium,
-    marginTop: 8,
-    marginBottom: 4,
-  },
-  levelRow: {
-    color: colors.text,
-    fontSize: typography.fontSize.sm,
-    marginTop: 2,
-  },
-  freshnessLabel: {
-    color: colors.textSecondary,
-    fontSize: typography.fontSize.xs,
-    marginTop: 8,
-  },
-  staleLabel: {
-    color: '#f59e0b',
-    fontSize: typography.fontSize.xs,
-    marginTop: 8,
-  },
-  muted: {
-    color: colors.textSecondary,
-    fontSize: typography.fontSize.sm,
-    marginTop: 16,
-  },
 };
 
 export function PositionDetailScreen({ position, onViewPreview, now: nowProp }: Props): JSX.Element {
@@ -295,28 +264,99 @@ export function PositionDetailScreen({ position, onViewPreview, now: nowProp }: 
         </View>
 
         {vm.srLevels ? (
-          <View style={{ marginTop: 4 }}>
-            <Text style={srStyles.sectionTitle}>
-              Support & Resistance (MCO)
-            </Text>
-            <Text style={srStyles.subsectionTitle}>Support</Text>
-            {vm.srLevels.supportsSorted.map((s, i) => (
-              <Text key={`s-${i}`} testID={`sr-support-${i}`} style={srStyles.levelRow}>
-                {s.priceLabel}{s.rankLabel ? ` (${s.rankLabel})` : ''}
+          <View style={{
+            marginTop: 14,
+            padding: 16,
+            backgroundColor: colors.surface,
+            borderRadius: 8,
+            borderWidth: 1,
+            borderColor: colors.border,
+          }}>
+            <View style={{
+              flexDirection: 'row',
+              justifyContent: 'space-between',
+              alignItems: 'center',
+              marginBottom: 10,
+            }}>
+              <Text style={{
+                color: colors.textSecondary,
+                fontSize: typography.fontSize.sm,
+                fontWeight: typography.fontWeight.medium,
+              }}>
+                Support & Resistance
               </Text>
-            ))}
-            <Text style={srStyles.subsectionTitle}>Resistance</Text>
-            {vm.srLevels.resistancesSorted.map((r, i) => (
-              <Text key={`r-${i}`} testID={`sr-resistance-${i}`} style={srStyles.levelRow}>
-                {r.priceLabel}{r.rankLabel ? ` (${r.rankLabel})` : ''}
+              <Text style={{
+                fontSize: typography.fontSize.micro,
+                color: colors.textMuted,
+              }}>
+                {vm.srLevels.freshnessLabel}
               </Text>
-            ))}
-            <Text testID="sr-freshness" style={vm.srLevels.isStale ? srStyles.staleLabel : srStyles.freshnessLabel}>
-              {vm.srLevels.freshnessLabel}
-            </Text>
+            </View>
+
+            {vm.srLevels.levels.map((level, i) => {
+              const tone = toneColors[level.tone];
+              return (
+                <View
+                  key={`sr-level-${i}`}
+                  testID={`sr-level-${i}`}
+                  style={{
+                    flexDirection: 'row',
+                    alignItems: 'center',
+                    justifyContent: 'space-between',
+                    paddingVertical: 10,
+                    borderTopWidth: i === 0 ? 0 : 1,
+                    borderTopColor: colors.border,
+                  }}
+                >
+                  <View style={{ flexDirection: 'row', alignItems: 'center', gap: 10 }}>
+                    <View style={{
+                      height: 22,
+                      paddingHorizontal: 8,
+                      borderRadius: 999,
+                      borderWidth: 1,
+                      borderColor: tone.border,
+                      justifyContent: 'center',
+                      alignItems: 'center',
+                    }}>
+                      <Text style={{
+                        fontSize: typography.fontSize.micro,
+                        color: tone.text,
+                        fontWeight: typography.fontWeight.semibold,
+                      }}>
+                        {level.kind === 'resistance' ? 'Resist' : 'Support'}
+                      </Text>
+                    </View>
+                    <Text style={{
+                      fontFamily: typography.fontFamily.mono,
+                      fontSize: typography.fontSize.sm,
+                      fontWeight: typography.fontWeight.semibold,
+                      color: colors.text,
+                    }}>
+                      {level.priceLabel}
+                    </Text>
+                  </View>
+                  {level.note ? (
+                    <Text style={{
+                      fontSize: typography.fontSize.micro,
+                      color: colors.textMuted,
+                      textAlign: 'right',
+                      maxWidth: 150,
+                    }}>
+                      {level.note}
+                    </Text>
+                  ) : null}
+                </View>
+              );
+            })}
           </View>
         ) : (
-          <Text style={srStyles.muted}>No current MCO levels available</Text>
+          <Text style={{
+            color: colors.textSecondary,
+            fontSize: typography.fontSize.sm,
+            marginTop: 16,
+          }}>
+            No current MCO levels available
+          </Text>
         )}
       </View>
     </ScrollView>

--- a/packages/ui/src/screens/PositionDetailScreen.tsx
+++ b/packages/ui/src/screens/PositionDetailScreen.tsx
@@ -7,6 +7,7 @@ import { presentPositionDetail } from '../presenters/PositionDetailPresenter.js'
 import { RangeStatusBadge } from '../components/RangeStatusBadge.js';
 import { DirectionalPolicyCard } from '../components/DirectionalPolicyCard.js';
 import { SrLevelsCard } from '../components/SrLevelsCard.js';
+import { MarketThesisCard } from '../components/MarketThesisCard.js';
 
 type Props = {
   position?: PositionDetailDto;
@@ -258,6 +259,9 @@ export function PositionDetailScreen({ position, onViewPreview, now: nowProp }: 
           </Text>
         </View>
 
+        {vm.srLevels?.summary ? (
+          <MarketThesisCard summary={vm.srLevels.summary} />
+        ) : null}
         <SrLevelsCard srLevels={vm.srLevels} />
       </View>
     </ScrollView>

--- a/packages/ui/src/screens/PositionDetailScreen.tsx
+++ b/packages/ui/src/screens/PositionDetailScreen.tsx
@@ -6,12 +6,7 @@ import { typography } from '../design-system/index.js';
 import { presentPositionDetail } from '../presenters/PositionDetailPresenter.js';
 import { RangeStatusBadge } from '../components/RangeStatusBadge.js';
 import { DirectionalPolicyCard } from '../components/DirectionalPolicyCard.js';
-
-const toneColors = {
-  safe: { text: colors.safe, border: 'rgba(158,236,209,0.30)' },
-  warn: { text: colors.warn, border: 'rgba(244,201,122,0.30)' },
-  breach: { text: colors.breachAccent, border: 'rgba(245,148,132,0.30)' },
-} as const;
+import { SrLevelsCard } from '../components/SrLevelsCard.js';
 
 type Props = {
   position?: PositionDetailDto;
@@ -263,101 +258,7 @@ export function PositionDetailScreen({ position, onViewPreview, now: nowProp }: 
           </Text>
         </View>
 
-        {vm.srLevels ? (
-          <View style={{
-            marginTop: 14,
-            padding: 16,
-            backgroundColor: colors.surface,
-            borderRadius: 8,
-            borderWidth: 1,
-            borderColor: colors.border,
-          }}>
-            <View style={{
-              flexDirection: 'row',
-              justifyContent: 'space-between',
-              alignItems: 'center',
-              marginBottom: 10,
-            }}>
-              <Text style={{
-                color: colors.textSecondary,
-                fontSize: typography.fontSize.sm,
-                fontWeight: typography.fontWeight.medium,
-              }}>
-                Support & Resistance
-              </Text>
-              <Text style={{
-                fontSize: typography.fontSize.micro,
-                color: colors.textMuted,
-              }}>
-                {vm.srLevels.freshnessLabel}
-              </Text>
-            </View>
-
-            {vm.srLevels.levels.map((level, i) => {
-              const tone = toneColors[level.tone];
-              return (
-                <View
-                  key={`sr-level-${i}`}
-                  testID={`sr-level-${i}`}
-                  style={{
-                    flexDirection: 'row',
-                    alignItems: 'center',
-                    justifyContent: 'space-between',
-                    paddingVertical: 10,
-                    borderTopWidth: i === 0 ? 0 : 1,
-                    borderTopColor: colors.border,
-                  }}
-                >
-                  <View style={{ flexDirection: 'row', alignItems: 'center', gap: 10 }}>
-                    <View style={{
-                      height: 22,
-                      paddingHorizontal: 8,
-                      borderRadius: 999,
-                      borderWidth: 1,
-                      borderColor: tone.border,
-                      justifyContent: 'center',
-                      alignItems: 'center',
-                    }}>
-                      <Text style={{
-                        fontSize: typography.fontSize.micro,
-                        color: tone.text,
-                        fontWeight: typography.fontWeight.semibold,
-                      }}>
-                        {level.kind === 'resistance' ? 'Resist' : 'Support'}
-                      </Text>
-                    </View>
-                    <Text style={{
-                      fontFamily: typography.fontFamily.mono,
-                      fontSize: typography.fontSize.sm,
-                      fontWeight: typography.fontWeight.semibold,
-                      color: colors.text,
-                    }}>
-                      {level.priceLabel}
-                    </Text>
-                  </View>
-                  {level.note ? (
-                    <Text style={{
-                      fontSize: typography.fontSize.micro,
-                      color: colors.textMuted,
-                      textAlign: 'right',
-                      maxWidth: 150,
-                    }}>
-                      {level.note}
-                    </Text>
-                  ) : null}
-                </View>
-              );
-            })}
-          </View>
-        ) : (
-          <Text style={{
-            color: colors.textSecondary,
-            fontSize: typography.fontSize.sm,
-            marginTop: 16,
-          }}>
-            No current MCO levels available
-          </Text>
-        )}
+        <SrLevelsCard srLevels={vm.srLevels} />
       </View>
     </ScrollView>
   );

--- a/packages/ui/src/view-models/PositionDetailViewModel.test.ts
+++ b/packages/ui/src/view-models/PositionDetailViewModel.test.ts
@@ -60,6 +60,7 @@ describe('buildPositionDetailViewModel srLevels', () => {
       now,
     );
     expect(vm.srLevels).toBeDefined();
+    expect(vm.srLevels!.levels.length).toBeGreaterThan(0);
   });
 
   it('computes freshness for 5 minutes ago', () => {
@@ -68,7 +69,7 @@ describe('buildPositionDetailViewModel srLevels', () => {
       makeDto({ srLevels: makeSrBlock({ capturedAtUnixMs: 1_700_000 }) }),
       now,
     );
-    expect(vm.srLevels?.freshnessLabel).toBe('captured 5m ago');
+    expect(vm.srLevels?.freshnessLabel).toBe('AI · MCO · 5m ago');
     expect(vm.srLevels?.isStale).toBe(false);
   });
 
@@ -78,17 +79,7 @@ describe('buildPositionDetailViewModel srLevels', () => {
       makeDto({ srLevels: makeSrBlock({ capturedAtUnixMs: 9_200_000 }) }),
       now,
     );
-    expect(vm.srLevels?.freshnessLabel).toBe('captured 3h ago');
-    expect(vm.srLevels?.isStale).toBe(false);
-  });
-
-  it('computes freshness for 47 hours ago', () => {
-    const now = 200_000_000;
-    const vm = buildPositionDetailViewModel(
-      makeDto({ srLevels: makeSrBlock({ capturedAtUnixMs: 30_800_000 }) }),
-      now,
-    );
-    expect(vm.srLevels?.freshnessLabel).toBe('captured 47h ago');
+    expect(vm.srLevels?.freshnessLabel).toBe('AI · MCO · 3h ago');
     expect(vm.srLevels?.isStale).toBe(false);
   });
 
@@ -98,76 +89,171 @@ describe('buildPositionDetailViewModel srLevels', () => {
       makeDto({ srLevels: makeSrBlock({ capturedAtUnixMs: 23_600_000 }) }),
       now,
     );
-    expect(vm.srLevels?.freshnessLabel).toBe('captured 49h ago · stale');
+    expect(vm.srLevels?.freshnessLabel).toBe('AI · MCO · 49h ago · stale');
     expect(vm.srLevels?.isStale).toBe(true);
   });
 
-  it('marks stale at exactly 48h boundary', () => {
-    const ms48h = 172_800_000;
-    const now = 200_000_000;
-    const vm = buildPositionDetailViewModel(
-      makeDto({ srLevels: makeSrBlock({ capturedAtUnixMs: now - ms48h }) }),
-      now,
-    );
-    expect(vm.srLevels?.freshnessLabel).toBe('captured 48h ago · stale');
-    expect(vm.srLevels?.isStale).toBe(true);
-  });
-
-  it('floors at 1 minute for 30 seconds ago', () => {
-    const now = 200_000_000;
-    const vm = buildPositionDetailViewModel(
-      makeDto({ srLevels: makeSrBlock({ capturedAtUnixMs: now - 30_000 }) }),
-      now,
-    );
-    expect(vm.srLevels?.freshnessLabel).toBe('captured 1m ago');
-    expect(vm.srLevels?.isStale).toBe(false);
-  });
-
-  it('sorts supports ascending by price', () => {
+  it('sorts all levels ascending by price', () => {
     const now = 200_000_000;
     const vm = buildPositionDetailViewModel(
       makeDto({
+        currentPrice: 150,
+        lowerBound: 100,
+        upperBound: 200,
         srLevels: makeSrBlock({
           capturedAtUnixMs: now,
-          supports: [{ price: 130 }, { price: 90 }, { price: 110 }],
+          supports: [{ price: 130 }, { price: 90 }],
+          resistances: [{ price: 180 }, { price: 210 }],
+        }),
+      }),
+      now,
+    );
+    const prices = vm.srLevels!.levels.map((l) => l.priceLabel);
+    expect(prices).toEqual(['$90.00', '$130.00', '$180.00', '$210.00']);
+  });
+
+  it('assigns support and resistance kinds correctly', () => {
+    const now = 200_000_000;
+    const vm = buildPositionDetailViewModel(
+      makeDto({
+        currentPrice: 150,
+        lowerBound: 100,
+        upperBound: 200,
+        srLevels: makeSrBlock({
+          capturedAtUnixMs: now,
+          supports: [{ price: 110 }],
+          resistances: [{ price: 190 }],
+        }),
+      }),
+      now,
+    );
+    expect(vm.srLevels!.levels[0]!.kind).toBe('support');
+    expect(vm.srLevels!.levels[1]!.kind).toBe('resistance');
+  });
+
+  it('uses DTO notes when available', () => {
+    const now = 200_000_000;
+    const vm = buildPositionDetailViewModel(
+      makeDto({
+        currentPrice: 150,
+        lowerBound: 100,
+        upperBound: 200,
+        srLevels: makeSrBlock({
+          capturedAtUnixMs: now,
+          supports: [{ price: 110, notes: 'Primary · 30d pivot' }],
           resistances: [],
         }),
       }),
       now,
     );
-    const prices = vm.srLevels!.supportsSorted.map((s) => s.priceLabel);
-    expect(prices).toEqual(['$90.00', '$110.00', '$130.00']);
+    expect(vm.srLevels!.levels[0]!.note).toBe('Primary · 30d pivot');
   });
 
-  it('sorts resistances ascending by price', () => {
+  it('falls back to range-bound note for lower bound match', () => {
     const now = 200_000_000;
     const vm = buildPositionDetailViewModel(
       makeDto({
+        currentPrice: 150,
+        lowerBound: 110,
+        upperBound: 200,
+        srLevels: makeSrBlock({
+          capturedAtUnixMs: now,
+          supports: [{ price: 110 }],
+          resistances: [],
+        }),
+      }),
+      now,
+    );
+    expect(vm.srLevels!.levels[0]!.note).toBe('Range lower · your position');
+  });
+
+  it('falls back to range-bound note for upper bound match', () => {
+    const now = 200_000_000;
+    const vm = buildPositionDetailViewModel(
+      makeDto({
+        currentPrice: 150,
+        lowerBound: 100,
+        upperBound: 190,
         srLevels: makeSrBlock({
           capturedAtUnixMs: now,
           supports: [],
-          resistances: [{ price: 250 }, { price: 180 }, { price: 210 }],
+          resistances: [{ price: 190 }],
         }),
       }),
       now,
     );
-    const prices = vm.srLevels!.resistancesSorted.map((r) => r.priceLabel);
-    expect(prices).toEqual(['$180.00', '$210.00', '$250.00']);
+    expect(vm.srLevels!.levels[0]!.note).toBe('Range upper · your position');
   });
 
-  it('includes rankLabel when rank is present', () => {
+  it('falls back to rank label when no notes or bound match', () => {
     const now = 200_000_000;
     const vm = buildPositionDetailViewModel(
       makeDto({
+        currentPrice: 150,
+        lowerBound: 100,
+        upperBound: 200,
         srLevels: makeSrBlock({
           capturedAtUnixMs: now,
-          supports: [{ price: 90, rank: 'S1' }],
-          resistances: [{ price: 210, rank: 'R1' }],
+          supports: [{ price: 110, rank: 'S1' }],
+          resistances: [],
         }),
       }),
       now,
     );
-    expect(vm.srLevels!.supportsSorted[0]?.rankLabel).toBe('S1');
-    expect(vm.srLevels!.resistancesSorted[0]?.rankLabel).toBe('R1');
+    expect(vm.srLevels!.levels[0]!.note).toBe('S1');
+  });
+
+  it('marks breached resistance as breach tone when price is above it', () => {
+    const now = 200_000_000;
+    const vm = buildPositionDetailViewModel(
+      makeDto({
+        currentPrice: 220,
+        lowerBound: 100,
+        upperBound: 200,
+        srLevels: makeSrBlock({
+          capturedAtUnixMs: now,
+          supports: [],
+          resistances: [{ price: 210 }],
+        }),
+      }),
+      now,
+    );
+    expect(vm.srLevels!.levels[0]!.tone).toBe('breach');
+  });
+
+  it('marks unbreached resistance near upper bound as warn tone', () => {
+    const now = 200_000_000;
+    const vm = buildPositionDetailViewModel(
+      makeDto({
+        currentPrice: 150,
+        lowerBound: 100,
+        upperBound: 200,
+        srLevels: makeSrBlock({
+          capturedAtUnixMs: now,
+          supports: [],
+          resistances: [{ price: 200 }],
+        }),
+      }),
+      now,
+    );
+    expect(vm.srLevels!.levels[0]!.tone).toBe('warn');
+  });
+
+  it('marks distant safe resistance as safe tone', () => {
+    const now = 200_000_000;
+    const vm = buildPositionDetailViewModel(
+      makeDto({
+        currentPrice: 150,
+        lowerBound: 100,
+        upperBound: 200,
+        srLevels: makeSrBlock({
+          capturedAtUnixMs: now,
+          supports: [],
+          resistances: [{ price: 500 }],
+        }),
+      }),
+      now,
+    );
+    expect(vm.srLevels!.levels[0]!.tone).toBe('safe');
   });
 });

--- a/packages/ui/src/view-models/PositionDetailViewModel.test.ts
+++ b/packages/ui/src/view-models/PositionDetailViewModel.test.ts
@@ -1,14 +1,14 @@
-import { describe, it, expect } from 'vitest';
-import { buildPositionDetailViewModel } from './PositionDetailViewModel.js';
+import { describe, expect, it } from 'vitest';
 import type { PositionDetailDto } from '@clmm/application/public';
+import { buildPositionDetailViewModel } from './PositionDetailViewModel.js';
 
 function makeDto(overrides: Partial<PositionDetailDto> = {}): PositionDetailDto {
   return {
-    positionId: 'pos-1' as PositionDetailDto['positionId'],
+    positionId: 'position-1' as PositionDetailDto['positionId'],
     poolId: 'pool-1' as PositionDetailDto['poolId'],
     tokenPairLabel: 'SOL / USDC',
-    currentPrice: 142.35,
-    currentPriceLabel: 'USDC 142.35',
+    currentPrice: 150,
+    currentPriceLabel: 'USDC 150.00',
     feeRateLabel: '10 bps',
     rangeState: 'in-range',
     rangeDistance: { belowLowerPercent: 0, aboveUpperPercent: 0 },
@@ -16,13 +16,13 @@ function makeDto(overrides: Partial<PositionDetailDto> = {}): PositionDetailDto 
     monitoringStatus: 'active',
     lowerBound: 100,
     upperBound: 200,
-    lowerBoundLabel: 'USDC 1.01',
-    upperBoundLabel: 'USDC 1.22',
-    sqrtPrice: '184467440737095516',
+    lowerBoundLabel: 'USDC 100.00',
+    upperBoundLabel: 'USDC 200.00',
+    sqrtPrice: '123456',
     unclaimedFees: {
-      feeOwedA: { raw: '120000000', decimals: 9, symbol: 'SOL', usdValue: 18 },
-      feeOwedB: { raw: '47230000', decimals: 6, symbol: 'USDC', usdValue: 47.23 },
-      totalUsd: 65.23,
+      feeOwedA: { raw: '100000000', decimals: 9, symbol: 'SOL', usdValue: 15 },
+      feeOwedB: { raw: '30000000', decimals: 6, symbol: 'USDC', usdValue: 30 },
+      totalUsd: 45,
     },
     unclaimedRewards: {
       rewards: [],
@@ -60,7 +60,7 @@ describe('buildPositionDetailViewModel srLevels', () => {
       now,
     );
     expect(vm.srLevels).toBeDefined();
-    expect(vm.srLevels!.levels.length).toBeGreaterThan(0);
+    expect(vm.srLevels!.groups.length).toBeGreaterThan(0);
   });
 
   it('computes freshness for 5 minutes ago', () => {
@@ -73,197 +73,105 @@ describe('buildPositionDetailViewModel srLevels', () => {
     expect(vm.srLevels?.isStale).toBe(false);
   });
 
-  it('computes freshness for 3 hours ago', () => {
-    const now = 20_000_000;
-    const vm = buildPositionDetailViewModel(
-      makeDto({ srLevels: makeSrBlock({ capturedAtUnixMs: 9_200_000 }) }),
-      now,
-    );
-    expect(vm.srLevels?.freshnessLabel).toBe('AI · MCO · 3h ago');
-    expect(vm.srLevels?.isStale).toBe(false);
-  });
-
-  it('computes freshness for 49 hours ago (stale)', () => {
-    const now = 200_000_000;
-    const vm = buildPositionDetailViewModel(
-      makeDto({ srLevels: makeSrBlock({ capturedAtUnixMs: 23_600_000 }) }),
-      now,
-    );
-    expect(vm.srLevels?.freshnessLabel).toBe('AI · MCO · 49h ago · stale');
-    expect(vm.srLevels?.isStale).toBe(true);
-  });
-
-  it('sorts all levels ascending by price', () => {
+  it('parses real notes format with trigger and invalidation', () => {
     const now = 200_000_000;
     const vm = buildPositionDetailViewModel(
       makeDto({
-        currentPrice: 150,
-        lowerBound: 100,
-        upperBound: 200,
         srLevels: makeSrBlock({
           capturedAtUnixMs: now,
-          supports: [{ price: 130 }, { price: 90 }],
-          resistances: [{ price: 180 }, { price: 210 }],
-        }),
-      }),
-      now,
-    );
-    const prices = vm.srLevels!.levels.map((l) => l.priceLabel);
-    expect(prices).toEqual(['$90.00', '$130.00', '$180.00', '$210.00']);
-  });
-
-  it('assigns support and resistance kinds correctly', () => {
-    const now = 200_000_000;
-    const vm = buildPositionDetailViewModel(
-      makeDto({
-        currentPrice: 150,
-        lowerBound: 100,
-        upperBound: 200,
-        srLevels: makeSrBlock({
-          capturedAtUnixMs: now,
-          supports: [{ price: 110 }],
-          resistances: [{ price: 190 }],
-        }),
-      }),
-      now,
-    );
-    expect(vm.srLevels!.levels[0]!.kind).toBe('support');
-    expect(vm.srLevels!.levels[1]!.kind).toBe('resistance');
-  });
-
-  it('uses DTO notes when available', () => {
-    const now = 200_000_000;
-    const vm = buildPositionDetailViewModel(
-      makeDto({
-        currentPrice: 150,
-        lowerBound: 100,
-        upperBound: 200,
-        srLevels: makeSrBlock({
-          capturedAtUnixMs: now,
-          supports: [{ price: 110, notes: 'Primary · 30d pivot' }],
+          supports: [{
+            price: 90,
+            notes: 'morecryptoonline swing, bearish. trend continuation | Trigger: break below 85 signals wave three down is underway | Invalidation: break above 88.30, shifting probabilities toward orange C-wave scenario | Support parsed from: "79–81 (blue zone)" | Raw support: 83 (Sunday low), 79–81 (blue zone)',
+          }],
           resistances: [],
         }),
       }),
       now,
     );
-    expect(vm.srLevels!.levels[0]!.note).toBe('Primary · 30d pivot');
+    const group = vm.srLevels!.groups[0]!;
+    expect(group.source).toBe('morecryptoonline');
+    expect(group.timeframe).toBe('swing');
+    expect(group.bias).toBe('bearish');
+    expect(group.setupType).toBe('trend continuation');
+    expect(group.trigger).toBe('break below 85 signals wave three down is underway');
+    expect(group.invalidation).toBe('break above 88.30, shifting probabilities toward orange C-wave scenario');
+    expect(group.note).toContain('Support parsed from:');
+    expect(group.note).toContain('Raw support:');
   });
 
-  it('falls back to range-bound note for lower bound match', () => {
+  it('returns raw notes when no pipe separator', () => {
     const now = 200_000_000;
     const vm = buildPositionDetailViewModel(
       makeDto({
-        currentPrice: 150,
-        lowerBound: 110,
-        upperBound: 200,
         srLevels: makeSrBlock({
           capturedAtUnixMs: now,
-          supports: [{ price: 110 }],
+          supports: [{ price: 90, notes: 'Primary support zone' }],
           resistances: [],
         }),
       }),
       now,
     );
-    expect(vm.srLevels!.levels[0]!.note).toBe('Range lower · your position');
+    const group = vm.srLevels!.groups[0]!;
+    expect(group.note).toBe('Primary support zone');
+    expect(group.source).toBeUndefined();
   });
 
-  it('falls back to range-bound note for upper bound match', () => {
+  it('groups levels with identical metadata', () => {
     const now = 200_000_000;
     const vm = buildPositionDetailViewModel(
       makeDto({
-        currentPrice: 150,
-        lowerBound: 100,
-        upperBound: 190,
         srLevels: makeSrBlock({
           capturedAtUnixMs: now,
-          supports: [],
-          resistances: [{ price: 190 }],
-        }),
-      }),
-      now,
-    );
-    expect(vm.srLevels!.levels[0]!.note).toBe('Range upper · your position');
-  });
-
-  it('falls back to rank label when no notes or bound match', () => {
-    const now = 200_000_000;
-    const vm = buildPositionDetailViewModel(
-      makeDto({
-        currentPrice: 150,
-        lowerBound: 100,
-        upperBound: 200,
-        srLevels: makeSrBlock({
-          capturedAtUnixMs: now,
-          supports: [{ price: 110, rank: 'S1' }],
+          supports: [
+            { price: 90, rank: 'S1', notes: 'source, 1h, Bullish. test | note body' },
+            { price: 110, rank: 'S1', notes: 'source, 1h, Bullish. test | note body' },
+          ],
           resistances: [],
         }),
       }),
       now,
     );
-    expect(vm.srLevels!.levels[0]!.note).toBe('S1');
+    expect(vm.srLevels!.groups.length).toBe(1);
+    expect(vm.srLevels!.groups[0]!.levels.length).toBe(2);
   });
 
-  it('marks breached resistance as breach tone when price is above it', () => {
+  it('creates separate groups for different metadata', () => {
     const now = 200_000_000;
     const vm = buildPositionDetailViewModel(
       makeDto({
-        currentPrice: 220,
-        lowerBound: 100,
-        upperBound: 200,
         srLevels: makeSrBlock({
           capturedAtUnixMs: now,
-          supports: [],
-          resistances: [{ price: 210 }],
+          supports: [
+            { price: 90, rank: 'S1', notes: 'note A' },
+            { price: 110, rank: 'S2', notes: 'note B' },
+          ],
+          resistances: [],
         }),
       }),
       now,
     );
-    expect(vm.srLevels!.levels[0]!.tone).toBe('breach');
+    expect(vm.srLevels!.groups.length).toBe(2);
   });
 
-  it('marks unbreached resistance near upper bound as warn tone', () => {
+  it('marks resistance as breach tone (red)', () => {
     const now = 200_000_000;
     const vm = buildPositionDetailViewModel(
       makeDto({
-        currentPrice: 150,
-        lowerBound: 100,
-        upperBound: 200,
         srLevels: makeSrBlock({
           capturedAtUnixMs: now,
           supports: [],
-          resistances: [{ price: 200 }],
+          resistances: [{ price: 180 }],
         }),
       }),
       now,
     );
-    expect(vm.srLevels!.levels[0]!.tone).toBe('warn');
+    expect(vm.srLevels!.groups[0]!.levels[0]!.tone).toBe('breach');
   });
 
-  it('marks distant safe resistance as safe tone', () => {
+  it('marks support as safe tone (green)', () => {
     const now = 200_000_000;
     const vm = buildPositionDetailViewModel(
       makeDto({
-        currentPrice: 150,
-        lowerBound: 100,
-        upperBound: 200,
-        srLevels: makeSrBlock({
-          capturedAtUnixMs: now,
-          supports: [],
-          resistances: [{ price: 500 }],
-        }),
-      }),
-      now,
-    );
-    expect(vm.srLevels!.levels[0]!.tone).toBe('safe');
-  });
-
-  it('marks breached support as breach tone when price is below it', () => {
-    const now = 200_000_000;
-    const vm = buildPositionDetailViewModel(
-      makeDto({
-        currentPrice: 80,
-        lowerBound: 100,
-        upperBound: 200,
         srLevels: makeSrBlock({
           capturedAtUnixMs: now,
           supports: [{ price: 90 }],
@@ -272,82 +180,36 @@ describe('buildPositionDetailViewModel srLevels', () => {
       }),
       now,
     );
-    expect(vm.srLevels!.levels[0]!.tone).toBe('breach');
+    expect(vm.srLevels!.groups[0]!.levels[0]!.tone).toBe('safe');
   });
 
-  it('marks unbreached support near lower bound as warn tone', () => {
+  it('passes summary through to view-model', () => {
     const now = 200_000_000;
     const vm = buildPositionDetailViewModel(
       makeDto({
-        currentPrice: 150,
-        lowerBound: 100,
-        upperBound: 200,
         srLevels: makeSrBlock({
           capturedAtUnixMs: now,
-          supports: [{ price: 100 }],
-          resistances: [],
+          summary: 'Bearish swing, trend continuation.',
         }),
       }),
       now,
     );
-    expect(vm.srLevels!.levels[0]!.tone).toBe('warn');
+    expect(vm.srLevels!.summary).toBe('Bearish swing, trend continuation.');
   });
 
-  it('marks distant safe support as safe tone', () => {
+  it('sorts groups by lowest price ascending', () => {
     const now = 200_000_000;
     const vm = buildPositionDetailViewModel(
       makeDto({
-        currentPrice: 150,
-        lowerBound: 100,
-        upperBound: 200,
         srLevels: makeSrBlock({
           capturedAtUnixMs: now,
-          supports: [{ price: 10 }],
-          resistances: [],
+          supports: [{ price: 130, notes: 'high' }],
+          resistances: [{ price: 80, notes: 'low' }],
         }),
       }),
       now,
     );
-    expect(vm.srLevels!.levels[0]!.tone).toBe('safe');
-  });
-
-  it('marks level as warn when within 5% proximity of current price', () => {
-    const now = 200_000_000;
-    // currentPrice 150, resistance at 155 = 3.3% above -> warn
-    const vm = buildPositionDetailViewModel(
-      makeDto({
-        currentPrice: 150,
-        lowerBound: 100,
-        upperBound: 200,
-        srLevels: makeSrBlock({
-          capturedAtUnixMs: now,
-          supports: [],
-          resistances: [{ price: 155 }],
-        }),
-      }),
-      now,
-    );
-    expect(vm.srLevels!.levels[0]!.tone).toBe('warn');
-  });
-
-  it('floors freshness at 1 minute for sub-minute age', () => {
-    const now = 200_000_000;
-    const vm = buildPositionDetailViewModel(
-      makeDto({ srLevels: makeSrBlock({ capturedAtUnixMs: now - 30_000 }) }),
-      now,
-    );
-    expect(vm.srLevels?.freshnessLabel).toBe('AI · MCO · 1m ago');
-    expect(vm.srLevels?.isStale).toBe(false);
-  });
-
-  it('marks stale at exactly 48h boundary', () => {
-    const ms48h = 172_800_000;
-    const now = 200_000_000;
-    const vm = buildPositionDetailViewModel(
-      makeDto({ srLevels: makeSrBlock({ capturedAtUnixMs: now - ms48h }) }),
-      now,
-    );
-    expect(vm.srLevels?.freshnessLabel).toBe('AI · MCO · 48h ago · stale');
-    expect(vm.srLevels?.isStale).toBe(true);
+    expect(vm.srLevels!.groups[0]!.levels[0]!.priceLabel).toBe('$80.00');
+    expect(vm.srLevels!.groups[1]!.levels[0]!.priceLabel).toBe('$130.00');
   });
 });

--- a/packages/ui/src/view-models/PositionDetailViewModel.test.ts
+++ b/packages/ui/src/view-models/PositionDetailViewModel.test.ts
@@ -208,7 +208,7 @@ describe('buildPositionDetailViewModel srLevels', () => {
       }),
       now,
     );
-    expect(vm.srLevels!.groups[0]!.levels[0]!.priceLabel).toBe('$80.00');
-    expect(vm.srLevels!.groups[1]!.levels[0]!.priceLabel).toBe('$130.00');
+    expect(vm.srLevels!.groups[0]!.levels[0]!.priceLabel).toBe('$130.00');
+    expect(vm.srLevels!.groups[1]!.levels[0]!.priceLabel).toBe('$80.00');
   });
 });

--- a/packages/ui/src/view-models/PositionDetailViewModel.test.ts
+++ b/packages/ui/src/view-models/PositionDetailViewModel.test.ts
@@ -256,4 +256,98 @@ describe('buildPositionDetailViewModel srLevels', () => {
     );
     expect(vm.srLevels!.levels[0]!.tone).toBe('safe');
   });
+
+  it('marks breached support as breach tone when price is below it', () => {
+    const now = 200_000_000;
+    const vm = buildPositionDetailViewModel(
+      makeDto({
+        currentPrice: 80,
+        lowerBound: 100,
+        upperBound: 200,
+        srLevels: makeSrBlock({
+          capturedAtUnixMs: now,
+          supports: [{ price: 90 }],
+          resistances: [],
+        }),
+      }),
+      now,
+    );
+    expect(vm.srLevels!.levels[0]!.tone).toBe('breach');
+  });
+
+  it('marks unbreached support near lower bound as warn tone', () => {
+    const now = 200_000_000;
+    const vm = buildPositionDetailViewModel(
+      makeDto({
+        currentPrice: 150,
+        lowerBound: 100,
+        upperBound: 200,
+        srLevels: makeSrBlock({
+          capturedAtUnixMs: now,
+          supports: [{ price: 100 }],
+          resistances: [],
+        }),
+      }),
+      now,
+    );
+    expect(vm.srLevels!.levels[0]!.tone).toBe('warn');
+  });
+
+  it('marks distant safe support as safe tone', () => {
+    const now = 200_000_000;
+    const vm = buildPositionDetailViewModel(
+      makeDto({
+        currentPrice: 150,
+        lowerBound: 100,
+        upperBound: 200,
+        srLevels: makeSrBlock({
+          capturedAtUnixMs: now,
+          supports: [{ price: 10 }],
+          resistances: [],
+        }),
+      }),
+      now,
+    );
+    expect(vm.srLevels!.levels[0]!.tone).toBe('safe');
+  });
+
+  it('marks level as warn when within 5% proximity of current price', () => {
+    const now = 200_000_000;
+    // currentPrice 150, resistance at 155 = 3.3% above -> warn
+    const vm = buildPositionDetailViewModel(
+      makeDto({
+        currentPrice: 150,
+        lowerBound: 100,
+        upperBound: 200,
+        srLevels: makeSrBlock({
+          capturedAtUnixMs: now,
+          supports: [],
+          resistances: [{ price: 155 }],
+        }),
+      }),
+      now,
+    );
+    expect(vm.srLevels!.levels[0]!.tone).toBe('warn');
+  });
+
+  it('floors freshness at 1 minute for sub-minute age', () => {
+    const now = 200_000_000;
+    const vm = buildPositionDetailViewModel(
+      makeDto({ srLevels: makeSrBlock({ capturedAtUnixMs: now - 30_000 }) }),
+      now,
+    );
+    expect(vm.srLevels?.freshnessLabel).toBe('AI · MCO · 1m ago');
+    expect(vm.srLevels?.isStale).toBe(false);
+  });
+
+  it('marks stale at exactly 48h boundary', () => {
+    const ms48h = 172_800_000;
+    const now = 200_000_000;
+    const vm = buildPositionDetailViewModel(
+      makeDto({ srLevels: makeSrBlock({ capturedAtUnixMs: now - ms48h }) }),
+      now,
+    );
+    expect(vm.srLevels?.freshnessLabel).toBe('AI · MCO · 48h ago · stale');
+    expect(vm.srLevels?.isStale).toBe(true);
+  });
 });

--- a/packages/ui/src/view-models/PositionDetailViewModel.test.ts
+++ b/packages/ui/src/view-models/PositionDetailViewModel.test.ts
@@ -95,8 +95,7 @@ describe('buildPositionDetailViewModel srLevels', () => {
     expect(group.setupType).toBe('trend continuation');
     expect(group.trigger).toBe('break below 85 signals wave three down is underway');
     expect(group.invalidation).toBe('break above 88.30, shifting probabilities toward orange C-wave scenario');
-    expect(group.note).toContain('Support parsed from:');
-    expect(group.note).toContain('Raw support:');
+    expect(group.note).toBe('');
   });
 
   it('returns raw notes when no pipe separator', () => {
@@ -112,7 +111,7 @@ describe('buildPositionDetailViewModel srLevels', () => {
       now,
     );
     const group = vm.srLevels!.groups[0]!;
-    expect(group.note).toBe('Primary support zone');
+    expect(group.note).toBe('');
     expect(group.source).toBeUndefined();
   });
 
@@ -142,8 +141,8 @@ describe('buildPositionDetailViewModel srLevels', () => {
         srLevels: makeSrBlock({
           capturedAtUnixMs: now,
           supports: [
-            { price: 90, rank: 'S1', notes: 'note A' },
-            { price: 110, rank: 'S2', notes: 'note B' },
+            { price: 90, rank: 'S1', notes: 's, 1h, Bullish. t | Trigger: A' },
+            { price: 110, rank: 'S2', notes: 's, 1h, Bullish. t | Trigger: B' },
           ],
           resistances: [],
         }),
@@ -203,8 +202,8 @@ describe('buildPositionDetailViewModel srLevels', () => {
       makeDto({
         srLevels: makeSrBlock({
           capturedAtUnixMs: now,
-          supports: [{ price: 130, notes: 'high' }],
-          resistances: [{ price: 80, notes: 'low' }],
+          supports: [{ price: 130, notes: 's, 1h, A. t | Trigger: high' }],
+          resistances: [{ price: 80, notes: 's, 1h, B. t | Trigger: low' }],
         }),
       }),
       now,

--- a/packages/ui/src/view-models/PositionDetailViewModel.ts
+++ b/packages/ui/src/view-models/PositionDetailViewModel.ts
@@ -218,7 +218,7 @@ function toSrLevelsViewModelBlock(
   groups.sort((a, b) => {
     const aPrice = a.levels[0]?.rawPrice ?? 0;
     const bPrice = b.levels[0]?.rawPrice ?? 0;
-    return aPrice - bPrice;
+    return bPrice - aPrice;
   });
 
   return {

--- a/packages/ui/src/view-models/PositionDetailViewModel.ts
+++ b/packages/ui/src/view-models/PositionDetailViewModel.ts
@@ -3,14 +3,25 @@ import { getRangeStatusBadgeProps } from '../components/RangeStatusBadgeUtils.js
 
 export type SrLevelViewModel = {
   kind: 'support' | 'resistance';
-  rawPrice: number; // for sorting
+  rawPrice: number;
   priceLabel: string;
-  note: string;
   tone: 'safe' | 'warn' | 'breach';
 };
 
-export type SrLevelsViewModelBlock = {
+export type SrLevelGroupViewModel = {
   levels: SrLevelViewModel[];
+  note: string;
+  source?: string;
+  timeframe?: string;
+  bias?: string;
+  setupType?: string;
+  trigger?: string;
+  invalidation?: string;
+};
+
+export type SrLevelsViewModelBlock = {
+  summary?: string;
+  groups: SrLevelGroupViewModel[];
   freshnessLabel: string;
   isStale: boolean;
 };
@@ -40,58 +51,7 @@ export type PositionDetailViewModel = {
 
 const MS_PER_MINUTE = 60_000;
 const MS_PER_HOUR = 3_600_000;
-const STALE_THRESHOLD_MS = 48 * MS_PER_HOUR; // 48 hours
-
-// Consider a level "near" a bound if within 1 cent — prevents floating-point mismatch
-const BOUND_EPSILON = 0.01;
-const PROXIMITY_THRESHOLD = 0.05; // 5%
-
-function isNearBound(price: number, bound: number): boolean {
-  return Math.abs(price - bound) <= BOUND_EPSILON;
-}
-
-function isWithinProximity(currentPrice: number, levelPrice: number): boolean {
-  if (levelPrice === 0) return false;
-  return Math.abs(currentPrice - levelPrice) / levelPrice <= PROXIMITY_THRESHOLD;
-}
-
-/**
- * Compute the semantic tone for an S/R level.
- * - `breach`: Price has crossed the level (above resistance / below support)
- * - `warn`: Level is near the position's bound OR within 5% of current price
- * - `safe`: Everything else
- */
-function computeLevelTone(
-  kind: 'support' | 'resistance',
-  levelPrice: number,
-  currentPrice: number,
-  lowerBound: number,
-  upperBound: number,
-): 'safe' | 'warn' | 'breach' {
-  if (kind === 'resistance') {
-    if (currentPrice > levelPrice) return 'breach';
-    if (isNearBound(levelPrice, upperBound)) return 'warn';
-    if (isWithinProximity(currentPrice, levelPrice)) return 'warn';
-    return 'safe';
-  }
-  // support
-  if (currentPrice < levelPrice) return 'breach';
-  if (isNearBound(levelPrice, lowerBound)) return 'warn';
-  if (isWithinProximity(currentPrice, levelPrice)) return 'warn';
-  return 'safe';
-}
-
-function computeLevelNote(
-  level: { price: number; rank?: string; notes?: string },
-  lowerBound: number,
-  upperBound: number,
-): string {
-  if (level.notes) return level.notes;
-  if (isNearBound(level.price, lowerBound)) return 'Range lower · your position';
-  if (isNearBound(level.price, upperBound)) return 'Range upper · your position';
-  if (level.rank) return level.rank;
-  return '';
-}
+const STALE_THRESHOLD_MS = 48 * MS_PER_HOUR;
 
 function computeFreshness(capturedAtUnixMs: number, now: number): { freshnessLabel: string; isStale: boolean } {
   const ageMs = now - capturedAtUnixMs;
@@ -106,37 +66,154 @@ function computeFreshness(capturedAtUnixMs: number, now: number): { freshnessLab
   return { freshnessLabel: `AI · MCO · ${hours}h ago · stale`, isStale: true };
 }
 
+function parseNotes(notes: string | undefined): {
+  source?: string;
+  timeframe?: string;
+  bias?: string;
+  setupType?: string;
+  trigger?: string;
+  invalidation?: string;
+  remaining: string;
+} {
+  if (!notes) {
+    return { remaining: '' };
+  }
+
+  const parts = notes.split('|').map((s) => s.trim()).filter(Boolean);
+  if (parts.length === 0) {
+    return { remaining: '' };
+  }
+  if (parts.length === 1) {
+    return { remaining: parts[0] };
+  }
+
+  // Parse metadata from first section
+  const firstSection = parts[0];
+  const lastDotIndex = firstSection.lastIndexOf('.');
+  let source: string | undefined;
+  let timeframe: string | undefined;
+  let bias: string | undefined;
+  let setupType: string | undefined;
+
+  if (lastDotIndex > -1) {
+    setupType = firstSection.slice(lastDotIndex + 1).trim();
+    const beforeDot = firstSection.slice(0, lastDotIndex).trim();
+    const commaParts = beforeDot.split(',').map((s) => s.trim());
+    if (commaParts.length >= 2) {
+      bias = commaParts[commaParts.length - 1];
+      const sourceTimeframe = commaParts.slice(0, -1).join(',').trim();
+      const spaceParts = sourceTimeframe.split(/\s+/);
+      if (spaceParts.length >= 2) {
+        source = spaceParts[0];
+        timeframe = spaceParts.slice(1).join(' ');
+      } else {
+        source = sourceTimeframe;
+      }
+    } else {
+      const spaceParts = beforeDot.split(/\s+/);
+      if (spaceParts.length >= 2) {
+        source = spaceParts[0];
+        timeframe = spaceParts.slice(1).join(' ');
+      } else {
+        source = beforeDot;
+      }
+    }
+  } else {
+    return { remaining: notes.trim() };
+  }
+
+  // Parse trigger and invalidation from remaining sections
+  let trigger: string | undefined;
+  let invalidation: string | undefined;
+  const noteParts: string[] = [];
+
+  for (let i = 1; i < parts.length; i++) {
+    const part = parts[i];
+    const lower = part.toLowerCase();
+    if (lower.startsWith('trigger:')) {
+      trigger = part.slice('trigger:'.length).trim();
+    } else if (lower.startsWith('invalidation:')) {
+      invalidation = part.slice('invalidation:'.length).trim();
+    } else {
+      noteParts.push(part);
+    }
+  }
+
+  return {
+    ...(source ? { source } : {}),
+    ...(timeframe ? { timeframe } : {}),
+    ...(bias ? { bias } : {}),
+    ...(setupType ? { setupType } : {}),
+    ...(trigger ? { trigger } : {}),
+    ...(invalidation ? { invalidation } : {}),
+    remaining: noteParts.join('\n'),
+  };
+}
+
 function toSrLevelsViewModelBlock(
   block: NonNullable<PositionDetailDto['srLevels']>,
-  currentPrice: number,
-  lowerBound: number,
-  upperBound: number,
+  _currentPrice: number,
+  _lowerBound: number,
+  _upperBound: number,
   now: number,
 ): SrLevelsViewModelBlock {
   const { freshnessLabel, isStale } = computeFreshness(block.capturedAtUnixMs, now);
 
-  const supportLevels: SrLevelViewModel[] = block.supports.map((s) => ({
-    kind: 'support',
-    rawPrice: s.price,
-    priceLabel: `$${s.price.toFixed(2)}`,
-    note: computeLevelNote(s, lowerBound, upperBound),
-    tone: computeLevelTone('support', s.price, currentPrice, lowerBound, upperBound),
-  }));
+  // Group raw levels by identical metadata (rank + timeframe + notes)
+  type RawItem = (typeof block.supports)[number] & { kind: 'support' | 'resistance' };
+  const rawGroups = new Map<string, RawItem[]>();
 
-  const resistanceLevels: SrLevelViewModel[] = block.resistances.map((r) => ({
-    kind: 'resistance',
-    rawPrice: r.price,
-    priceLabel: `$${r.price.toFixed(2)}`,
-    note: computeLevelNote(r, lowerBound, upperBound),
-    tone: computeLevelTone('resistance', r.price, currentPrice, lowerBound, upperBound),
-  }));
+  const addItems = (kind: 'support' | 'resistance', items: typeof block.supports) => {
+    for (const item of items) {
+      const key = `${item.rank ?? ''}:${item.timeframe ?? ''}:${item.notes ?? ''}`;
+      const existing = rawGroups.get(key);
+      const itemWithKind = { ...item, kind };
+      if (existing) {
+        existing.push(itemWithKind);
+      } else {
+        rawGroups.set(key, [itemWithKind]);
+      }
+    }
+  };
 
-  // Sort all levels by price ascending
-  const levels = [...supportLevels, ...resistanceLevels].sort(
-    (a, b) => a.rawPrice - b.rawPrice,
-  );
+  addItems('support', block.supports);
+  addItems('resistance', block.resistances);
 
-  return { levels, freshnessLabel, isStale };
+  const groups: SrLevelGroupViewModel[] = [];
+
+  for (const [, items] of rawGroups) {
+    const first = items[0];
+    const parsed = parseNotes(first.notes);
+
+    const levels = items.map((item) => ({
+      kind: item.kind,
+      rawPrice: item.price,
+      priceLabel: `$${item.price.toFixed(2)}`,
+      tone: item.kind === 'resistance' ? ('breach' as const) : ('safe' as const),
+    }));
+
+    levels.sort((a, b) => a.rawPrice - b.rawPrice);
+
+    groups.push({
+      levels,
+      note: parsed.remaining,
+      ...(parsed.source ? { source: parsed.source } : {}),
+      ...(parsed.timeframe ? { timeframe: parsed.timeframe } : {}),
+      ...(parsed.bias ? { bias: parsed.bias } : {}),
+      ...(parsed.setupType ? { setupType: parsed.setupType } : {}),
+      ...(parsed.trigger ? { trigger: parsed.trigger } : {}),
+      ...(parsed.invalidation ? { invalidation: parsed.invalidation } : {}),
+    });
+  }
+
+  groups.sort((a, b) => a.levels[0].rawPrice - b.levels[0].rawPrice);
+
+  return {
+    summary: block.summary ?? undefined,
+    groups,
+    freshnessLabel,
+    isStale,
+  };
 }
 
 function formatTokenAmount(raw: string, decimals: number | null, symbol: string): string {
@@ -145,7 +222,6 @@ function formatTokenAmount(raw: string, decimals: number | null, symbol: string)
 
   const fractionalDigits = decimals > 2 ? 4 : 2;
 
-  // String-based decimal shift — avoids Number precision loss for large u64s
   const padded = raw.padStart(decimals + 1, '0');
   const whole = padded.slice(0, -decimals);
   const fraction = padded.slice(-decimals).slice(0, fractionalDigits);

--- a/packages/ui/src/view-models/PositionDetailViewModel.ts
+++ b/packages/ui/src/view-models/PositionDetailViewModel.ts
@@ -20,7 +20,7 @@ export type SrLevelGroupViewModel = {
 };
 
 export type SrLevelsViewModelBlock = {
-  summary?: string;
+  summary?: string | undefined;
   groups: SrLevelGroupViewModel[];
   freshnessLabel: string;
   isStale: boolean;
@@ -84,11 +84,11 @@ function parseNotes(notes: string | undefined): {
     return { remaining: '' };
   }
   if (parts.length === 1) {
-    return { remaining: parts[0] };
+    return { remaining: parts[0] ?? '' };
   }
 
   // Parse metadata from first section
-  const firstSection = parts[0];
+  const firstSection = parts[0]!;
   const lastDotIndex = firstSection.lastIndexOf('.');
   let source: string | undefined;
   let timeframe: string | undefined;
@@ -128,7 +128,7 @@ function parseNotes(notes: string | undefined): {
   const noteParts: string[] = [];
 
   for (let i = 1; i < parts.length; i++) {
-    const part = parts[i];
+    const part = parts[i]!;
     const lower = part.toLowerCase();
     if (lower.startsWith('trigger:')) {
       trigger = part.slice('trigger:'.length).trim();
@@ -182,7 +182,8 @@ function toSrLevelsViewModelBlock(
   const groups: SrLevelGroupViewModel[] = [];
 
   for (const [, items] of rawGroups) {
-    const first = items[0];
+    if (items.length === 0) continue;
+    const first = items[0]!;
     const parsed = parseNotes(first.notes);
 
     const levels = items.map((item) => ({
@@ -206,7 +207,11 @@ function toSrLevelsViewModelBlock(
     });
   }
 
-  groups.sort((a, b) => a.levels[0].rawPrice - b.levels[0].rawPrice);
+  groups.sort((a, b) => {
+    const aPrice = a.levels[0]?.rawPrice ?? 0;
+    const bPrice = b.levels[0]?.rawPrice ?? 0;
+    return aPrice - bPrice;
+  });
 
   return {
     summary: block.summary ?? undefined,

--- a/packages/ui/src/view-models/PositionDetailViewModel.ts
+++ b/packages/ui/src/view-models/PositionDetailViewModel.ts
@@ -3,6 +3,7 @@ import { getRangeStatusBadgeProps } from '../components/RangeStatusBadgeUtils.js
 
 export type SrLevelViewModel = {
   kind: 'support' | 'resistance';
+  rawPrice: number; // for sorting
   priceLabel: string;
   note: string;
   tone: 'safe' | 'warn' | 'breach';
@@ -37,6 +38,11 @@ export type PositionDetailViewModel = {
   srLevels?: SrLevelsViewModelBlock;
 };
 
+const MS_PER_MINUTE = 60_000;
+const MS_PER_HOUR = 3_600_000;
+const STALE_THRESHOLD_MS = 48 * MS_PER_HOUR; // 48 hours
+
+// Consider a level "near" a bound if within 1 cent — prevents floating-point mismatch
 const BOUND_EPSILON = 0.01;
 const PROXIMITY_THRESHOLD = 0.05; // 5%
 
@@ -49,6 +55,12 @@ function isWithinProximity(currentPrice: number, levelPrice: number): boolean {
   return Math.abs(currentPrice - levelPrice) / levelPrice <= PROXIMITY_THRESHOLD;
 }
 
+/**
+ * Compute the semantic tone for an S/R level.
+ * - `breach`: Price has crossed the level (above resistance / below support)
+ * - `warn`: Level is near the position's bound OR within 5% of current price
+ * - `safe`: Everything else
+ */
 function computeLevelTone(
   kind: 'support' | 'resistance',
   levelPrice: number,
@@ -83,12 +95,12 @@ function computeLevelNote(
 
 function computeFreshness(capturedAtUnixMs: number, now: number): { freshnessLabel: string; isStale: boolean } {
   const ageMs = now - capturedAtUnixMs;
-  if (ageMs < 3600000) {
-    const minutes = Math.max(1, Math.round(ageMs / 60000));
+  if (ageMs < MS_PER_HOUR) {
+    const minutes = Math.max(1, Math.round(ageMs / MS_PER_MINUTE));
     return { freshnessLabel: `AI · MCO · ${minutes}m ago`, isStale: false };
   }
-  const hours = Math.round(ageMs / 3600000);
-  if (ageMs < 172800000) {
+  const hours = Math.round(ageMs / MS_PER_HOUR);
+  if (ageMs < STALE_THRESHOLD_MS) {
     return { freshnessLabel: `AI · MCO · ${hours}h ago`, isStale: false };
   }
   return { freshnessLabel: `AI · MCO · ${hours}h ago · stale`, isStale: true };
@@ -105,6 +117,7 @@ function toSrLevelsViewModelBlock(
 
   const supportLevels: SrLevelViewModel[] = block.supports.map((s) => ({
     kind: 'support',
+    rawPrice: s.price,
     priceLabel: `$${s.price.toFixed(2)}`,
     note: computeLevelNote(s, lowerBound, upperBound),
     tone: computeLevelTone('support', s.price, currentPrice, lowerBound, upperBound),
@@ -112,6 +125,7 @@ function toSrLevelsViewModelBlock(
 
   const resistanceLevels: SrLevelViewModel[] = block.resistances.map((r) => ({
     kind: 'resistance',
+    rawPrice: r.price,
     priceLabel: `$${r.price.toFixed(2)}`,
     note: computeLevelNote(r, lowerBound, upperBound),
     tone: computeLevelTone('resistance', r.price, currentPrice, lowerBound, upperBound),
@@ -119,7 +133,7 @@ function toSrLevelsViewModelBlock(
 
   // Sort all levels by price ascending
   const levels = [...supportLevels, ...resistanceLevels].sort(
-    (a, b) => parseFloat(a.priceLabel.slice(1)) - parseFloat(b.priceLabel.slice(1)),
+    (a, b) => a.rawPrice - b.rawPrice,
   );
 
   return { levels, freshnessLabel, isStale };

--- a/packages/ui/src/view-models/PositionDetailViewModel.ts
+++ b/packages/ui/src/view-models/PositionDetailViewModel.ts
@@ -201,7 +201,7 @@ function toSrLevelsViewModelBlock(
       tone: item.kind === 'resistance' ? ('breach' as const) : ('safe' as const),
     }));
 
-    levels.sort((a, b) => a.rawPrice - b.rawPrice);
+    levels.sort((a, b) => b.rawPrice - a.rawPrice);
 
     groups.push({
       levels,

--- a/packages/ui/src/view-models/PositionDetailViewModel.ts
+++ b/packages/ui/src/view-models/PositionDetailViewModel.ts
@@ -159,32 +159,40 @@ function toSrLevelsViewModelBlock(
 ): SrLevelsViewModelBlock {
   const { freshnessLabel, isStale } = computeFreshness(block.capturedAtUnixMs, now);
 
-  // Group raw levels by identical metadata (rank + timeframe + notes)
-  type RawItem = (typeof block.supports)[number] & { kind: 'support' | 'resistance' };
-  const rawGroups = new Map<string, RawItem[]>();
-
-  const addItems = (kind: 'support' | 'resistance', items: typeof block.supports) => {
-    for (const item of items) {
-      const key = `${item.rank ?? ''}:${item.timeframe ?? ''}:${item.notes ?? ''}`;
-      const existing = rawGroups.get(key);
-      const itemWithKind = { ...item, kind };
-      if (existing) {
-        existing.push(itemWithKind);
-      } else {
-        rawGroups.set(key, [itemWithKind]);
-      }
-    }
+  // Collect all levels with parsed metadata
+  type LevelWithMeta = {
+    kind: 'support' | 'resistance';
+    price: number;
+    parsed: ReturnType<typeof parseNotes>;
   };
 
-  addItems('support', block.supports);
-  addItems('resistance', block.resistances);
+  const allLevels: LevelWithMeta[] = [];
+
+  for (const item of block.supports) {
+    allLevels.push({ kind: 'support', price: item.price, parsed: parseNotes(item.notes) });
+  }
+  for (const item of block.resistances) {
+    allLevels.push({ kind: 'resistance', price: item.price, parsed: parseNotes(item.notes) });
+  }
+
+  // Group by identical parsed metadata (trigger + invalidation + bias + source + timeframe + setupType)
+  const rawGroups = new Map<string, LevelWithMeta[]>();
+
+  for (const level of allLevels) {
+    const key = `${level.parsed.bias ?? ''}:${level.parsed.source ?? ''}:${level.parsed.timeframe ?? ''}:${level.parsed.setupType ?? ''}:${level.parsed.trigger ?? ''}:${level.parsed.invalidation ?? ''}`;
+    const existing = rawGroups.get(key);
+    if (existing) {
+      existing.push(level);
+    } else {
+      rawGroups.set(key, [level]);
+    }
+  }
 
   const groups: SrLevelGroupViewModel[] = [];
 
   for (const [, items] of rawGroups) {
     if (items.length === 0) continue;
     const first = items[0]!;
-    const parsed = parseNotes(first.notes);
 
     const levels = items.map((item) => ({
       kind: item.kind,
@@ -197,13 +205,13 @@ function toSrLevelsViewModelBlock(
 
     groups.push({
       levels,
-      note: parsed.remaining,
-      ...(parsed.source ? { source: parsed.source } : {}),
-      ...(parsed.timeframe ? { timeframe: parsed.timeframe } : {}),
-      ...(parsed.bias ? { bias: parsed.bias } : {}),
-      ...(parsed.setupType ? { setupType: parsed.setupType } : {}),
-      ...(parsed.trigger ? { trigger: parsed.trigger } : {}),
-      ...(parsed.invalidation ? { invalidation: parsed.invalidation } : {}),
+      note: '',
+      ...(first.parsed.source ? { source: first.parsed.source } : {}),
+      ...(first.parsed.timeframe ? { timeframe: first.parsed.timeframe } : {}),
+      ...(first.parsed.bias ? { bias: first.parsed.bias } : {}),
+      ...(first.parsed.setupType ? { setupType: first.parsed.setupType } : {}),
+      ...(first.parsed.trigger ? { trigger: first.parsed.trigger } : {}),
+      ...(first.parsed.invalidation ? { invalidation: first.parsed.invalidation } : {}),
     });
   }
 

--- a/packages/ui/src/view-models/PositionDetailViewModel.ts
+++ b/packages/ui/src/view-models/PositionDetailViewModel.ts
@@ -1,9 +1,15 @@
 import type { PositionDetailDto } from '@clmm/application/public';
 import { getRangeStatusBadgeProps } from '../components/RangeStatusBadgeUtils.js';
 
+export type SrLevelViewModel = {
+  kind: 'support' | 'resistance';
+  priceLabel: string;
+  note: string;
+  tone: 'safe' | 'warn' | 'breach';
+};
+
 export type SrLevelsViewModelBlock = {
-  supportsSorted: Array<{ priceLabel: string; rankLabel?: string }>;
-  resistancesSorted: Array<{ priceLabel: string; rankLabel?: string }>;
+  levels: SrLevelViewModel[];
   freshnessLabel: string;
   isStale: boolean;
 };
@@ -31,40 +37,92 @@ export type PositionDetailViewModel = {
   srLevels?: SrLevelsViewModelBlock;
 };
 
+const BOUND_EPSILON = 0.01;
+const PROXIMITY_THRESHOLD = 0.05; // 5%
+
+function isNearBound(price: number, bound: number): boolean {
+  return Math.abs(price - bound) <= BOUND_EPSILON;
+}
+
+function isWithinProximity(currentPrice: number, levelPrice: number): boolean {
+  if (levelPrice === 0) return false;
+  return Math.abs(currentPrice - levelPrice) / levelPrice <= PROXIMITY_THRESHOLD;
+}
+
+function computeLevelTone(
+  kind: 'support' | 'resistance',
+  levelPrice: number,
+  currentPrice: number,
+  lowerBound: number,
+  upperBound: number,
+): 'safe' | 'warn' | 'breach' {
+  if (kind === 'resistance') {
+    if (currentPrice > levelPrice) return 'breach';
+    if (isNearBound(levelPrice, upperBound)) return 'warn';
+    if (isWithinProximity(currentPrice, levelPrice)) return 'warn';
+    return 'safe';
+  }
+  // support
+  if (currentPrice < levelPrice) return 'breach';
+  if (isNearBound(levelPrice, lowerBound)) return 'warn';
+  if (isWithinProximity(currentPrice, levelPrice)) return 'warn';
+  return 'safe';
+}
+
+function computeLevelNote(
+  level: { price: number; rank?: string; notes?: string },
+  lowerBound: number,
+  upperBound: number,
+): string {
+  if (level.notes) return level.notes;
+  if (isNearBound(level.price, lowerBound)) return 'Range lower · your position';
+  if (isNearBound(level.price, upperBound)) return 'Range upper · your position';
+  if (level.rank) return level.rank;
+  return '';
+}
+
 function computeFreshness(capturedAtUnixMs: number, now: number): { freshnessLabel: string; isStale: boolean } {
   const ageMs = now - capturedAtUnixMs;
   if (ageMs < 3600000) {
     const minutes = Math.max(1, Math.round(ageMs / 60000));
-    return { freshnessLabel: `captured ${minutes}m ago`, isStale: false };
+    return { freshnessLabel: `AI · MCO · ${minutes}m ago`, isStale: false };
   }
   const hours = Math.round(ageMs / 3600000);
   if (ageMs < 172800000) {
-    return { freshnessLabel: `captured ${hours}h ago`, isStale: false };
+    return { freshnessLabel: `AI · MCO · ${hours}h ago`, isStale: false };
   }
-  return { freshnessLabel: `captured ${hours}h ago · stale`, isStale: true };
+  return { freshnessLabel: `AI · MCO · ${hours}h ago · stale`, isStale: true };
 }
 
 function toSrLevelsViewModelBlock(
   block: NonNullable<PositionDetailDto['srLevels']>,
+  currentPrice: number,
+  lowerBound: number,
+  upperBound: number,
   now: number,
 ): SrLevelsViewModelBlock {
   const { freshnessLabel, isStale } = computeFreshness(block.capturedAtUnixMs, now);
 
-  const supportsSorted = [...block.supports]
-    .sort((a, b) => a.price - b.price)
-    .map((s) => ({
-      priceLabel: `$${s.price.toFixed(2)}`,
-      ...(s.rank ? { rankLabel: s.rank } : {}),
-    }));
+  const supportLevels: SrLevelViewModel[] = block.supports.map((s) => ({
+    kind: 'support',
+    priceLabel: `$${s.price.toFixed(2)}`,
+    note: computeLevelNote(s, lowerBound, upperBound),
+    tone: computeLevelTone('support', s.price, currentPrice, lowerBound, upperBound),
+  }));
 
-  const resistancesSorted = [...block.resistances]
-    .sort((a, b) => a.price - b.price)
-    .map((r) => ({
-      priceLabel: `$${r.price.toFixed(2)}`,
-      ...(r.rank ? { rankLabel: r.rank } : {}),
-    }));
+  const resistanceLevels: SrLevelViewModel[] = block.resistances.map((r) => ({
+    kind: 'resistance',
+    priceLabel: `$${r.price.toFixed(2)}`,
+    note: computeLevelNote(r, lowerBound, upperBound),
+    tone: computeLevelTone('resistance', r.price, currentPrice, lowerBound, upperBound),
+  }));
 
-  return { supportsSorted, resistancesSorted, freshnessLabel, isStale };
+  // Sort all levels by price ascending
+  const levels = [...supportLevels, ...resistanceLevels].sort(
+    (a, b) => parseFloat(a.priceLabel.slice(1)) - parseFloat(b.priceLabel.slice(1)),
+  );
+
+  return { levels, freshnessLabel, isStale };
 }
 
 function formatTokenAmount(raw: string, decimals: number | null, symbol: string): string {
@@ -126,7 +184,7 @@ export function buildPositionDetailViewModel(dto: PositionDetailDto, now: number
   };
 
   const srLevelsVm = dto.srLevels
-    ? toSrLevelsViewModelBlock(dto.srLevels, now)
+    ? toSrLevelsViewModelBlock(dto.srLevels, dto.currentPrice, dto.lowerBound, dto.upperBound, now)
     : undefined;
 
   if (dto.breachDirection) {


### PR DESCRIPTION
Redesigns the Support & Resistance section on the Position Detail screen from a plain text list into a card-based layout with semantic cues.

**What changed:**
- **Unified level model:** `SrLevelsViewModelBlock` now outputs a single `levels` array where each item carries `kind` (support/resistance), `priceLabel`, contextual `note`, and semantic `tone`.
- **Tone computation:** Each level is tagged `safe`, `warn`, or `breach` based on the position's current price and range bounds. Breached levels, levels near a bound, and levels within 5% proximity all surface as `warn` or `breach`.
- **Note fallback hierarchy:** DTO notes are preferred, followed by auto-generated range-bound labels ("Range lower · your position"), then rank labels, then empty.
- **Freshness label:** Updated to "AI · MCO · Xm ago" with stale indicator after 48h.
- **Component extraction:** The ~90 lines of inline S/R JSX and styles were extracted into a new `SrLevelsCard` component; `PositionDetailScreen` now delegates rendering in a single line.
- **Sorting:** Supports and resistances are now intermixed and sorted ascending by raw numeric price before formatting.

**Test coverage:**
- 20 view-model tests covering tone logic, note fallback, freshness boundaries, and unified sorting
- 9 screen tests covering card rendering, chip labels, stale states, support-only, resistance-only, and empty-level scenarios

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)