### PR TITLE
fix: add missing .js extensions on srTheses imports

### DIFF
--- a/apps/app/app/(tabs)/positions.tsx
+++ b/apps/app/app/(tabs)/positions.tsx
@@ -5,7 +5,7 @@ import { useStore } from 'zustand';
 import { fetchSupportedPositions } from '../../src/api/positions';
 import { fetchCurrentSrLevels, SrLevelsUnsupportedPoolError } from '../../src/api/srLevels';
 import { fetchCurrentRegime, RegimeUnsupportedPoolError } from '../../src/api/regime';
-import { fetchCurrentSrTheses, SrThesesUnsupportedPoolError } from '../../src/api/srTheses';
+import { fetchCurrentSrTheses, SrThesesUnsupportedPoolError } from '../../src/api/srTheses.js';
 import { walletSessionStore } from '../../src/state/walletSessionStore';
 import type { PositionListItemViewModel } from '@clmm/ui';
 import { navigateRoute } from '../../src/platform/webNavigation';

--- a/packages/adapters/src/index.ts
+++ b/packages/adapters/src/index.ts
@@ -20,4 +20,4 @@ export { OperationalStorageAdapter } from './outbound/storage/OperationalStorage
 export { OffChainHistoryStorageAdapter } from './outbound/storage/OffChainHistoryStorageAdapter';
 export { TelemetryAdapter } from './outbound/observability/TelemetryAdapter';
 export { JupiterPriceAdapter } from './outbound/price/JupiterPriceAdapter';
-export { CurrentSrThesesAdapter } from './outbound/regime-engine/CurrentSrThesesAdapter';
+export { CurrentSrThesesAdapter } from './outbound/regime-engine/CurrentSrThesesAdapter.js';


### PR DESCRIPTION
## Summary
- Two `.js` extensions were missed during the earlier safe-auto fix pass on PR #78 and were pushed after that PR was merged
- `apps/app/app/(tabs)/positions.tsx`: `srTheses` import missing `.js` extension
- `packages/adapters/src/index.ts`: `CurrentSrThesesAdapter` re-export missing `.js` extension

## Verification
- typecheck: pass
- lint: pass
- boundaries: pass