### PR TITLE
Tighten positions-list UI contracts: typed MonitoringStatus + PositionCard item API

### DIFF
--- a/docs/solutions/best-practices/exhaustive-switch-runtime-guard-view-model-unions-2026-05-05.md
+++ b/docs/solutions/best-practices/exhaustive-switch-runtime-guard-view-model-unions-2026-05-05.md
@@ -1,0 +1,168 @@
+---
+title: Exhaustive switch with runtime fallback for typed unions in view models
+date: 2026-05-05
+category: best-practices
+module: packages/ui
+problem_type: best_practice
+component: development_workflow
+severity: medium
+applies_when:
+  - Mapping a closed union type to display values or behavior
+  - Building view model mappers that pass through string unions from DTOs
+  - Adding a typed union field to replace an untyped string field
+tags:
+  - clmm
+  - monitoring-status
+  - exhaustive-switch
+  - type-safety
+  - view-model
+  - runtime-guard
+  - barrel-export
+---
+
+# Exhaustive Switch with Runtime Fallback for Typed Unions in View Models
+
+## Context
+
+During issue #71, `monitoringStatus` was promoted from an untyped `string` label (`monitoringLabel`) to a typed union (`MonitoringStatus = 'active' | 'degraded' | 'inactive'`) on `PositionListItemViewModel`. The `getMonitoringDisplay` function used an exhaustive `switch` with no `default` case — TypeScript ensures all cases are handled at compile time, but at runtime an unexpected value (e.g., from a malformed DTO or `as any` cast) would fall through and return `undefined`, causing a crash at the call site (`monitoring.text` → `undefined.text`).
+
+Review also found that `buildPositionListViewModel` passed `p.monitoringStatus` through without runtime narrowing, trusting the DTO type. If the DTO type constraint was ever widened or bypassed, invalid values would silently enter the typed view model field.
+
+Additionally, the typed union and its display function were not exported from the barrel, preventing external consumers (tests, agents) from importing them without deep imports.
+
+## Guidance
+
+### 1. Add an exhaustiveness guard with a `never` default that throws
+
+An exhaustive `switch` over a closed union provides compile-time safety, ensuring new members trigger a type error until handled. But the `default` case should still exist as a runtime defense:
+
+```ts
+// WRONG — silently returns undefined for unexpected values
+export function getMonitoringDisplay(status: MonitoringStatus): MonitoringDisplay {
+  switch (status) {
+    case 'active':
+      return { text: 'Live', tone: 'safe' };
+    case 'degraded':
+      return { text: 'Degraded', tone: 'warn' };
+    case 'inactive':
+      return { text: 'Inactive', tone: 'faint' };
+  }
+}
+
+// CORRECT — compile-time exhaustiveness + runtime defense
+export function getMonitoringDisplay(status: MonitoringStatus): MonitoringDisplay {
+  switch (status) {
+    case 'active':
+      return { text: 'Live', tone: 'safe' };
+    case 'degraded':
+      return { text: 'Degraded', tone: 'warn' };
+    case 'inactive':
+      return { text: 'Inactive', tone: 'faint' };
+    default: {
+      const _exhaustive: never = status;
+      throw new Error(`Unexpected monitoringStatus: ${String(_exhaustive)}`);
+    }
+  }
+}
+```
+
+The `const _exhaustive: never = status` assignment preserves compile-time exhaustiveness checking (TypeScript errors if any union member is unhandled) while adding a runtime throw for values that bypass the type system.
+
+### 2. Validate union values at view-model construction boundaries
+
+When a DTO field flows into a typed view model field, add runtime narrowing at the boundary:
+
+```ts
+const VALID_MONITORING_STATUSES: ReadonlySet<string> = new Set<string>([
+  'active',
+  'degraded',
+  'inactive',
+]);
+
+export function asMonitoringStatus(value: string): MonitoringStatus {
+  if (!VALID_MONITORING_STATUSES.has(value)) {
+    throw new Error(`Invalid monitoringStatus: ${value}`);
+  }
+  return value as MonitoringStatus;
+}
+
+export function buildPositionListViewModel(positions: PositionSummaryDto[]): PositionListViewModel {
+  const items = positions.map((p) => ({
+    // ...
+    monitoringStatus: asMonitoringStatus(p.monitoringStatus),
+    // ...
+  }));
+  // ...
+}
+```
+
+This catches invalid values at the point of entry rather than at the point of use, producing a clear error message instead of a cryptic crash deep in a rendering function.
+
+### 3. Export typed unions and display functions from the barrel
+
+Types and functions that external consumers need (tests, agents, screen composition) must be barrel-exported. Without this, consumers deep-import from internal paths, coupling to file layout:
+
+```ts
+// packages/ui/src/index.ts
+export type { MonitoringStatus } from './view-models/PositionListViewModel.js';
+export { asMonitoringStatus } from './view-models/PositionListViewModel.js';
+export { getMonitoringDisplay } from './components/PositionCardUtils.js';
+export type { MonitoringDisplay, MonitoringTone } from './components/PositionCardUtils.js';
+```
+
+## Why This Matters
+
+- **Silent `undefined` from exhaustive switches** is a common TypeScript pitfall. The compiler says "all cases handled" but runtime `as any` or malformed data silently falls through.
+- **DTO-to-view-model pass-through** without narrowing relies on the DTO type always matching. If the backend adds a status before the DTO type is updated, the view model silently accepts an invalid value.
+- **Missing barrel exports** force consumers to deep-import, making refactoring harder and preventing agents from discovering available types.
+
+## When to Apply
+
+- When adding a typed union field to a view model that replaces an untyped string
+- When writing an exhaustive `switch` over a closed union that maps to display or behavior
+- When a DTO field flows directly into a typed view model field
+- When types or functions are needed outside their defining module
+
+## Examples
+
+**Before (silent undefined on unexpected value):**
+
+```ts
+export function getMonitoringDisplay(status: MonitoringStatus): MonitoringDisplay {
+  switch (status) {
+    case 'active':
+      return { text: 'Live', tone: 'safe' };
+    case 'degraded':
+      return { text: 'Degraded', tone: 'warn' };
+    case 'inactive':
+      return { text: 'Inactive', tone: 'faint' };
+  }
+}
+// getMonitoringDisplay('unknown' as never) → undefined (crashes at .text)
+```
+
+**After (compile-time exhaustive + runtime throw):**
+
+```ts
+export function getMonitoringDisplay(status: MonitoringStatus): MonitoringDisplay {
+  switch (status) {
+    case 'active':
+      return { text: 'Live', tone: 'safe' };
+    case 'degraded':
+      return { text: 'Degraded', tone: 'warn' };
+    case 'inactive':
+      return { text: 'Inactive', tone: 'faint' };
+    default: {
+      const _exhaustive: never = status;
+      throw new Error(`Unexpected monitoringStatus: ${String(_exhaustive)}`);
+    }
+  }
+}
+// getMonitoringDisplay('unknown' as never) → throws with clear message
+```
+
+## Related
+
+- `docs/solutions/best-practices/ui-component-review-patterns-2026-05-05.md` — review patterns from the same UI module (isNearEdge guard, dead field removal, a11y)
+- `docs/solutions/best-practices/enriching-dtos-across-layers-2026-04-25.md` — DTO enrichment pipeline feeding PositionCardUtils
+- GitHub #71 — View-model contract: typed monitoring status + PositionCard `{ item, onPress }` API

--- a/docs/superpowers/plans/2026-05-05-view-model-contract-improvements.md
+++ b/docs/superpowers/plans/2026-05-05-view-model-contract-improvements.md
@@ -1,0 +1,791 @@
+# View-Model Contract Improvements Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Tighten two positions-list UI contracts so monitoring state flows through as a typed `MonitoringStatus` union, and `PositionCard` accepts a single `item` view model instead of a long list of individual props.
+
+**Architecture:** All changes stay inside `packages/ui`. `PositionListViewModel.ts` exports a new `MonitoringStatus = 'active' | 'degraded' | 'inactive'` union and exposes `monitoringStatus` (typed) on `PositionListItemViewModel`, copying it directly from `PositionSummaryDto.monitoringStatus`. `PositionCardUtils.getMonitoringDisplay` is rewritten to accept `MonitoringStatus` with an exhaustive `switch`. `PositionCard` swaps individual field props for `{ item, onPress }`. `PositionsListScreen` passes `item={item}` instead of forwarding each field. The legacy `monitoringLabel` view-model field and the in-file `monitoringLabel(status)` helper are deleted once nothing references them.
+
+**Tech Stack:** TypeScript, React + React Native, pnpm workspaces, Vitest, Turbo (`pnpm typecheck`, `pnpm test`), `dependency-cruiser` (`pnpm boundaries`).
+
+---
+
+## File Structure
+
+| File                                                        | Responsibility                                                            | Action                                                                                                                                                                     |
+| ----------------------------------------------------------- | ------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `packages/ui/src/view-models/PositionListViewModel.ts`      | List view model + `MonitoringStatus` union, builder maps DTO → view model | Modify: export `MonitoringStatus`; add `monitoringStatus` field; copy from DTO; remove `monitoringLabel` field and `monitoringLabel(status)` helper after callers migrated |
+| `packages/ui/src/view-models/PositionListViewModel.test.ts` | View-model unit tests                                                     | Modify: assert `monitoringStatus` is copied for `active`/`degraded`/`inactive`                                                                                             |
+| `packages/ui/src/components/PositionCardUtils.ts`           | Pure helpers used by the card, including `getMonitoringDisplay`           | Modify: change `getMonitoringDisplay` signature to take `MonitoringStatus` (imported via `import type`), use exhaustive `switch`                                           |
+| `packages/ui/src/components/PositionCardUtils.test.ts`      | Unit tests for the helpers                                                | Modify: rewrite the `getMonitoringDisplay` tests to call with typed statuses                                                                                               |
+| `packages/ui/src/components/PositionCard.tsx`               | The card component                                                        | Modify: import `PositionListItemViewModel` via `import type`; replace individual props with `{ item, onPress }`; destructure `item` internally                             |
+| `packages/ui/src/screens/PositionsListScreen.tsx`           | Owns `FlatList` rendering of position cards                               | Modify: render `<PositionCard item={item} onPress={...} />` instead of forwarding individual fields                                                                        |
+| `packages/ui/src/screens/PositionsListScreen.test.tsx`      | Screen integration tests                                                  | No changes expected; existing assertions (`Live`, `Degraded`, `Inactive`, chip labels, `onSelectPosition`) must keep passing — only update if a fixture stops typechecking |
+
+The contract change is small enough that no new files are needed. The `MonitoringStatus` union lives next to `PositionListItemViewModel` because the view model is its primary source; the card helper consumes it via `import type`.
+
+`PositionCardUtils.ts` already lives in `packages/ui/src/components/`; importing the view-model type from `../view-models/PositionListViewModel.js` is the same direction as `PositionCard.tsx`'s existing import path. `pnpm boundaries` checks cross-package boundaries (e.g., adapters → application), not intra-package paths, so this import is safe — but Task 11 still runs it as part of final verification.
+
+---
+
+## Pre-flight
+
+### Task 0: Confirm baseline is green
+
+**Files:** none
+
+- [ ] **Step 1: Install dependencies (idempotent)**
+
+Run: `pnpm install --frozen-lockfile`
+Expected: completes without modifying the lockfile.
+
+- [ ] **Step 2: Confirm typecheck passes on the unchanged branch**
+
+Run: `pnpm typecheck`
+Expected: PASS for all packages.
+
+- [ ] **Step 3: Confirm tests pass on the unchanged branch**
+
+Run: `pnpm --filter @clmm/ui test`
+Expected: PASS. This is the only package this plan touches; the wider `pnpm test` is run during final verification.
+
+If any of the above fail, stop and resolve before continuing — the plan assumes a green baseline.
+
+---
+
+## Phase 1 — Typed monitoring on the view model
+
+### Task 1: Add a failing test that `buildPositionListViewModel` exposes typed `monitoringStatus`
+
+**Files:**
+
+- Modify: `packages/ui/src/view-models/PositionListViewModel.test.ts`
+
+- [ ] **Step 1: Append a new `describe` block to the test file**
+
+Open `packages/ui/src/view-models/PositionListViewModel.test.ts` and append the following block at the end of the file (after the existing `describe('buildPositionListViewModel', ...)` block, still at top level):
+
+```ts
+describe('buildPositionListViewModel monitoringStatus mapping', () => {
+  it('copies active monitoring status through as a typed value', () => {
+    const vm = buildPositionListViewModel([makeSummaryDto({ monitoringStatus: 'active' })]);
+    expect(vm.items[0]!.monitoringStatus).toBe('active');
+  });
+
+  it('copies degraded monitoring status through as a typed value', () => {
+    const vm = buildPositionListViewModel([makeSummaryDto({ monitoringStatus: 'degraded' })]);
+    expect(vm.items[0]!.monitoringStatus).toBe('degraded');
+  });
+
+  it('copies inactive monitoring status through as a typed value', () => {
+    const vm = buildPositionListViewModel([makeSummaryDto({ monitoringStatus: 'inactive' })]);
+    expect(vm.items[0]!.monitoringStatus).toBe('inactive');
+  });
+});
+```
+
+- [ ] **Step 2: Run the new tests and verify they fail**
+
+Run: `pnpm --filter @clmm/ui test -- PositionListViewModel`
+Expected: the three new specs FAIL — TypeScript will report `Property 'monitoringStatus' does not exist on type 'PositionListItemViewModel'`, or, if compilation proceeds, the assertions read `undefined`.
+
+If the rest of the file's tests fail for unrelated reasons, stop and investigate.
+
+- [ ] **Step 3: Commit the failing test**
+
+```bash
+git add packages/ui/src/view-models/PositionListViewModel.test.ts
+git commit -m "test(ui): add failing assertions for typed monitoringStatus on list view model"
+```
+
+---
+
+### Task 2: Add `MonitoringStatus` and `monitoringStatus` to the view model
+
+**Files:**
+
+- Modify: `packages/ui/src/view-models/PositionListViewModel.ts`
+
+- [ ] **Step 1: Add the union type and field, and pass `monitoringStatus` through in the mapping**
+
+Open `packages/ui/src/view-models/PositionListViewModel.ts` and replace the entire file with:
+
+```ts
+import type { PositionSummaryDto } from '@clmm/application/public';
+
+export type MonitoringStatus = 'active' | 'degraded' | 'inactive';
+
+export type PositionListItemViewModel = {
+  positionId: string;
+  poolId: string;
+  poolLabel: string;
+  currentPrice: number;
+  currentPriceLabel: string;
+  rangeStatusKind: 'in-range' | 'below-range' | 'above-range';
+  hasAlert: boolean;
+  monitoringStatus: MonitoringStatus;
+  monitoringLabel: string;
+  lowerBoundPrice: number;
+  upperBoundPrice: number;
+  lowerBoundLabel: string;
+  upperBoundLabel: string;
+};
+
+export type PositionListViewModel = {
+  items: PositionListItemViewModel[];
+  isEmpty: boolean;
+};
+
+function monitoringLabel(status: string): string {
+  switch (status) {
+    case 'active':
+      return 'Monitoring Active';
+    case 'degraded':
+      return 'Monitoring Degraded';
+    case 'inactive':
+      return 'Monitoring Inactive';
+    default:
+      return 'Unknown';
+  }
+}
+
+export function buildPositionListViewModel(positions: PositionSummaryDto[]): PositionListViewModel {
+  const items: PositionListItemViewModel[] = positions.map((p) => ({
+    positionId: p.positionId,
+    poolId: p.poolId,
+    poolLabel: p.tokenPairLabel,
+    currentPrice: p.currentPrice,
+    currentPriceLabel: p.currentPriceLabel ?? `Current: ${p.currentPrice}`,
+    rangeStatusKind: p.rangeState,
+    hasAlert: p.hasActionableTrigger,
+    monitoringStatus: p.monitoringStatus,
+    monitoringLabel: monitoringLabel(p.monitoringStatus),
+    lowerBoundPrice: p.lowerBoundPrice,
+    upperBoundPrice: p.upperBoundPrice,
+    lowerBoundLabel: p.lowerBoundLabel,
+    upperBoundLabel: p.upperBoundLabel,
+  }));
+
+  return { items, isEmpty: items.length === 0 };
+}
+```
+
+Note: this intermediate state keeps `monitoringLabel` on the view model so existing card callers continue to typecheck. The legacy field and helper are deleted in Task 8 once `PositionCard` no longer reads them.
+
+`p.monitoringStatus` is already typed `'active' | 'degraded' | 'inactive'` by `PositionSummaryDto` (see `packages/application/src/dto/index.ts:53`), so the assignment to `monitoringStatus: MonitoringStatus` typechecks without a cast.
+
+- [ ] **Step 2: Run the view-model tests and verify they pass**
+
+Run: `pnpm --filter @clmm/ui test -- PositionListViewModel`
+Expected: PASS, including the three new monitoring specs.
+
+- [ ] **Step 3: Run typecheck**
+
+Run: `pnpm --filter @clmm/ui typecheck`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/ui/src/view-models/PositionListViewModel.ts
+git commit -m "feat(ui): expose typed monitoringStatus on PositionListItemViewModel"
+```
+
+---
+
+## Phase 2 — Typed `getMonitoringDisplay`
+
+### Task 3: Add failing tests that `getMonitoringDisplay` accepts `MonitoringStatus`
+
+**Files:**
+
+- Modify: `packages/ui/src/components/PositionCardUtils.test.ts`
+
+- [ ] **Step 1: Replace the existing `describe('getMonitoringDisplay', ...)` block**
+
+Open `packages/ui/src/components/PositionCardUtils.test.ts`. Find this exact block (currently at lines 180–202):
+
+```ts
+describe('getMonitoringDisplay', () => {
+  it('maps the active label to Live with the safe tone color', () => {
+    const r = getMonitoringDisplay('Monitoring Active');
+    expect(r.text).toBe('Live');
+    expect(r.tone).toBe('safe');
+  });
+
+  it('maps the degraded label to Degraded with the warn tone color', () => {
+    const r = getMonitoringDisplay('Monitoring Degraded');
+    expect(r.text).toBe('Degraded');
+    expect(r.tone).toBe('warn');
+  });
+
+  it('falls back to Inactive with a faint tone for any other input', () => {
+    const r = getMonitoringDisplay('Monitoring Inactive');
+    expect(r.text).toBe('Inactive');
+    expect(r.tone).toBe('faint');
+
+    const u = getMonitoringDisplay('totally unknown');
+    expect(u.text).toBe('Inactive');
+    expect(u.tone).toBe('faint');
+  });
+});
+```
+
+Replace it with:
+
+```ts
+describe('getMonitoringDisplay', () => {
+  it('maps active to Live with the safe tone', () => {
+    const r = getMonitoringDisplay('active');
+    expect(r.text).toBe('Live');
+    expect(r.tone).toBe('safe');
+  });
+
+  it('maps degraded to Degraded with the warn tone', () => {
+    const r = getMonitoringDisplay('degraded');
+    expect(r.text).toBe('Degraded');
+    expect(r.tone).toBe('warn');
+  });
+
+  it('maps inactive to Inactive with the faint tone', () => {
+    const r = getMonitoringDisplay('inactive');
+    expect(r.text).toBe('Inactive');
+    expect(r.tone).toBe('faint');
+  });
+});
+```
+
+The "totally unknown" fallback test is intentionally removed: `getMonitoringDisplay` now consumes a closed union, so an unknown string is a TypeScript error rather than a runtime branch.
+
+- [ ] **Step 2: Run the helper tests and verify they fail**
+
+Run: `pnpm --filter @clmm/ui test -- PositionCardUtils`
+Expected: the three rewritten specs FAIL. The existing implementation compares against the literal strings `'Monitoring Active'` / `'Monitoring Degraded'` and falls through to `Inactive` for anything else, so:
+
+- `getMonitoringDisplay('active')` returns `{ text: 'Inactive', tone: 'faint' }` — test expects `Live`/`safe`.
+- `getMonitoringDisplay('degraded')` returns `{ text: 'Inactive', tone: 'faint' }` — test expects `Degraded`/`warn`.
+- `getMonitoringDisplay('inactive')` returns `{ text: 'Inactive', tone: 'faint' }` — passes today by coincidence; will still pass after the implementation change.
+
+If only the third test passes, that matches expectations. Other tests in the file must remain green.
+
+- [ ] **Step 3: Commit the failing tests**
+
+```bash
+git add packages/ui/src/components/PositionCardUtils.test.ts
+git commit -m "test(ui): drive getMonitoringDisplay toward typed MonitoringStatus input"
+```
+
+---
+
+### Task 4: Rewrite `getMonitoringDisplay` to accept `MonitoringStatus`
+
+**Files:**
+
+- Modify: `packages/ui/src/components/PositionCardUtils.ts`
+
+- [ ] **Step 1: Add the type import at the top of the file**
+
+Open `packages/ui/src/components/PositionCardUtils.ts`. The file currently has no imports. Add this as the very first line:
+
+```ts
+import type { MonitoringStatus } from '../view-models/PositionListViewModel.js';
+```
+
+- [ ] **Step 2: Replace the `getMonitoringDisplay` function body**
+
+Find this exact block (currently lines 80–84):
+
+```ts
+export function getMonitoringDisplay(monitoringLabel: string): MonitoringDisplay {
+  if (monitoringLabel === 'Monitoring Active') return { text: 'Live', tone: 'safe' };
+  if (monitoringLabel === 'Monitoring Degraded') return { text: 'Degraded', tone: 'warn' };
+  return { text: 'Inactive', tone: 'faint' };
+}
+```
+
+Replace it with:
+
+```ts
+export function getMonitoringDisplay(status: MonitoringStatus): MonitoringDisplay {
+  switch (status) {
+    case 'active':
+      return { text: 'Live', tone: 'safe' };
+    case 'degraded':
+      return { text: 'Degraded', tone: 'warn' };
+    case 'inactive':
+      return { text: 'Inactive', tone: 'faint' };
+  }
+}
+```
+
+The `switch` is exhaustive over the closed union, so TypeScript will allow the function to return `MonitoringDisplay` without a fallback. If a future change adds a new status to the union, this function will fail to compile — that is the desired failure mode (per the spec's Error Handling section).
+
+- [ ] **Step 3: Run the helper tests and verify they pass**
+
+Run: `pnpm --filter @clmm/ui test -- PositionCardUtils`
+Expected: PASS for all `getMonitoringDisplay` specs and unchanged for the rest of the file.
+
+- [ ] **Step 4: Run typecheck**
+
+Run: `pnpm --filter @clmm/ui typecheck`
+Expected: a NEW error in `packages/ui/src/components/PositionCard.tsx` — `Argument of type 'string' is not assignable to parameter of type 'MonitoringStatus'` at the `getMonitoringDisplay(monitoringLabel)` call site (currently line 55). This is expected and will be fixed in Task 6.
+
+Do not commit yet — the next phase fixes the card to make typecheck green.
+
+---
+
+## Phase 3 — `PositionCard` accepts the view-model item
+
+### Task 5: Update the card component to take `{ item, onPress }`
+
+**Files:**
+
+- Modify: `packages/ui/src/components/PositionCard.tsx`
+
+- [ ] **Step 1: Replace the entire file**
+
+Open `packages/ui/src/components/PositionCard.tsx` and replace the whole file with:
+
+```tsx
+import { View, Text, TouchableOpacity } from 'react-native';
+import type { PositionListItemViewModel } from '../view-models/PositionListViewModel.js';
+import { colors, typography } from '../design-system/index.js';
+import { Chip } from './Chip.js';
+import { PairGlyph } from './PairGlyph.js';
+import { RangeBar } from './RangeBar.js';
+import {
+  formatPoolId,
+  getBreachSide,
+  getCardPlaceholderMetrics,
+  getMonitoringDisplay,
+  getStatusChipProps,
+  isNearEdge,
+  splitTokenPair,
+} from './PositionCardUtils.js';
+
+type Props = {
+  item: PositionListItemViewModel;
+  onPress?: () => void;
+};
+
+function monitoringDotColor(tone: 'safe' | 'warn' | 'faint'): string {
+  if (tone === 'safe') return colors.safe;
+  if (tone === 'warn') return colors.warn;
+  return colors.textFaint;
+}
+
+export function PositionCard({ item, onPress }: Props): JSX.Element {
+  const {
+    poolId,
+    poolLabel,
+    currentPrice,
+    currentPriceLabel,
+    lowerBoundPrice,
+    upperBoundPrice,
+    lowerBoundLabel,
+    upperBoundLabel,
+    rangeStatusKind,
+    hasAlert,
+    monitoringStatus,
+  } = item;
+
+  const tokens = splitTokenPair(poolLabel);
+  const truncatedPoolId = formatPoolId(poolId);
+  const nearEdge = isNearEdge({ currentPrice, lowerBoundPrice, upperBoundPrice });
+  const chip = getStatusChipProps({ rangeStatusKind, hasAlert, nearEdge });
+  const monitoring = getMonitoringDisplay(monitoringStatus);
+  const placeholders = getCardPlaceholderMetrics(poolId);
+
+  const breachSide = getBreachSide(hasAlert, rangeStatusKind);
+
+  return (
+    <TouchableOpacity
+      testID={`position-card-${poolId}`}
+      accessibilityRole="button"
+      accessibilityLabel={`Position card for ${poolLabel}, ${chip.label}`}
+      onPress={onPress}
+      activeOpacity={0.8}
+      style={{
+        backgroundColor: colors.card,
+        borderWidth: 1,
+        borderColor: colors.border,
+        borderRadius: 12,
+        padding: 16,
+        marginBottom: 10,
+        marginHorizontal: 20,
+      }}
+    >
+      {/* Top row: pair glyph + label + pool id, chip on the right */}
+      <View
+        style={{
+          flexDirection: 'row',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          marginBottom: 14,
+        }}
+      >
+        <View style={{ flexDirection: 'row', alignItems: 'center', gap: 12 }}>
+          <PairGlyph a={tokens.a} b={tokens.b} size={30} />
+          <View>
+            <Text
+              style={{
+                fontWeight: typography.fontWeight.semibold,
+                fontSize: typography.fontSize.md,
+                color: colors.textPrimary,
+                letterSpacing: -0.01 * typography.fontSize.md,
+              }}
+            >
+              {poolLabel}
+            </Text>
+            <Text
+              style={{
+                fontFamily: typography.fontFamily.mono,
+                fontSize: 11,
+                color: colors.textTertiary,
+              }}
+            >
+              {truncatedPoolId}
+            </Text>
+          </View>
+        </View>
+        <Chip tone={chip.tone}>{chip.label}</Chip>
+      </View>
+
+      {/* Range bar */}
+      <RangeBar
+        lowerBoundPrice={lowerBoundPrice}
+        upperBoundPrice={upperBoundPrice}
+        currentPrice={currentPrice}
+        lowerBoundLabel={lowerBoundLabel}
+        upperBoundLabel={upperBoundLabel}
+        currentPriceLabel={currentPriceLabel}
+        {...(breachSide ? { breachSide } : {})}
+      />
+
+      {/* Bottom row: TVL · Fees 24h · Monitor */}
+      <View
+        style={{
+          flexDirection: 'row',
+          marginTop: 4,
+        }}
+      >
+        <View style={{ flex: 1 }}>
+          <Text
+            style={{
+              fontSize: 10,
+              textTransform: 'uppercase',
+              letterSpacing: 0.08,
+              color: colors.textTertiary,
+              fontWeight: typography.fontWeight.semibold,
+            }}
+          >
+            TVL
+          </Text>
+          <Text
+            style={{
+              fontFamily: typography.fontFamily.mono,
+              fontSize: 14,
+              marginTop: 2,
+              color: colors.textPrimary,
+            }}
+          >
+            {placeholders.tvlLabel}
+          </Text>
+        </View>
+        <View style={{ flex: 1 }}>
+          <Text
+            style={{
+              fontSize: 10,
+              textTransform: 'uppercase',
+              letterSpacing: 0.08,
+              color: colors.textTertiary,
+              fontWeight: typography.fontWeight.semibold,
+            }}
+          >
+            Fees 24h
+          </Text>
+          <Text
+            style={{
+              fontFamily: typography.fontFamily.mono,
+              fontSize: 14,
+              marginTop: 2,
+              color: colors.safe,
+            }}
+          >
+            {placeholders.fees24hLabel}
+          </Text>
+        </View>
+        <View style={{ flex: 1, alignItems: 'flex-end' }}>
+          <Text
+            style={{
+              fontSize: 10,
+              textTransform: 'uppercase',
+              letterSpacing: 0.08,
+              color: colors.textTertiary,
+              fontWeight: typography.fontWeight.semibold,
+            }}
+          >
+            Monitor
+          </Text>
+          <View style={{ flexDirection: 'row', alignItems: 'center', marginTop: 3 }}>
+            <View
+              style={{
+                width: 6,
+                height: 6,
+                borderRadius: 999,
+                backgroundColor: monitoringDotColor(monitoring.tone),
+                marginRight: 5,
+              }}
+            />
+            <Text
+              style={{
+                fontSize: typography.fontSize.caption,
+                color: colors.textBody,
+              }}
+            >
+              {monitoring.text}
+            </Text>
+          </View>
+        </View>
+      </View>
+    </TouchableOpacity>
+  );
+}
+```
+
+The visual JSX is identical to the previous version — only the props API and the destructuring changed. `monitoringStatus` (typed `MonitoringStatus`) flows directly into `getMonitoringDisplay`, which now accepts that union. `monitoringLabel` is no longer read by this file.
+
+- [ ] **Step 2: Do not run typecheck yet**
+
+After this step `PositionCard.tsx` is internally consistent, but `PositionsListScreen.tsx` still passes the old props (`poolId={item.poolId}`, ..., `monitoringLabel={item.monitoringLabel}`), which will produce a wall of TypeScript errors at the call site. Continue to Task 6 first, then run typecheck.
+
+---
+
+### Task 6: Update `PositionsListScreen` to pass `item={item}`
+
+**Files:**
+
+- Modify: `packages/ui/src/screens/PositionsListScreen.tsx`
+
+- [ ] **Step 1: Replace the `renderItem` block**
+
+Open `packages/ui/src/screens/PositionsListScreen.tsx`. Find this exact block (currently lines 237–252, inside the `FlatList`):
+
+```tsx
+      renderItem={({ item }) => (
+        <PositionCard
+          poolId={item.poolId}
+          poolLabel={item.poolLabel}
+          currentPrice={item.currentPrice}
+          currentPriceLabel={item.currentPriceLabel}
+          lowerBoundPrice={item.lowerBoundPrice}
+          upperBoundPrice={item.upperBoundPrice}
+          lowerBoundLabel={item.lowerBoundLabel}
+          upperBoundLabel={item.upperBoundLabel}
+          rangeStatusKind={item.rangeStatusKind}
+          hasAlert={item.hasAlert}
+          monitoringLabel={item.monitoringLabel}
+          onPress={() => onSelectPosition?.(item.positionId)}
+        />
+      )}
+```
+
+Replace it with:
+
+```tsx
+      renderItem={({ item }) => (
+        <PositionCard
+          item={item}
+          onPress={() => onSelectPosition?.(item.positionId)}
+        />
+      )}
+```
+
+No other lines in this file change.
+
+- [ ] **Step 2: Run typecheck**
+
+Run: `pnpm --filter @clmm/ui typecheck`
+Expected: PASS. The errors introduced in Task 4 and Task 5 are now resolved because the screen passes a `PositionListItemViewModel` whose `monitoringStatus` is a typed `MonitoringStatus`.
+
+- [ ] **Step 3: Run the UI tests**
+
+Run: `pnpm --filter @clmm/ui test`
+Expected: PASS for the whole `@clmm/ui` package. In particular:
+
+- `PositionListViewModel.test.ts` (Phase 1 specs).
+- `PositionCardUtils.test.ts` (Phase 2 specs).
+- `PositionsListScreen.test.tsx` — assertions for `Live` / `Degraded` / `Inactive`, the six chip labels, `onSelectPosition('pos-tap-test')`, and `RangeBar` labels must all keep passing because the rendered output is unchanged.
+
+If a `PositionsListScreen.test.tsx` spec fails, do **not** mass-rewrite the test file. Read the failure: it should be either a fixture missing a typed `monitoringStatus` (already typed as `'active'`/`'degraded'`/`'inactive'` in the fixture, so this should not happen) or a behavioral assertion that legitimately broke (which means the card's visible output drifted — investigate the card change rather than rewriting the test).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/ui/src/components/PositionCardUtils.ts \
+        packages/ui/src/components/PositionCard.tsx \
+        packages/ui/src/screens/PositionsListScreen.tsx
+git commit -m "refactor(ui): PositionCard accepts list item view model and typed monitoring status"
+```
+
+This single commit groups the three coupled changes: helper signature, card prop API, screen call site. Splitting them would leave the tree uncompilable between commits (Task 5 alone leaves the screen broken; Task 6 alone leaves the helper unused).
+
+---
+
+## Phase 4 — Remove the now-unused legacy field
+
+### Task 7: Confirm no consumer reads `monitoringLabel`
+
+**Files:** none
+
+- [ ] **Step 1: Grep across `packages/` and `apps/`**
+
+Run:
+
+```bash
+grep -rn "monitoringLabel" packages/ apps/ --include='*.ts' --include='*.tsx' \
+  | grep -v '/dist/' \
+  | grep -v 'apps/app/dist/'
+```
+
+Expected output (only the soon-to-be-removed declarations and helper inside `PositionListViewModel.ts`):
+
+```
+packages/ui/src/view-models/PositionListViewModel.ts:11:  monitoringLabel: string;
+packages/ui/src/view-models/PositionListViewModel.ts:23:function monitoringLabel(status: string): string {
+packages/ui/src/view-models/PositionListViewModel.ts:45:    monitoringLabel: monitoringLabel(p.monitoringStatus),
+```
+
+If any other source file (anything not under `dist/`) reads `monitoringLabel`, stop and migrate that consumer before continuing. Common places to double-check by hand: the `apps/app` screen wiring and any `*.test.tsx` fixture in the UI package. As of this plan, `PositionsListScreen.test.tsx` constructs `PositionSummaryDto` fixtures (which carry `monitoringStatus`, not `monitoringLabel`), so it does not need changes.
+
+---
+
+### Task 8: Delete `monitoringLabel` from the view model
+
+**Files:**
+
+- Modify: `packages/ui/src/view-models/PositionListViewModel.ts`
+
+- [ ] **Step 1: Remove the field, the helper function, and the mapping line**
+
+Open `packages/ui/src/view-models/PositionListViewModel.ts` and replace the whole file with:
+
+```ts
+import type { PositionSummaryDto } from '@clmm/application/public';
+
+export type MonitoringStatus = 'active' | 'degraded' | 'inactive';
+
+export type PositionListItemViewModel = {
+  positionId: string;
+  poolId: string;
+  poolLabel: string;
+  currentPrice: number;
+  currentPriceLabel: string;
+  rangeStatusKind: 'in-range' | 'below-range' | 'above-range';
+  hasAlert: boolean;
+  monitoringStatus: MonitoringStatus;
+  lowerBoundPrice: number;
+  upperBoundPrice: number;
+  lowerBoundLabel: string;
+  upperBoundLabel: string;
+};
+
+export type PositionListViewModel = {
+  items: PositionListItemViewModel[];
+  isEmpty: boolean;
+};
+
+export function buildPositionListViewModel(positions: PositionSummaryDto[]): PositionListViewModel {
+  const items: PositionListItemViewModel[] = positions.map((p) => ({
+    positionId: p.positionId,
+    poolId: p.poolId,
+    poolLabel: p.tokenPairLabel,
+    currentPrice: p.currentPrice,
+    currentPriceLabel: p.currentPriceLabel ?? `Current: ${p.currentPrice}`,
+    rangeStatusKind: p.rangeState,
+    hasAlert: p.hasActionableTrigger,
+    monitoringStatus: p.monitoringStatus,
+    lowerBoundPrice: p.lowerBoundPrice,
+    upperBoundPrice: p.upperBoundPrice,
+    lowerBoundLabel: p.lowerBoundLabel,
+    upperBoundLabel: p.upperBoundLabel,
+  }));
+
+  return { items, isEmpty: items.length === 0 };
+}
+```
+
+The `monitoringLabel` field, the inner `monitoringLabel(status)` helper, and the `monitoringLabel: monitoringLabel(p.monitoringStatus),` mapping line are all gone. Nothing else changes.
+
+- [ ] **Step 2: Run typecheck**
+
+Run: `pnpm --filter @clmm/ui typecheck`
+Expected: PASS. If TypeScript reports a `monitoringLabel` reference somewhere, return to Task 7 — that consumer was missed.
+
+- [ ] **Step 3: Run the UI tests**
+
+Run: `pnpm --filter @clmm/ui test`
+Expected: PASS, including `PositionListViewModel.test.ts` (which never asserted `monitoringLabel`).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/ui/src/view-models/PositionListViewModel.ts
+git commit -m "refactor(ui): remove legacy monitoringLabel from PositionListItemViewModel"
+```
+
+---
+
+## Phase 5 — Final verification
+
+### Task 9: Workspace-wide typecheck
+
+**Files:** none
+
+- [ ] **Step 1: Run typecheck on the whole workspace**
+
+Run: `pnpm typecheck`
+Expected: PASS for every package. This catches any consumer outside `packages/ui` that we missed (e.g., a re-export or a screen in `apps/app` that read `monitoringLabel`).
+
+If it fails, identify the consumer, port it to `monitoringStatus`, and re-run before continuing.
+
+---
+
+### Task 10: Workspace-wide tests
+
+**Files:** none
+
+- [ ] **Step 1: Run the full test suite**
+
+Run: `pnpm test`
+Expected: PASS for every package. The change is confined to `packages/ui`, so this is a regression check rather than a behavior check.
+
+If a test in another package fails, stop and investigate — this plan should not have changed any contract outside `packages/ui`.
+
+---
+
+### Task 11: Boundaries check
+
+**Files:** none
+
+- [ ] **Step 1: Run dependency-cruiser**
+
+Run: `pnpm boundaries`
+Expected: PASS. The new `import type { MonitoringStatus }` from `../view-models/PositionListViewModel.js` inside `PositionCardUtils.ts` is intra-package and intra-`src`; the dependency-cruiser config (`packages/config/boundaries/dependency-cruiser.cjs`) enforces inter-package layering and should not flag it. If it does flag it, surface the rule output and stop — do not silence the rule without discussing with the user.
+
+---
+
+## Acceptance Criteria Trace
+
+Every spec acceptance criterion maps to at least one task above:
+
+- "`PositionListItemViewModel` exposes `monitoringStatus: 'active' | 'degraded' | 'inactive'`." → Task 2.
+- "`monitoringLabel` is removed from `PositionListItemViewModel` if unused after card migration." → Task 7 (verify) + Task 8 (delete).
+- "`getMonitoringDisplay` accepts typed monitoring status, not display-label strings." → Task 4.
+- "No card logic branches on `\"Monitoring Active\"`, `\"Monitoring Degraded\"`, or `\"Monitoring Inactive\"`." → Task 4 deletes those string literals from `getMonitoringDisplay`; Task 5 stops `PositionCard` from forwarding `monitoringLabel`.
+- "`PositionCard` accepts `{ item, onPress }` instead of individual view-model fields." → Task 5.
+- "`PositionsListScreen` passes `item={item}` and no longer manually forwards each card field." → Task 6.
+- "Displayed monitor text remains `Live`, `Degraded`, and `Inactive`." → Task 4 (helper output) + Task 6 Step 3 (`PositionsListScreen.test.tsx` assertions for `Live`/`Degraded`/`Inactive` keep passing).
+- "`pnpm typecheck` passes." → Task 9.
+- "`pnpm test` passes." → Task 10.
+- "`pnpm boundaries` passes." → Task 11.

--- a/docs/superpowers/specs/2026-05-05-view-model-contract-improvements-design.md
+++ b/docs/superpowers/specs/2026-05-05-view-model-contract-improvements-design.md
@@ -1,0 +1,166 @@
+# View-Model Contract Improvements Design
+
+**Issue:** https://github.com/opsclawd/clmm-v2/issues/71
+**Date:** 2026-05-05
+**Status:** Approved for implementation planning
+
+## Goal
+
+Clean up two positions-list UI contracts that became brittle during the issue #67 card redesign:
+
+- `PositionCardUtils.getMonitoringDisplay` must consume typed monitoring state instead of display-label strings.
+- `PositionCard` must accept the list item view model directly instead of a long list of individual fields.
+
+This is a contained UI contract cleanup. It must stay inside `packages/ui` and must not touch DTOs, application-layer code, adapters, domain logic, trigger qualification, execution logic, or directional-exit policy.
+
+## Scope
+
+In scope:
+
+- Add a `MonitoringStatus` union to `packages/ui/src/view-models/PositionListViewModel.ts`.
+- Expose `monitoringStatus: MonitoringStatus` on `PositionListItemViewModel`.
+- Map `PositionSummaryDto.monitoringStatus` directly into the list item view model.
+- Remove `monitoringLabel` from `PositionListItemViewModel` once the card migration leaves it unused.
+- Change `getMonitoringDisplay` to accept `MonitoringStatus`.
+- Change `PositionCard` to accept `{ item, onPress }`.
+- Change `PositionsListScreen` to pass `item={item}` instead of manually forwarding card fields.
+- Update focused tests for view-model mapping, monitoring display, and list/card behavior.
+
+Out of scope:
+
+- DTO changes.
+- Application-layer changes.
+- Domain or adapter changes.
+- API validation changes.
+- Trigger qualification changes.
+- Directional exit policy changes.
+- Execution or signing flow changes.
+- Creating a separate `PositionCardItem` subset type unless the full view model creates a concrete compile-time problem.
+
+## Architecture
+
+All changes stay in `packages/ui`.
+
+`PositionListViewModel` becomes the typed boundary for monitoring state used by the card:
+
+```ts
+export type MonitoringStatus = 'active' | 'degraded' | 'inactive';
+
+export type PositionListItemViewModel = {
+  positionId: string;
+  poolId: string;
+  poolLabel: string;
+  currentPrice: number;
+  currentPriceLabel: string;
+  rangeStatusKind: 'in-range' | 'below-range' | 'above-range';
+  hasAlert: boolean;
+  monitoringStatus: MonitoringStatus;
+  lowerBoundPrice: number;
+  upperBoundPrice: number;
+  lowerBoundLabel: string;
+  upperBoundLabel: string;
+};
+```
+
+`buildPositionListViewModel` copies `p.monitoringStatus` through from `PositionSummaryDto`. The application DTO already exposes the same closed union, so UI code should not re-derive monitoring state from copy.
+
+`PositionCard` imports `PositionListItemViewModel` with `import type`, accepts `{ item, onPress }`, and destructures internally. This keeps `PositionsListScreen` responsible for list composition and selection behavior, not the card's internal field list.
+
+## Component Contract
+
+`PositionCard` changes from many individual props to one item prop:
+
+```ts
+import type { PositionListItemViewModel } from '../view-models/PositionListViewModel.js';
+
+type PositionCardProps = {
+  item: PositionListItemViewModel;
+  onPress?: () => void;
+};
+```
+
+`PositionsListScreen` renders:
+
+```tsx
+<PositionCard item={item} onPress={() => onSelectPosition?.(item.positionId)} />
+```
+
+The card keeps the current visual behavior: pair glyph, pool ID, chip, range bar, placeholder TVL/fees, and monitor footer. The change is only the TypeScript props API and the typed monitoring input.
+
+## Monitoring Display
+
+`PositionCardUtils.getMonitoringDisplay` accepts `MonitoringStatus`, not a display label:
+
+```ts
+export function getMonitoringDisplay(status: MonitoringStatus): MonitoringDisplay {
+  switch (status) {
+    case 'active':
+      return { text: 'Live', tone: 'safe' };
+    case 'degraded':
+      return { text: 'Degraded', tone: 'warn' };
+    case 'inactive':
+      return { text: 'Inactive', tone: 'faint' };
+  }
+}
+```
+
+Displayed monitor text remains unchanged:
+
+| Status     | Display text | Tone  |
+| ---------- | ------------ | ----- |
+| `active`   | `Live`       | safe  |
+| `degraded` | `Degraded`   | warn  |
+| `inactive` | `Inactive`   | faint |
+
+No card logic may branch on `"Monitoring Active"`, `"Monitoring Degraded"`, or `"Monitoring Inactive"`.
+
+## Data Flow
+
+The intended flow is:
+
+1. `PositionSummaryDto.monitoringStatus`
+2. `PositionListItemViewModel.monitoringStatus`
+3. `PositionCard item.monitoringStatus`
+4. `getMonitoringDisplay(status)`
+5. `Live`, `Degraded`, or `Inactive`
+
+`monitoringLabel` is removed from the list view model after the migration if a grep confirms no remaining consumer.
+
+## Error Handling
+
+There is no new runtime error path.
+
+The valid statuses are already constrained at the application DTO boundary and mirrored by the UI union. Because `getMonitoringDisplay` receives a closed union, it does not need an unknown fallback branch. Compile-time exhaustiveness is the desired failure mode if a new monitoring status is added later.
+
+## Testing
+
+Update focused tests instead of broad snapshot-style assertions:
+
+- `PositionListViewModel.test.ts`: verify `active`, `degraded`, and `inactive` map through as typed `monitoringStatus`.
+- `PositionCardUtils.test.ts`: call `getMonitoringDisplay` with typed statuses and verify `Live`, `Degraded`, `Inactive`, and tones.
+- `PositionsListScreen.test.tsx`: update only if prop wiring or displayed behavior assertions require it. Preserve coverage that cards render the monitor text and invoke `onSelectPosition` with the selected `positionId`.
+
+TypeScript should prove that `PositionCard` call sites no longer pass individual card fields.
+
+## Verification
+
+Implementation verification should include:
+
+- `pnpm typecheck`
+- `pnpm test`
+- `pnpm boundaries`
+
+`pnpm build` and `pnpm lint` are optional for this narrow UI contract cleanup unless implementation touches broader package exports or style-sensitive files.
+
+## Acceptance Criteria
+
+- `PositionListItemViewModel` exposes `monitoringStatus: 'active' | 'degraded' | 'inactive'`.
+- `monitoringLabel` is removed from `PositionListItemViewModel` if unused after card migration.
+- `getMonitoringDisplay` accepts typed monitoring status, not display-label strings.
+- No card logic branches on `"Monitoring Active"`, `"Monitoring Degraded"`, or `"Monitoring Inactive"`.
+- `PositionCard` accepts `{ item, onPress }` instead of individual view-model fields.
+- `PositionsListScreen` passes `item={item}` and no longer manually forwards each card field.
+- Displayed monitor text remains `Live`, `Degraded`, and `Inactive`.
+- `pnpm typecheck` passes.
+- `pnpm test` passes.
+- `pnpm boundaries` passes.

--- a/packages/ui/src/components/PositionCard.test.tsx
+++ b/packages/ui/src/components/PositionCard.test.tsx
@@ -1,0 +1,67 @@
+import React from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, render, screen, fireEvent } from '@testing-library/react';
+import { PositionCard } from './PositionCard.js';
+import type { PositionListItemViewModel } from '../view-models/PositionListViewModel.js';
+
+const baseItem: PositionListItemViewModel = {
+  positionId: 'pos-1',
+  poolId: 'CzfqAaBbCcDdEeFfGgHh1234kkkk44zE',
+  poolLabel: 'SOL / USDC',
+  currentPrice: 150,
+  currentPriceLabel: 'USDC 150.00',
+  rangeStatusKind: 'in-range',
+  hasAlert: false,
+  monitoringStatus: 'active',
+  lowerBoundPrice: 100,
+  upperBoundPrice: 200,
+  lowerBoundLabel: 'USDC 100.00',
+  upperBoundLabel: 'USDC 200.00',
+};
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('PositionCard', () => {
+  it('renders pool label and truncated pool id', () => {
+    render(<PositionCard item={baseItem} />);
+
+    expect(screen.getByText('SOL / USDC')).toBeTruthy();
+    expect(screen.getByText('Czfq…44zE')).toBeTruthy();
+  });
+
+  it('renders monitoring display text for each status', () => {
+    const { rerender } = render(<PositionCard item={baseItem} />);
+    expect(screen.getByText('Live')).toBeTruthy();
+
+    rerender(<PositionCard item={{ ...baseItem, monitoringStatus: 'degraded' }} />);
+    expect(screen.getByText('Degraded')).toBeTruthy();
+
+    rerender(<PositionCard item={{ ...baseItem, monitoringStatus: 'inactive' }} />);
+    expect(screen.getByText('Inactive')).toBeTruthy();
+  });
+
+  it('renders chip label for in-range position without alert', () => {
+    render(<PositionCard item={baseItem} />);
+    expect(screen.getByText('In range')).toBeTruthy();
+  });
+
+  it('renders chip label for breach · below', () => {
+    render(<PositionCard item={{ ...baseItem, rangeStatusKind: 'below-range', hasAlert: true }} />);
+    expect(screen.getByText('Breach · below')).toBeTruthy();
+  });
+
+  it('calls onPress when tapped', () => {
+    const onPress = vi.fn();
+    render(<PositionCard item={baseItem} onPress={onPress} />);
+
+    fireEvent.click(screen.getByRole('button'));
+    expect(onPress).toHaveBeenCalledOnce();
+  });
+
+  it('has accessible label with pool label and chip text', () => {
+    render(<PositionCard item={baseItem} />);
+    expect(screen.getByLabelText('Position card for SOL / USDC, In range')).toBeTruthy();
+  });
+});

--- a/packages/ui/src/components/PositionCard.tsx
+++ b/packages/ui/src/components/PositionCard.tsx
@@ -1,4 +1,5 @@
 import { View, Text, TouchableOpacity } from 'react-native';
+import type { PositionListItemViewModel } from '../view-models/PositionListViewModel.js';
 import { colors, typography } from '../design-system/index.js';
 import { Chip } from './Chip.js';
 import { PairGlyph } from './PairGlyph.js';
@@ -14,17 +15,7 @@ import {
 } from './PositionCardUtils.js';
 
 type Props = {
-  poolId: string;
-  poolLabel: string;
-  currentPrice: number;
-  currentPriceLabel: string;
-  lowerBoundPrice: number;
-  upperBoundPrice: number;
-  lowerBoundLabel: string;
-  upperBoundLabel: string;
-  rangeStatusKind: 'in-range' | 'below-range' | 'above-range';
-  hasAlert: boolean;
-  monitoringLabel: string;
+  item: PositionListItemViewModel;
   onPress?: () => void;
 };
 
@@ -34,25 +25,26 @@ function monitoringDotColor(tone: 'safe' | 'warn' | 'faint'): string {
   return colors.textFaint;
 }
 
-export function PositionCard({
-  poolId,
-  poolLabel,
-  currentPrice,
-  currentPriceLabel,
-  lowerBoundPrice,
-  upperBoundPrice,
-  lowerBoundLabel,
-  upperBoundLabel,
-  rangeStatusKind,
-  hasAlert,
-  monitoringLabel,
-  onPress,
-}: Props): JSX.Element {
+export function PositionCard({ item, onPress }: Props): JSX.Element {
+  const {
+    poolId,
+    poolLabel,
+    currentPrice,
+    currentPriceLabel,
+    lowerBoundPrice,
+    upperBoundPrice,
+    lowerBoundLabel,
+    upperBoundLabel,
+    rangeStatusKind,
+    hasAlert,
+    monitoringStatus,
+  } = item;
+
   const tokens = splitTokenPair(poolLabel);
   const truncatedPoolId = formatPoolId(poolId);
   const nearEdge = isNearEdge({ currentPrice, lowerBoundPrice, upperBoundPrice });
   const chip = getStatusChipProps({ rangeStatusKind, hasAlert, nearEdge });
-  const monitoring = getMonitoringDisplay(monitoringLabel);
+  const monitoring = getMonitoringDisplay(monitoringStatus);
   const placeholders = getCardPlaceholderMetrics(poolId);
 
   const breachSide = getBreachSide(hasAlert, rangeStatusKind);

--- a/packages/ui/src/components/PositionCardUtils.test.ts
+++ b/packages/ui/src/components/PositionCardUtils.test.ts
@@ -178,26 +178,22 @@ describe('getStatusChipProps', () => {
 });
 
 describe('getMonitoringDisplay', () => {
-  it('maps the active label to Live with the safe tone color', () => {
-    const r = getMonitoringDisplay('Monitoring Active');
+  it('maps active to Live with the safe tone', () => {
+    const r = getMonitoringDisplay('active');
     expect(r.text).toBe('Live');
     expect(r.tone).toBe('safe');
   });
 
-  it('maps the degraded label to Degraded with the warn tone color', () => {
-    const r = getMonitoringDisplay('Monitoring Degraded');
+  it('maps degraded to Degraded with the warn tone', () => {
+    const r = getMonitoringDisplay('degraded');
     expect(r.text).toBe('Degraded');
     expect(r.tone).toBe('warn');
   });
 
-  it('falls back to Inactive with a faint tone for any other input', () => {
-    const r = getMonitoringDisplay('Monitoring Inactive');
+  it('maps inactive to Inactive with the faint tone', () => {
+    const r = getMonitoringDisplay('inactive');
     expect(r.text).toBe('Inactive');
     expect(r.tone).toBe('faint');
-
-    const u = getMonitoringDisplay('totally unknown');
-    expect(u.text).toBe('Inactive');
-    expect(u.tone).toBe('faint');
   });
 });
 

--- a/packages/ui/src/components/PositionCardUtils.test.ts
+++ b/packages/ui/src/components/PositionCardUtils.test.ts
@@ -195,6 +195,10 @@ describe('getMonitoringDisplay', () => {
     expect(r.text).toBe('Inactive');
     expect(r.tone).toBe('faint');
   });
+
+  it('throws for an invalid monitoring status at runtime', () => {
+    expect(() => getMonitoringDisplay('unknown' as never)).toThrow('Unexpected monitoringStatus');
+  });
 });
 
 describe('getCardPlaceholderMetrics', () => {

--- a/packages/ui/src/components/PositionCardUtils.ts
+++ b/packages/ui/src/components/PositionCardUtils.ts
@@ -1,3 +1,5 @@
+import type { MonitoringStatus } from '../view-models/PositionListViewModel.js';
+
 export type TokenPair = { a: string; b: string };
 
 export function splitTokenPair(label: string): TokenPair {
@@ -77,10 +79,15 @@ export function getStatusChipProps({
 export type MonitoringTone = 'safe' | 'warn' | 'faint';
 export type MonitoringDisplay = { text: string; tone: MonitoringTone };
 
-export function getMonitoringDisplay(monitoringLabel: string): MonitoringDisplay {
-  if (monitoringLabel === 'Monitoring Active') return { text: 'Live', tone: 'safe' };
-  if (monitoringLabel === 'Monitoring Degraded') return { text: 'Degraded', tone: 'warn' };
-  return { text: 'Inactive', tone: 'faint' };
+export function getMonitoringDisplay(status: MonitoringStatus): MonitoringDisplay {
+  switch (status) {
+    case 'active':
+      return { text: 'Live', tone: 'safe' };
+    case 'degraded':
+      return { text: 'Degraded', tone: 'warn' };
+    case 'inactive':
+      return { text: 'Inactive', tone: 'faint' };
+  }
 }
 
 export type CardPlaceholderMetrics = { tvlLabel: string; fees24hLabel: string };

--- a/packages/ui/src/components/PositionCardUtils.ts
+++ b/packages/ui/src/components/PositionCardUtils.ts
@@ -87,6 +87,10 @@ export function getMonitoringDisplay(status: MonitoringStatus): MonitoringDispla
       return { text: 'Degraded', tone: 'warn' };
     case 'inactive':
       return { text: 'Inactive', tone: 'faint' };
+    default: {
+      const _exhaustive: never = status;
+      throw new Error(`Unexpected monitoringStatus: ${String(_exhaustive)}`);
+    }
   }
 }
 

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -31,6 +31,8 @@ export { Chip } from './components/Chip.js';
 export type { ChipTone } from './components/Chip.js';
 export { SectionHeader } from './components/SectionHeader.js';
 export { PositionCard } from './components/PositionCard.js';
+export { getMonitoringDisplay } from './components/PositionCardUtils.js';
+export type { MonitoringDisplay, MonitoringTone } from './components/PositionCardUtils.js';
 
 // Wallet connection utils
 export {
@@ -56,8 +58,14 @@ export type {
 // View models — for testing and screen composition
 export { buildPreviewViewModel } from './view-models/PreviewViewModel.js';
 export { buildExecutionStateViewModel } from './view-models/ExecutionStateViewModel.js';
-export { buildPositionListViewModel } from './view-models/PositionListViewModel.js';
-export type { PositionListItemViewModel } from './view-models/PositionListViewModel.js';
+export {
+  buildPositionListViewModel,
+  asMonitoringStatus,
+} from './view-models/PositionListViewModel.js';
+export type {
+  PositionListItemViewModel,
+  MonitoringStatus,
+} from './view-models/PositionListViewModel.js';
 export { buildPositionDetailViewModel } from './view-models/PositionDetailViewModel.js';
 export { buildHistoryViewModel } from './view-models/HistoryViewModel.js';
 export { buildWalletConnectViewModel } from './view-models/WalletConnectionViewModel.js';

--- a/packages/ui/src/screens/PositionsListScreen.tsx
+++ b/packages/ui/src/screens/PositionsListScreen.tsx
@@ -235,20 +235,7 @@ function ConnectedPositionsList({
         />
       }
       renderItem={({ item }) => (
-        <PositionCard
-          poolId={item.poolId}
-          poolLabel={item.poolLabel}
-          currentPrice={item.currentPrice}
-          currentPriceLabel={item.currentPriceLabel}
-          lowerBoundPrice={item.lowerBoundPrice}
-          upperBoundPrice={item.upperBoundPrice}
-          lowerBoundLabel={item.lowerBoundLabel}
-          upperBoundLabel={item.upperBoundLabel}
-          rangeStatusKind={item.rangeStatusKind}
-          hasAlert={item.hasAlert}
-          monitoringLabel={item.monitoringLabel}
-          onPress={() => onSelectPosition?.(item.positionId)}
-        />
+        <PositionCard item={item} onPress={() => onSelectPosition?.(item.positionId)} />
       )}
     />
   );

--- a/packages/ui/src/view-models/PositionListViewModel.test.ts
+++ b/packages/ui/src/view-models/PositionListViewModel.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import type { PositionSummaryDto } from '@clmm/application/public';
-import { buildPositionListViewModel } from './PositionListViewModel.js';
+import { buildPositionListViewModel, asMonitoringStatus } from './PositionListViewModel.js';
 
 function makeSummaryDto(overrides: Partial<PositionSummaryDto> = {}): PositionSummaryDto {
   return {
@@ -67,5 +67,25 @@ describe('buildPositionListViewModel monitoringStatus mapping', () => {
   it('copies inactive monitoring status through as a typed value', () => {
     const vm = buildPositionListViewModel([makeSummaryDto({ monitoringStatus: 'inactive' })]);
     expect(vm.items[0]!.monitoringStatus).toBe('inactive');
+  });
+
+  it('throws on an invalid monitoringStatus from the DTO', () => {
+    expect(() =>
+      buildPositionListViewModel([
+        makeSummaryDto({ monitoringStatus: 'unknown' as PositionSummaryDto['monitoringStatus'] }),
+      ]),
+    ).toThrow('Invalid monitoringStatus');
+  });
+});
+
+describe('asMonitoringStatus', () => {
+  it('returns valid statuses unchanged', () => {
+    expect(asMonitoringStatus('active')).toBe('active');
+    expect(asMonitoringStatus('degraded')).toBe('degraded');
+    expect(asMonitoringStatus('inactive')).toBe('inactive');
+  });
+
+  it('throws for an invalid value', () => {
+    expect(() => asMonitoringStatus('unknown')).toThrow('Invalid monitoringStatus');
   });
 });

--- a/packages/ui/src/view-models/PositionListViewModel.test.ts
+++ b/packages/ui/src/view-models/PositionListViewModel.test.ts
@@ -52,3 +52,20 @@ describe('buildPositionListViewModel', () => {
     expect(vm.items).toHaveLength(0);
   });
 });
+
+describe('buildPositionListViewModel monitoringStatus mapping', () => {
+  it('copies active monitoring status through as a typed value', () => {
+    const vm = buildPositionListViewModel([makeSummaryDto({ monitoringStatus: 'active' })]);
+    expect(vm.items[0]!.monitoringStatus).toBe('active');
+  });
+
+  it('copies degraded monitoring status through as a typed value', () => {
+    const vm = buildPositionListViewModel([makeSummaryDto({ monitoringStatus: 'degraded' })]);
+    expect(vm.items[0]!.monitoringStatus).toBe('degraded');
+  });
+
+  it('copies inactive monitoring status through as a typed value', () => {
+    const vm = buildPositionListViewModel([makeSummaryDto({ monitoringStatus: 'inactive' })]);
+    expect(vm.items[0]!.monitoringStatus).toBe('inactive');
+  });
+});

--- a/packages/ui/src/view-models/PositionListViewModel.ts
+++ b/packages/ui/src/view-models/PositionListViewModel.ts
@@ -2,6 +2,19 @@ import type { PositionSummaryDto } from '@clmm/application/public';
 
 export type MonitoringStatus = 'active' | 'degraded' | 'inactive';
 
+const VALID_MONITORING_STATUSES: ReadonlySet<string> = new Set<string>([
+  'active',
+  'degraded',
+  'inactive',
+]);
+
+export function asMonitoringStatus(value: string): MonitoringStatus {
+  if (!VALID_MONITORING_STATUSES.has(value)) {
+    throw new Error(`Invalid monitoringStatus: ${value}`);
+  }
+  return value as MonitoringStatus;
+}
+
 export type PositionListItemViewModel = {
   positionId: string;
   poolId: string;
@@ -31,7 +44,7 @@ export function buildPositionListViewModel(positions: PositionSummaryDto[]): Pos
     currentPriceLabel: p.currentPriceLabel ?? `Current: ${p.currentPrice}`,
     rangeStatusKind: p.rangeState,
     hasAlert: p.hasActionableTrigger,
-    monitoringStatus: p.monitoringStatus,
+    monitoringStatus: asMonitoringStatus(p.monitoringStatus),
     lowerBoundPrice: p.lowerBoundPrice,
     upperBoundPrice: p.upperBoundPrice,
     lowerBoundLabel: p.lowerBoundLabel,

--- a/packages/ui/src/view-models/PositionListViewModel.ts
+++ b/packages/ui/src/view-models/PositionListViewModel.ts
@@ -11,7 +11,6 @@ export type PositionListItemViewModel = {
   rangeStatusKind: 'in-range' | 'below-range' | 'above-range';
   hasAlert: boolean;
   monitoringStatus: MonitoringStatus;
-  monitoringLabel: string;
   lowerBoundPrice: number;
   upperBoundPrice: number;
   lowerBoundLabel: string;
@@ -23,19 +22,6 @@ export type PositionListViewModel = {
   isEmpty: boolean;
 };
 
-function monitoringLabel(status: string): string {
-  switch (status) {
-    case 'active':
-      return 'Monitoring Active';
-    case 'degraded':
-      return 'Monitoring Degraded';
-    case 'inactive':
-      return 'Monitoring Inactive';
-    default:
-      return 'Unknown';
-  }
-}
-
 export function buildPositionListViewModel(positions: PositionSummaryDto[]): PositionListViewModel {
   const items: PositionListItemViewModel[] = positions.map((p) => ({
     positionId: p.positionId,
@@ -46,7 +32,6 @@ export function buildPositionListViewModel(positions: PositionSummaryDto[]): Pos
     rangeStatusKind: p.rangeState,
     hasAlert: p.hasActionableTrigger,
     monitoringStatus: p.monitoringStatus,
-    monitoringLabel: monitoringLabel(p.monitoringStatus),
     lowerBoundPrice: p.lowerBoundPrice,
     upperBoundPrice: p.upperBoundPrice,
     lowerBoundLabel: p.lowerBoundLabel,

--- a/packages/ui/src/view-models/PositionListViewModel.ts
+++ b/packages/ui/src/view-models/PositionListViewModel.ts
@@ -1,5 +1,7 @@
 import type { PositionSummaryDto } from '@clmm/application/public';
 
+export type MonitoringStatus = 'active' | 'degraded' | 'inactive';
+
 export type PositionListItemViewModel = {
   positionId: string;
   poolId: string;
@@ -8,6 +10,7 @@ export type PositionListItemViewModel = {
   currentPriceLabel: string;
   rangeStatusKind: 'in-range' | 'below-range' | 'above-range';
   hasAlert: boolean;
+  monitoringStatus: MonitoringStatus;
   monitoringLabel: string;
   lowerBoundPrice: number;
   upperBoundPrice: number;
@@ -42,6 +45,7 @@ export function buildPositionListViewModel(positions: PositionSummaryDto[]): Pos
     currentPriceLabel: p.currentPriceLabel ?? `Current: ${p.currentPrice}`,
     rangeStatusKind: p.rangeState,
     hasAlert: p.hasActionableTrigger,
+    monitoringStatus: p.monitoringStatus,
     monitoringLabel: monitoringLabel(p.monitoringStatus),
     lowerBoundPrice: p.lowerBoundPrice,
     upperBoundPrice: p.upperBoundPrice,


### PR DESCRIPTION
## Summary

Closes #71

Tightens two positions-list UI contracts to improve type safety, reduce prop drilling, and add runtime defense:

1. **Typed `MonitoringStatus` union on `PositionListItemViewModel`** — replaces the untyped `monitoringLabel` string with a closed `'active' | 'degraded' | 'inactive'` union. The `getMonitoringDisplay` function now uses an exhaustive switch with a `default: never` runtime guard that throws on unexpected values. The `buildPositionListViewModel` mapper validates incoming DTO values via `asMonitoringStatus` before assignment.

2. **`PositionCard` accepts `{ item, onPress }` instead of ~10 individual props** — the component now takes a single `PositionListItemViewModel` object plus an optional `onPress` callback, eliminating prop drilling and making the card trivially composable.

## Changes

- Add `MonitoringStatus` type union and `asMonitoringStatus` runtime narrowing to `PositionListViewModel.ts`
- Rewrite `getMonitoringDisplay` with exhaustive switch + `default: const _exhaustive: never = status; throw ...`
- Refactor `PositionCard` props from ~10 individual fields to `{ item: PositionListItemViewModel, onPress? }`
- Remove `monitoringLabel` from `PositionListItemViewModel` (zero consumers confirmed via grep)
- Export `MonitoringStatus`, `asMonitoringStatus`, `getMonitoringDisplay`, `MonitoringDisplay`, `MonitoringTone` from `packages/ui/src/index.ts`
- Add `PositionCard.test.tsx` with 6 component-level tests (pool label, monitoring text per status, chip labels, onPress, accessibility)
- Add throw-assertion tests for invalid `MonitoringStatus` in both `PositionCardUtils.test.ts` and `PositionListViewModel.test.ts`
- Document the exhaustive-switch-with-runtime-guard pattern in `docs/solutions/`

## Verification

- `pnpm typecheck` — PASS
- `pnpm test` — 790 tests passed (218 in `@clmm/ui`, including 6 new PositionCard + 9 PositionListViewModel)
- `pnpm boundaries` — 0 violations