### PR TITLE
fix(adapters): align regime-engine adapters with actual upstream response shape

### DIFF
--- a/packages/adapters/src/outbound/regime-engine/CurrentPolicyInsightsAdapter.test.ts
+++ b/packages/adapters/src/outbound/regime-engine/CurrentPolicyInsightsAdapter.test.ts
@@ -104,9 +104,13 @@ describe('CurrentPolicyInsightsAdapter', () => {
 
   it('returns kind:"not-found" on 404 with INSIGHT_NOT_FOUND code', async () => {
     vi.mocked(fetch).mockResolvedValue(
-      new Response(JSON.stringify({ code: 'INSIGHT_NOT_FOUND', message: 'not yet' }), {
-        status: 404,
-      }),
+      new Response(
+        JSON.stringify({
+          schemaVersion: '1.0',
+          error: { code: 'INSIGHT_NOT_FOUND', message: 'not yet', details: [] },
+        }),
+        { status: 404 },
+      ),
     );
     const adapter = new CurrentPolicyInsightsAdapter('https://regime.example.com', obs.port);
     const result = await adapter.fetchCurrent();

--- a/packages/adapters/src/outbound/regime-engine/CurrentPolicyInsightsAdapter.ts
+++ b/packages/adapters/src/outbound/regime-engine/CurrentPolicyInsightsAdapter.ts
@@ -261,11 +261,12 @@ export class CurrentPolicyInsightsAdapter implements PolicyInsightsReadPort {
     try {
       const body: unknown = await response.json();
       if (!isRecord(body)) return null;
+      const err = body['error'];
       const out: { code?: string; message?: string } = {};
-      const codeRaw = body['code'];
-      const messageRaw = body['message'];
-      if (typeof codeRaw === 'string') out.code = codeRaw;
-      if (typeof messageRaw === 'string') out.message = messageRaw;
+      if (isRecord(err)) {
+        if (typeof err['code'] === 'string') out.code = err['code'];
+        if (typeof err['message'] === 'string') out.message = err['message'];
+      }
       return out;
     } catch {
       return null;

--- a/packages/adapters/src/outbound/regime-engine/CurrentRegimeAdapter.test.ts
+++ b/packages/adapters/src/outbound/regime-engine/CurrentRegimeAdapter.test.ts
@@ -31,15 +31,20 @@ const PARAMS = {
 
 const SAMPLE_UPSTREAM = {
   regime: 'UP',
-  trendStrength: 0.62,
-  volRatio: 1.08,
+  telemetry: {
+    realizedVolShort: 0.007,
+    realizedVolLong: 0.02,
+    volRatio: 1.08,
+    trendStrength: 0.62,
+    compression: 0.02,
+  },
   clmmSuitability: {
     status: 'ALLOWED',
-    reasons: [{ severity: 'INFO', text: 'Trend supports range LP', code: 'CLMM_OK' }],
+    reasons: [{ severity: 'INFO', message: 'Trend supports range LP', code: 'CLMM_OK' }],
   },
-  marketReasons: [{ severity: 'INFO', text: 'Constructive trend', code: 'TREND_OK' }],
+  marketReasons: [{ severity: 'INFO', message: 'Constructive trend', code: 'TREND_OK' }],
   freshness: {
-    capturedAtIso: '2026-05-06T12:00:00Z',
+    generatedAtIso: '2026-05-06T12:00:00Z',
     softStale: false,
     hardStale: false,
   },
@@ -96,27 +101,59 @@ describe('CurrentRegimeAdapter', () => {
     expect(calledUrl).toContain('timeframe=1h');
   });
 
-  it('returns kind:"not-found" when upstream returns 404 CANDLES_NOT_FOUND', async () => {
+  it('returns kind:"not-found" when upstream returns 404 with nested error envelope', async () => {
     vi.mocked(fetch).mockResolvedValue(
-      new Response(JSON.stringify({ code: 'CANDLES_NOT_FOUND', message: 'no candles' }), {
-        status: 404,
-      }),
+      new Response(
+        JSON.stringify({
+          schemaVersion: '1.0',
+          error: { code: 'CANDLES_NOT_FOUND', message: 'No candles found', details: [] },
+        }),
+        { status: 404 },
+      ),
     );
     const adapter = new CurrentRegimeAdapter('https://regime.example.com', obs.port);
     const result = await adapter.fetchCurrent(PARAMS);
     expect(result.kind).toBe('not-found');
   });
 
-  it('returns kind:"config-error" when upstream returns 400 VALIDATION_ERROR', async () => {
+  it('returns kind:"config-error" when upstream returns 400 with nested error envelope', async () => {
     vi.mocked(fetch).mockResolvedValue(
-      new Response(JSON.stringify({ code: 'VALIDATION_ERROR', message: 'bad symbol' }), {
-        status: 400,
-      }),
+      new Response(
+        JSON.stringify({
+          schemaVersion: '1.0',
+          error: { code: 'VALIDATION_ERROR', message: 'bad symbol', details: [] },
+        }),
+        { status: 400 },
+      ),
     );
     const adapter = new CurrentRegimeAdapter('https://regime.example.com', obs.port);
     const result = await adapter.fetchCurrent(PARAMS);
     expect(result.kind).toBe('config-error');
     expect(obs.logs.some((l) => l.message.includes('VALIDATION_ERROR'))).toBe(true);
+  });
+
+  it('returns kind:"upstream-error" on 404 with unrecognized error code', async () => {
+    vi.mocked(fetch).mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          schemaVersion: '1.0',
+          error: { code: 'UNKNOWN_CODE', message: 'something', details: [] },
+        }),
+        { status: 404 },
+      ),
+    );
+    const adapter = new CurrentRegimeAdapter('https://regime.example.com', obs.port);
+    const result = await adapter.fetchCurrent(PARAMS);
+    expect(result.kind).toBe('upstream-error');
+  });
+
+  it('returns kind:"upstream-error" on 404 with unparseable error envelope', async () => {
+    vi.mocked(fetch).mockResolvedValue(
+      new Response(JSON.stringify({ schemaVersion: '1.0' }), { status: 404 }),
+    );
+    const adapter = new CurrentRegimeAdapter('https://regime.example.com', obs.port);
+    const result = await adapter.fetchCurrent(PARAMS);
+    expect(result.kind).toBe('upstream-error');
   });
 
   it('returns kind:"upstream-error" on 5xx', async () => {
@@ -172,5 +209,17 @@ describe('CurrentRegimeAdapter', () => {
     await adapter.fetchCurrent(PARAMS);
     const calledUrl = (fetch as ReturnType<typeof vi.fn>).mock.calls[0]![0] as string;
     expect(calledUrl).toMatch(/^https:\/\/regime\.example\.com\/v1\/regime\/current\?/);
+  });
+
+  it('maps upstream message field to DTO text in reasons', async () => {
+    vi.mocked(fetch).mockResolvedValue(
+      new Response(JSON.stringify(SAMPLE_UPSTREAM), { status: 200 }),
+    );
+    const adapter = new CurrentRegimeAdapter('https://regime.example.com', obs.port);
+    const result = await adapter.fetchCurrent(PARAMS);
+    expect(result.kind).toBe('block');
+    if (result.kind !== 'block') return;
+    expect(result.block.clmmSuitability.reasons[0]!.text).toBe('Trend supports range LP');
+    expect(result.block.marketReasons[0]!.text).toBe('Constructive trend');
   });
 });

--- a/packages/adapters/src/outbound/regime-engine/CurrentRegimeAdapter.ts
+++ b/packages/adapters/src/outbound/regime-engine/CurrentRegimeAdapter.ts
@@ -29,13 +29,13 @@ function parseReasons(raw: unknown): RegimeReason[] | null {
   for (const item of raw) {
     if (!isRecord(item)) return null;
     const sev = item['severity'];
-    const text = item['text'];
+    const message = item['message'];
     if (typeof sev !== 'string' || !VALID_SEVERITIES.has(sev as RegimeReasonSeverity)) return null;
-    if (typeof text !== 'string') return null;
+    if (typeof message !== 'string') return null;
     const code = item['code'];
     out.push({
       severity: sev as RegimeReasonSeverity,
-      text,
+      text: message,
       ...(typeof code === 'string' ? { code } : {}),
     });
   }
@@ -48,8 +48,10 @@ function parseUpstream(data: unknown): RegimeBlock | null {
   const regime = data['regime'];
   if (typeof regime !== 'string' || !VALID_REGIMES.has(regime as MarketRegime)) return null;
 
-  const trendStrength = data['trendStrength'];
-  const volRatio = data['volRatio'];
+  const telemetry = data['telemetry'];
+  if (!isRecord(telemetry)) return null;
+  const trendStrength = telemetry['trendStrength'];
+  const volRatio = telemetry['volRatio'];
   if (typeof trendStrength !== 'number' || !Number.isFinite(trendStrength)) return null;
   if (typeof volRatio !== 'number' || !Number.isFinite(volRatio)) return null;
 
@@ -66,12 +68,12 @@ function parseUpstream(data: unknown): RegimeBlock | null {
 
   const freshness = data['freshness'];
   if (!isRecord(freshness)) return null;
-  const capturedAtIso = freshness['capturedAtIso'];
+  const generatedAtIso = freshness['generatedAtIso'];
   const softStale = freshness['softStale'];
   const hardStale = freshness['hardStale'];
-  if (typeof capturedAtIso !== 'string') return null;
+  if (typeof generatedAtIso !== 'string') return null;
   if (typeof softStale !== 'boolean' || typeof hardStale !== 'boolean') return null;
-  const capturedAtUnixMs = Date.parse(capturedAtIso);
+  const capturedAtUnixMs = Date.parse(generatedAtIso);
   if (!Number.isFinite(capturedAtUnixMs)) return null;
 
   const metadataRaw = data['metadata'];
@@ -191,9 +193,12 @@ export class CurrentRegimeAdapter implements RegimeReadPort {
     try {
       const body = (await response.json()) as unknown;
       if (!isRecord(body)) return null;
+      const err = body['error'];
       const out: { code?: string; message?: string } = {};
-      if (typeof body['code'] === 'string') out.code = body['code'];
-      if (typeof body['message'] === 'string') out.message = body['message'];
+      if (isRecord(err)) {
+        if (typeof err['code'] === 'string') out.code = err['code'];
+        if (typeof err['message'] === 'string') out.message = err['message'];
+      }
       return out;
     } catch {
       return null;


### PR DESCRIPTION
## Summary

Fixes 5 shape mismatches between the CLMM adapters and the actual regime-engine API responses that caused all regime data to fail validation, resulting in "Regime analysis unavailable" and "Market context unavailable" in the UI.

## Problem

The BFF logs showed `{"message": "Regime response failed shape validation", "severity": "warn"}` — the adapters were successfully calling regime-engine and receiving 200 responses, but `parseUpstream()` rejected every response because field names and nesting didn't match.

A live curl against regime-engine confirmed the actual response shape, revealing five mismatches.

## Changes

| Mismatch | Adapter expected | Regime-engine returns | Fix |
|---|---|---|---|
| Telemetry nesting | `data.trendStrength`, `data.volRatio` (top-level) | `data.telemetry.trendStrength`, `data.telemetry.volRatio` (nested) | Read from `data.telemetry` |
| Freshness field | `freshness.capturedAtIso` | `freshness.generatedAtIso` | Read `generatedAtIso` |
| Reason text field | `reasons[].text` | `reasons[].message` | Accept `message`, map to DTO's `text` |
| Error envelope (regime) | `body.code`, `body.message` (flat) | `body.error.code`, `body.error.message` (nested) | Read from `body.error` |
| Error envelope (policy) | Same flat shape | Same nested shape | Same fix |

**Files changed:**
- `CurrentRegimeAdapter.ts` — parseUpstream, parseReasons, readErrorEnvelope
- `CurrentPolicyInsightsAdapter.ts` — readErrorEnvelope
- `CurrentRegimeAdapter.test.ts` — updated fixtures to match real response shape, added nested error envelope tests, added message→text mapping test
- `CurrentPolicyInsightsAdapter.test.ts` — updated error envelope test fixture

## Verification

- `pnpm test` — 411 tests pass
- `pnpm typecheck` — clean
- `pnpm lint` — 0 errors (pre-existing warnings only)
- `pnpm boundaries` — clean
- `pnpm build` — clean

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Claude_Code-GLM_5.1-D97757?logo=claude&logoColor=white)