### PR TITLE
fix(adapters): use sql.join() for IN clause in SchemaReadiness

### DIFF
--- a/docs/solutions/best-practices/schema-readiness-gate-deploy-ordering-2026-05-02.md
+++ b/docs/solutions/best-practices/schema-readiness-gate-deploy-ordering-2026-05-02.md
@@ -57,9 +57,17 @@ const expected = Object.values(schemaNamespace)
   .filter((value): value is PgTable => is(value, PgTable))
   .map((table) => getTableName(table));
 
-const rows = await db.execute(sql`
+if (expected.length === 0) return { ready: true };
+
+// IMPORTANT: Use sql.join() to produce IN ($1, $2, $3) with individual params.
+// Do NOT use IN (${expected}) or ANY(${expected}) — Drizzle's sql template
+// wraps JS arrays as row constructors ($1, $2, $3) producing IN (($1, $2, ...))
+// which PostgreSQL rejects as "operator does not exist: sql_identifier = record".
+const tableParams = expected.map((name) => sql`${name}`);
+const rows = await db.execute<{ table_name: string }>(sql`
   SELECT table_name FROM information_schema.tables
-  WHERE table_schema = current_schema() AND table_name = ANY(${expected})
+  WHERE table_schema = current_schema()
+    AND table_name IN (${sql.join(tableParams, sql`, `)})
 `);
 const present = new Set(rows.map((row) => row.table_name));
 const missing = expected.filter((t) => !present.has(t)).sort();

--- a/docs/solutions/database-issues/notification-events-migration-and-deliveredat-fix-2026-04-14.md
+++ b/docs/solutions/database-issues/notification-events-migration-and-deliveredat-fix-2026-04-14.md
@@ -36,7 +36,7 @@ PR #11 introduced a durable notification write path, but the database schema and
 - Recording delivery timing with `clock.now()` measured handler time, not provider delivery time.
 
 ## Solution
-- Add the missing migration and journal entry. The project later consolidated migrations into a single baseline (`0000_bitter_riptide`); the `notification_events` schema lives in `packages/adapters/src/outbound/storage/schema/notification-events.ts`.
+- Add the missing migration and journal entry. The project consolidated migrations into a baseline (`0000_bitter_riptide`), with a follow-up migration (`0001_fat_beyonder`) for `wallet_challenges`; the `notification_events` schema lives in `packages/adapters/src/outbound/storage/schema/notification-events.ts`.
   - `packages/adapters/drizzle/0000_bitter_riptide.sql` (consolidated baseline)
   - `packages/adapters/drizzle/meta/_journal.json`
 - Preserve the adapter's timestamp in `NotificationDispatchJobHandler`:

--- a/docs/solutions/integration-issues/connectorkit-wallet-probe-metro-package-exports-hydration-failure-2026-04-24.md
+++ b/docs/solutions/integration-issues/connectorkit-wallet-probe-metro-package-exports-hydration-failure-2026-04-24.md
@@ -99,7 +99,7 @@ config.resolver.resolveRequest = (context, moduleName, platform) => {
 };
 ```
 
-Then make the diagnostic route prove client hydration explicitly. In `apps/app/app/spike-wallet.web.tsx`, initialize environment fields as pending client state and populate them from `window` and `navigator` inside `useEffect`:
+Then make the diagnostic route prove client hydration explicitly. Initialize environment fields as pending client state and populate them from `window` and `navigator` inside `useEffect`:
 
 ```typescript
 const [environment, setEnvironment] = useState({
@@ -122,7 +122,7 @@ useEffect(() => {
 
 Include a `hydrated: true` field in the debug JSON so browser automation can distinguish a working client route from static export output.
 
-Keep the sibling `apps/app/app/spike-wallet.tsx` fallback route. Expo Router still needs a non-platform sibling for the `.web.tsx` route.
+The spike diagnostic route files (`spike-wallet.web.tsx` and `spike-wallet.tsx`) were removed after the real `BrowserWalletProvider` integration was completed. The production equivalents are `apps/app/src/platform/browserWallet/BrowserWalletProvider.web.tsx` and `apps/app/src/platform/browserWallet/connectorKitAdapter.web.ts`.
 
 ## Why This Works
 

--- a/packages/adapters/src/outbound/storage/SchemaReadiness.test.ts
+++ b/packages/adapters/src/outbound/storage/SchemaReadiness.test.ts
@@ -88,6 +88,28 @@ describe('checkSchemaReadiness', () => {
     expect(executeMock).toHaveBeenCalledTimes(1);
   });
 
+  it('produces IN with individual params, not a row constructor', async () => {
+    const executeMock = vi.fn(async () => [
+      { table_name: 'fixture_a' },
+      { table_name: 'fixture_b' },
+    ]);
+    const db = { execute: executeMock } as unknown as Db;
+    const namespace = { fixtureTableA, fixtureTableB };
+
+    await checkSchemaReadiness(db, namespace);
+
+    const callArgs = executeMock.mock.calls as unknown as [[unknown]];
+    const query = callArgs[0][0] as { toQuery: (config: unknown) => { sql: string; params: unknown[] } };
+    const built = query.toQuery({
+      escapeName: (s: string) => `"${s}"`,
+      escapeParam: (_: unknown, i: number) => `$${i + 1}`,
+      prepareTyping: () => [],
+      paramStartIndex: { value: 0 },
+    });
+    expect(built.sql).toContain('IN');
+    expect(built.sql).not.toMatch(/IN\s*\(\s*\(/);
+  });
+
   it('propagates database errors from execute', async () => {
     const db = {
       execute: vi.fn().mockRejectedValue(new Error('ECONNREFUSED')),

--- a/packages/adapters/src/outbound/storage/SchemaReadiness.ts
+++ b/packages/adapters/src/outbound/storage/SchemaReadiness.ts
@@ -16,11 +16,12 @@ export async function checkSchemaReadiness(
 
   if (expected.length === 0) return { ready: true };
 
+  const tableParams = expected.map((name) => sql`${name}`);
   const rows = await db.execute<{ table_name: string }>(sql`
     SELECT table_name
     FROM information_schema.tables
     WHERE table_schema = current_schema()
-      AND table_name IN (${expected})
+      AND table_name IN (${sql.join(tableParams, sql`, `)})
   `);
 
   const present = new Set(rows.map((row) => row.table_name));


### PR DESCRIPTION
## Summary

Fixes a production-breaking bug in `checkSchemaReadiness` where the SQL query used `IN (${expected})` with a Drizzle `sql` tagged template. Drizzle wraps JS arrays as row constructors `($1, $2, $3)`, producing invalid PostgreSQL: `IN (($1, $2, ...))` → `operator does not exist: information_schema.sql_identifier = record`.

Both the API `/health` and worker bootstrap gate were broken — any call to `checkSchemaReadiness` against a real PostgreSQL instance would fail with this error.

## Root Cause

Drizzle's `sql` tagged template handles JS arrays by wrapping them as `(param, param, ...)` — a PostgreSQL row/record constructor. This means:

- `IN (${expected})` → `IN (($1, $2, $3))` — compares `sql_identifier` to `record` → **PostgreSQL error**
- `ANY(${expected})` → `ANY($1, $2, $3)` — too many args to ANY → **also broken**

Neither form works. The correct approach is `sql.join()` which produces individual comma-separated params (`$1, $2, $3`) without outer parens, yielding valid SQL: `IN ($1, $2, $3)`.

## Fix

- `SchemaReadiness.ts:19-24`: Replace `IN (${expected})` with `IN (${sql.join(tableParams, sql\`, \`)})` where `tableParams = expected.map((name) => sql\`${name}\`)`
- `SchemaReadiness.test.ts`: Add test that inspects the built SQL query via `toQuery()` to assert it contains `IN` without the `IN ((` row-constructor pattern

## Verification

- 319 adapter tests pass (including new SQL structure test)
- Typecheck clean
- Lint: 0 errors (18 pre-existing warnings)

Fixes the production issue reported where both API health check and worker startup produced `operator does not exist: information_schema.sql_identifier = record`.

Refs: #58