### PR TITLE
fix: use ClockPort DI for InsightsDataController

### DIFF
--- a/packages/adapters/src/inbound/http/InsightsDataController.test.ts
+++ b/packages/adapters/src/inbound/http/InsightsDataController.test.ts
@@ -14,7 +14,7 @@ import {
   FIXTURE_USDC_PRICE_QUOTE,
 } from '@clmm/testing';
 import { makePoolId, makePositionId } from '@clmm/domain';
-import type { SrLevelsReadPort, SrLevelsBlock, SupportedPositionReadPort, TriggerRepository, PricePort } from '@clmm/application';
+import type { SrLevelsReadPort, SrLevelsBlock, SupportedPositionReadPort, TriggerRepository, PricePort, ClockPort } from '@clmm/application';
 import type { PositionDetail } from '@clmm/domain';
 
 const SOL_USDC_POOL_ID = 'Czfq3xZZDmsdGdUyrNLtRhGc47cXcZtLG4crryfu44zE';
@@ -54,7 +54,7 @@ const samplePort = (positions: ReturnType<typeof positionInPool>[]) =>
     getPoolData: async () => poolDataFor(SOL_USDC_POOL_ID),
   }) as unknown as SupportedPositionReadPort;
 
-const fixedClock = () => 1_700_000_000_000;
+const fixedClock: ClockPort = { now: () => 1_700_000_000_000 as any };
 
 function makeController(overrides?: {
   positions?: ReturnType<typeof positionInPool>[];

--- a/packages/adapters/src/inbound/http/InsightsDataController.test.ts
+++ b/packages/adapters/src/inbound/http/InsightsDataController.test.ts
@@ -13,7 +13,7 @@ import {
   FIXTURE_SOL_PRICE_QUOTE,
   FIXTURE_USDC_PRICE_QUOTE,
 } from '@clmm/testing';
-import { makePoolId, makePositionId } from '@clmm/domain';
+import { makePoolId, makePositionId, makeClockTimestamp } from '@clmm/domain';
 import type { SrLevelsReadPort, SrLevelsBlock, SupportedPositionReadPort, TriggerRepository, PricePort, ClockPort } from '@clmm/application';
 import type { PositionDetail } from '@clmm/domain';
 
@@ -54,7 +54,7 @@ const samplePort = (positions: ReturnType<typeof positionInPool>[]) =>
     getPoolData: async () => poolDataFor(SOL_USDC_POOL_ID),
   }) as unknown as SupportedPositionReadPort;
 
-const fixedClock: ClockPort = { now: () => 1_700_000_000_000 as any };
+const fixedClock: ClockPort = { now: () => makeClockTimestamp(1_700_000_000_000) };
 
 function makeController(overrides?: {
   positions?: ReturnType<typeof positionInPool>[];

--- a/packages/adapters/src/inbound/http/InsightsDataController.ts
+++ b/packages/adapters/src/inbound/http/InsightsDataController.ts
@@ -17,6 +17,7 @@ import type {
   TriggerRepository,
   PricePort,
   SrLevelsReadPort,
+  ClockPort,
   SolUsdcInsightErrorDto,
 } from '@clmm/application';
 import { makePoolId, makeWalletId } from '@clmm/domain';
@@ -26,6 +27,7 @@ import {
   PRICE_PORT,
   SR_LEVELS_READ_PORT,
   SR_LEVELS_POOL_ALLOWLIST,
+  CLOCK_PORT,
   // eslint-disable-next-line @typescript-eslint/no-unused-vars -- used via @Inject
   INSIGHTS_API_KEY,
 } from './tokens.js';
@@ -56,7 +58,8 @@ export class InsightsDataController {
     private readonly srLevelsReadPort: SrLevelsReadPort,
     @Inject(SR_LEVELS_POOL_ALLOWLIST)
     private readonly srLevelsAllowlist: SrLevelsAllowlist,
-    private readonly now: () => number = Date.now,
+    @Inject(CLOCK_PORT)
+    private readonly clock: ClockPort,
   ) {
     if (this.srLevelsAllowlist.size !== EXPECTED_ALLOWLIST_SIZE_V1) {
       throw new Error(
@@ -86,7 +89,7 @@ export class InsightsDataController {
     const result = await getSolUsdcInsightPoolSnapshot({
       poolId: makePoolId(this.poolIdRaw),
       positionReadPort: this.positionReadPort,
-      now: this.now,
+      now: this.clock.now,
     });
     if (result.kind === 'pool-unavailable') {
       throw this.poolUnavailable();
@@ -103,7 +106,7 @@ export class InsightsDataController {
       positionReadPort: this.positionReadPort,
       triggerRepo: this.triggerRepo,
       pricePort: this.pricePort,
-      now: this.now,
+      now: this.clock.now,
     });
     if (result.kind === 'pool-unavailable') {
       throw this.poolUnavailable();
@@ -128,7 +131,7 @@ export class InsightsDataController {
       triggerRepo: this.triggerRepo,
       pricePort: this.pricePort,
       srLevelsReadPort: this.srLevelsReadPort,
-      now: this.now,
+      now: this.clock.now,
     });
     if (result.kind === 'pool-unavailable') {
       throw this.poolUnavailable();

--- a/packages/adapters/src/inbound/http/InsightsDataController.ts
+++ b/packages/adapters/src/inbound/http/InsightsDataController.ts
@@ -89,7 +89,7 @@ export class InsightsDataController {
     const result = await getSolUsdcInsightPoolSnapshot({
       poolId: makePoolId(this.poolIdRaw),
       positionReadPort: this.positionReadPort,
-      now: this.clock.now,
+      now: () => this.clock.now(),
     });
     if (result.kind === 'pool-unavailable') {
       throw this.poolUnavailable();
@@ -106,7 +106,7 @@ export class InsightsDataController {
       positionReadPort: this.positionReadPort,
       triggerRepo: this.triggerRepo,
       pricePort: this.pricePort,
-      now: this.clock.now,
+      now: () => this.clock.now(),
     });
     if (result.kind === 'pool-unavailable') {
       throw this.poolUnavailable();
@@ -131,7 +131,7 @@ export class InsightsDataController {
       triggerRepo: this.triggerRepo,
       pricePort: this.pricePort,
       srLevelsReadPort: this.srLevelsReadPort,
-      now: this.clock.now,
+      now: () => this.clock.now(),
     });
     if (result.kind === 'pool-unavailable') {
       throw this.poolUnavailable();


### PR DESCRIPTION
## Summary

Fixes a Railway deploy crash caused by the `now: () => number` constructor parameter in `InsightsDataController` lacking an `@Inject()` decorator. NestJS cannot resolve bare function parameters through its DI container, causing the app to fail to start.

The fix replaces the bare function with `@Inject(CLOCK_PORT) private readonly clock: ClockPort`, matching the pattern used by `ExecutionController`, `PreviewController`, and `WalletController`.

## Changes

- `InsightsDataController.ts`: Replace `private readonly now: () => number = Date.now` with `@Inject(CLOCK_PORT) private readonly clock: ClockPort`
- `InsightsDataController.test.ts`: Change `fixedClock` from bare function to `ClockPort` object

## Verification

- `pnpm --filter @clmm/adapters typecheck` — PASS
- `pnpm --filter @clmm/adapters test -- InsightsDataController` — 15/15 PASS
- `pnpm --filter @clmm/adapters test` — 271/271 PASS
- `pnpm --filter @clmm/application test` — 137/137 PASS