### PR TITLE
feat(adapters): live fee/reward quotes with graceful degradation

### DIFF
--- a/docs/solutions/best-practices/live-fee-reward-quotes-graceful-degradation-2026-05-07.md
+++ b/docs/solutions/best-practices/live-fee-reward-quotes-graceful-degradation-2026-05-07.md
@@ -1,0 +1,167 @@
+---
+title: Live Fee and Reward Quotes with Graceful Degradation
+date: '2026-05-07'
+category: best-practices
+module: orca-position-fee-reward-quote
+problem_type: best_practice
+component: service_object
+severity: medium
+applies_when:
+  - fetching on-chain data that may be unavailable or stale
+  - replacing stale pre-computed accumulators with live computed quotes
+  - designing discriminated union results for adapter failure modes
+root_cause: inadequate_documentation
+resolution_type: code_fix
+related_components:
+  - solana-position-snapshot-reader
+  - observability-port
+tags:
+  - orca
+  - clmm
+  - fee-reward-quote
+  - discriminated-union
+  - graceful-degradation
+  - observability
+  - adapter-pattern
+  - solana
+---
+
+# Live Fee and Reward Quotes with Graceful Degradation
+
+## Context
+
+On-chain CLMM position snapshots expose `feeOwedA`, `feeOwedB`, and `rewardInfos[].amountOwed` — but these accumulators are only updated when a transaction touches the position. Between updates, the values grow stale, diverging from the true earned fees and rewards. Naively displaying these stale values misleads LPs. However, live quote computation depends on tick arrays fetched over HTTP, which can fail or return incomplete data. Without a disciplined pattern, every consumer must invent its own fallback logic — or worse, silently serve bad data.
+
+## Guidance
+
+**Model fee/reward availability as a discriminated union, not a nullable scalar.**
+
+Compute live quotes in a dedicated, stateless helper and return a result type that distinguishes _why_ a quote is unavailable:
+
+```typescript
+type FeeRewardQuoteResult =
+  | {
+      status: 'ok';
+      fees: { amountOwedA: bigint; amountOwedB: bigint };
+      rewards: PositionRewardQuote[];
+    }
+  | { status: 'tick-array-fetch-failed'; reason: string }
+  | { status: 'tick-data-missing'; reason: string }
+  | { status: 'fee-quote-failed'; reason: string; errorName?: string }
+  | { status: 'reward-quote-failed'; reason: string; errorName?: string };
+```
+
+**Handle inactive reward mints defensively.** Orca positions can contain reward slots with empty mints (`mint = ''`). Assign `amountOwed = 0n, decimals = null` instead of attempting to quote them — this avoids downstream NaN/null crashes.
+
+**Delegate and observe.** The snapshot reader delegates to the helper and logs structured unavailability:
+
+```typescript
+const result = this.quoteHelper.quote(params);
+
+if (result.status !== 'ok') {
+  this.observability?.trackEvent({
+    name: 'orca_position_fee_reward_quote_unavailable',
+    properties: {
+      positionId,
+      walletId,
+      poolId,
+      lowerTick,
+      upperTick,
+      tickSpacing,
+      reason: result.reason,
+      errorName: (result as any).errorName,
+      errorMessage: (result as any).errorMessage?.slice(0, 200),
+    },
+  });
+  return null;
+}
+```
+
+Returning `null` for the position detail propagates cleanly to the existing 503 error path, letting the UI surface "temporarily unavailable" instead of stale or incorrect numbers.
+
+**Constructor design for backwards compatibility.** Wire the helper and observability through optional constructor params so existing callers continue working without changes:
+
+```typescript
+constructor(
+  // ... existing deps
+  observability?: ObservabilityPort,
+  quoteHelper?: OrcaPositionFeeRewardQuoteHelper,
+) {
+  this.observability = observability ?? null;
+  this.quoteHelper = quoteHelper ?? new OrcaPositionFeeRewardQuoteHelper();
+}
+```
+
+## Why This Matters
+
+- **Stale data is worse than no data.** Showing outdated `feeOwedA`/`feeOwedB` misleads LPs into acting on incorrect P&L. Surfacing unavailability is the correct behavior.
+- **Discriminated unions prevent silent fallback bugs.** Modeling each failure mode as a distinct arm gives observability precise reason codes and lets callers reason about _what_ failed rather than just _that_ something failed.
+- **Observability closes the feedback loop.** Structured events with position identity and failure reason make it possible to detect systemic RPC issues, tick-array coverage gaps, or Orca SDK incompatibilities in production.
+- **Without this pattern**, every consumer re-implements partial fallback logic, leading to inconsistent UX and undiagnosable failures.
+
+## When to Apply
+
+- Any adapter that transforms on-chain accumulator data that can grow stale between transactions
+- Any data source that depends on external HTTP availability (tick arrays, RPC nodes) where partial failure is expected, not exceptional
+- Any UI that must choose between "show stale data" vs. "show unavailable" — always pick the latter and log why
+
+## Examples
+
+**Before — stale accumulators served directly:**
+
+```typescript
+const positionDetail = {
+  fees: {
+    feeOwedA: snapshot.feeOwedA, // stale — only updated on last touch
+    feeOwedB: snapshot.feeOwedB, // stale
+  },
+  rewards: snapshot.rewardInfos.map((r) => ({
+    amountOwed: r.amountOwed, // stale, or NaN for empty-mint slots
+    decimals: r.decimals,
+  })),
+};
+```
+
+**After — live quote with graceful degradation:**
+
+```typescript
+const result = this.quoteHelper.quote({
+  position,
+  whirlpool,
+  tokenExtensions,
+  tickArrays,
+});
+
+if (result.status !== 'ok') {
+  this.observability?.trackEvent({
+    name: 'orca_position_fee_reward_quote_unavailable',
+    properties: {
+      positionId: position.publicKey.toString(),
+      walletId,
+      poolId,
+      lowerTick,
+      upperTick,
+      tickSpacing,
+      reason: result.reason,
+      errorName: (result as any).errorName,
+      errorMessage: (result as any).errorMessage?.slice(0, 200),
+    },
+  });
+  return null; // triggers 503 — UI shows "temporarily unavailable"
+}
+
+return {
+  fees: {
+    feeOwedA: result.fees.amountOwedA, // live computed
+    feeOwedB: result.fees.amountOwedB, // live computed
+  },
+  rewards: result.rewards, // inactive mints: amountOwed=0n, decimals=null
+};
+```
+
+## Related
+
+- [Enriching DTOs Across Layers](enriching-dtos-across-layers-2026-04-25.md) — USD enrichment on top of fee/reward fields; this doc supersedes the direct on-chain field reads
+- [Read-Only Data API Discriminated Unions](read-only-data-api-discriminated-unions-bff-2026-05-01.md) — BFF composition pattern with partial-failure semantics; live quotes extend this pattern
+- [Position-Bound Fields: Tick-to-Price Migration](position-bound-fields-tick-to-price-migration-2026-05-04.md) — Same reader adapter; live quotes add tick-array-failure handling
+- [GitHub Issue #61](https://github.com/opsclawd/clmm-v2/issues/61) — Bug report that stale on-chain fields show zero; this pattern is the fix

--- a/docs/superpowers/plans/2026-05-07-orca-live-fee-reward-quotes-implementation.md
+++ b/docs/superpowers/plans/2026-05-07-orca-live-fee-reward-quotes-implementation.md
@@ -1,0 +1,1276 @@
+# Orca Live Fee And Reward Quotes Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stop the position detail read path from exposing Orca's checkpointed `feeOwedA`, `feeOwedB`, and `rewardInfos[].amountOwed` as if they were live, by computing live fee/reward quotes via Orca's `collectFeesQuote` / `collectRewardsQuote` and failing closed when quotes cannot be computed.
+
+**Architecture:** Add a stateless adapter-local helper (`OrcaPositionFeeRewardQuoteHelper`) that derives tick-array data and calls Orca's quote primitives, returning a discriminated `FeeRewardQuoteResult` union. `SolanaPositionSnapshotReader.fetchPositionDetail` delegates to this helper, never falls back to checkpointed fields, and emits one structured `orca_position_fee_reward_quote_unavailable` warning when the helper returns `unavailable`. Domain types (`PositionFees`, `PositionRewardInfo`, `PositionDetail`) and HTTP contracts stay unchanged; the existing `null`-from-reader → 404 (single position) / 503 `position_detail_unavailable` (insights) plumbing carries quote failures through.
+
+**Tech Stack:** TypeScript, NestJS DI, Vitest, `@solana/kit` v6, `@orca-so/whirlpools-client` v6.2.1 (`getPositionAddress`, `fetchPosition`, `fetchWhirlpool`, `getTickArrayAddress`, `fetchAllTickArray`), `@orca-so/whirlpools-core` v3.1.0 (`collectFeesQuote`, `collectRewardsQuote`, `getTickArrayStartTickIndex`, `getTickIndexInArray`).
+
+---
+
+## File Structure
+
+**Create:**
+
+- `packages/adapters/src/outbound/solana-position-reads/OrcaPositionFeeRewardQuoteHelper.ts` — stateless helper. Owns tick-array derivation, fetch, lower/upper tick extraction, `collectFeesQuote`, `collectRewardsQuote`, mapping into domain `PositionFees`. Returns `FeeRewardQuoteResult` discriminated union. Does not log.
+- `packages/adapters/src/outbound/solana-position-reads/OrcaPositionFeeRewardQuoteHelper.test.ts` — unit tests for every result-union arm.
+
+**Modify:**
+
+- `packages/adapters/src/outbound/solana-position-reads/SolanaPositionSnapshotReader.ts` — accept optional `ObservabilityPort` and helper via constructor; in `fetchPositionDetail`, drop direct `pos.feeOwedA / feeOwedB / rewardInfos[].amountOwed` mapping; delegate to helper; on `unavailable`, log one `orca_position_fee_reward_quote_unavailable` warn entry with the documented context fields and return `null`.
+- `packages/adapters/src/outbound/solana-position-reads/SolanaPositionSnapshotReader.test.ts` — add `fetchPositionDetail` describe block: ok path, unavailable → null + log, no-fallback assertion.
+- `packages/adapters/src/composition/AdaptersModule.ts` — pass `telemetry` (existing `ObservabilityPort` instance) into the `SolanaPositionSnapshotReader` constructor.
+- `packages/adapters/src/inbound/http/AppModule.ts` — same composition wiring as above.
+
+**Verify (no edits expected):**
+
+- `packages/adapters/src/inbound/http/InsightsDataController.test.ts` — confirm 503 `position_detail_unavailable` still fires when `getPositionDetail` returns `null`, since the reader will now return `null` more often (on quote failures).
+
+---
+
+## Task Breakdown
+
+### Task 1: Define result types and ok-path quote helper
+
+**Files:**
+
+- Create: `packages/adapters/src/outbound/solana-position-reads/OrcaPositionFeeRewardQuoteHelper.ts`
+- Create: `packages/adapters/src/outbound/solana-position-reads/OrcaPositionFeeRewardQuoteHelper.test.ts`
+
+- [ ] **Step 1: Write the failing test (ok path)**
+
+Create `OrcaPositionFeeRewardQuoteHelper.test.ts` with:
+
+```ts
+/**
+ * OrcaPositionFeeRewardQuoteHelper TDD tests
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { OrcaPositionFeeRewardQuoteHelper } from './OrcaPositionFeeRewardQuoteHelper';
+import type { createSolanaRpc } from '@solana/kit';
+
+vi.mock('@orca-so/whirlpools-client', () => ({
+  getTickArrayAddress: vi.fn(),
+  fetchAllTickArray: vi.fn(),
+}));
+
+vi.mock('@orca-so/whirlpools-core', () => ({
+  getTickArrayStartTickIndex: vi.fn(),
+  getTickIndexInArray: vi.fn(),
+  collectFeesQuote: vi.fn(),
+  collectRewardsQuote: vi.fn(),
+}));
+
+const MOCK_WHIRLPOOL = '7qbRF6YsyGuLUVs6Y1q64bdVrfe4ZcUUz1JRdoVNUJnm';
+const MOCK_POSITION_MINT = '2Wgh4mq6rp1q6H1G6K3ZsR3LBdqT5qVJb5KfF3U7Y2hX';
+const SOL_MINT = 'So11111111111111111111111111111111111111112';
+const USDC_MINT = 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v';
+
+type MockRpc = ReturnType<typeof createSolanaRpc>;
+
+function makePosition(
+  overrides: Partial<{
+    tickLowerIndex: number;
+    tickUpperIndex: number;
+    liquidity: bigint;
+    feeOwedA: bigint;
+    feeOwedB: bigint;
+    rewardInfos: Array<{ amountOwed: bigint; growthInsideCheckpoint: bigint }>;
+  }> = {},
+) {
+  return {
+    whirlpool: MOCK_WHIRLPOOL,
+    tickLowerIndex: -18304,
+    tickUpperIndex: -17956,
+    liquidity: 100000n,
+    feeGrowthCheckpointA: 0n,
+    feeGrowthCheckpointB: 0n,
+    feeOwedA: 999n,
+    feeOwedB: 888n,
+    rewardInfos: [
+      { amountOwed: 777n, growthInsideCheckpoint: 0n },
+      { amountOwed: 0n, growthInsideCheckpoint: 0n },
+      { amountOwed: 0n, growthInsideCheckpoint: 0n },
+    ],
+    ...overrides,
+  };
+}
+
+function makeWhirlpool(
+  overrides: Partial<{
+    tickSpacing: number;
+    rewardInfos: Array<{ mint: { toString: () => string } }>;
+  }> = {},
+) {
+  return {
+    tokenMintA: { toString: () => SOL_MINT },
+    tokenMintB: { toString: () => USDC_MINT },
+    tickSpacing: 64,
+    feeRate: 1000,
+    liquidity: 2400000000n,
+    sqrtPrice: 184467440737095516n,
+    tickCurrentIndex: -18130,
+    feeGrowthGlobalA: 0n,
+    feeGrowthGlobalB: 0n,
+    rewardLastUpdatedTimestamp: 0n,
+    rewardInfos: [
+      { mint: { toString: () => SOL_MINT } },
+      { mint: { toString: () => '11111111111111111111111111111111' } },
+      { mint: { toString: () => '11111111111111111111111111111111' } },
+    ],
+    ...overrides,
+  };
+}
+
+describe('OrcaPositionFeeRewardQuoteHelper', () => {
+  let mockRpc: MockRpc;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRpc = {} as MockRpc;
+  });
+
+  describe('quote', () => {
+    it('returns ok with PositionFees built from collectFeesQuote and collectRewardsQuote', async () => {
+      const { getTickArrayAddress, fetchAllTickArray } = await import('@orca-so/whirlpools-client');
+      const {
+        getTickArrayStartTickIndex,
+        getTickIndexInArray,
+        collectFeesQuote,
+        collectRewardsQuote,
+      } = await import('@orca-so/whirlpools-core');
+
+      vi.mocked(getTickArrayStartTickIndex).mockReturnValueOnce(-22528).mockReturnValueOnce(-22528);
+      vi.mocked(getTickArrayAddress)
+        .mockResolvedValueOnce(['LowerTickArrayAddr1' as never] as never)
+        .mockResolvedValueOnce(['UpperTickArrayAddr1' as never] as never);
+      vi.mocked(getTickIndexInArray).mockReturnValueOnce(5).mockReturnValueOnce(10);
+
+      const lowerTick = { initialized: true, liquidityNet: 0n };
+      const upperTick = { initialized: true, liquidityNet: 0n };
+      vi.mocked(fetchAllTickArray).mockResolvedValue([
+        {
+          data: {
+            ticks: Array.from({ length: 88 }, (_, i) =>
+              i === 5 ? lowerTick : { initialized: false },
+            ),
+          },
+        },
+        {
+          data: {
+            ticks: Array.from({ length: 88 }, (_, i) =>
+              i === 10 ? upperTick : { initialized: false },
+            ),
+          },
+        },
+      ] as never);
+
+      vi.mocked(collectFeesQuote).mockReturnValue({ feeOwedA: 12345n, feeOwedB: 67890n } as never);
+      vi.mocked(collectRewardsQuote).mockReturnValue({
+        rewards: [{ rewardsOwed: 11111n }, { rewardsOwed: 0n }, { rewardsOwed: 0n }],
+      } as never);
+
+      const helper = new OrcaPositionFeeRewardQuoteHelper();
+      const result = await helper.quote({
+        rpc: mockRpc,
+        position: makePosition(),
+        positionMint: MOCK_POSITION_MINT,
+        whirlpool: makeWhirlpool(),
+        whirlpoolAddress: MOCK_WHIRLPOOL,
+      });
+
+      expect(result.kind).toBe('ok');
+      if (result.kind !== 'ok') throw new Error('expected ok');
+      expect(result.fees.feeOwedA).toBe(12345n);
+      expect(result.fees.feeOwedB).toBe(67890n);
+      expect(result.fees.rewardInfos.length).toBe(3);
+      expect(result.fees.rewardInfos[0]!.mint).toBe(SOL_MINT);
+      expect(result.fees.rewardInfos[0]!.amountOwed).toBe(11111n);
+      expect(result.fees.rewardInfos[0]!.decimals).toBe(9);
+      expect(result.fees.rewardInfos[1]!.mint).toBe('11111111111111111111111111111111');
+      expect(result.fees.rewardInfos[1]!.amountOwed).toBe(0n);
+      expect(result.fees.rewardInfos[1]!.decimals).toBeNull();
+    });
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm --filter @clmm/adapters test -- OrcaPositionFeeRewardQuoteHelper`
+Expected: FAIL — `Cannot find module './OrcaPositionFeeRewardQuoteHelper'`.
+
+- [ ] **Step 3: Create helper with types and ok-path implementation**
+
+Create `OrcaPositionFeeRewardQuoteHelper.ts`:
+
+```ts
+/**
+ * OrcaPositionFeeRewardQuoteHelper
+ *
+ * Computes live fee + reward quotes for an Orca position using the Whirlpools
+ * SDK direct quote path. Returns a discriminated `FeeRewardQuoteResult` union;
+ * the caller decides what to log and how to surface unavailability.
+ *
+ * Docs: @orca-so/whirlpools-client v6.2.1, @orca-so/whirlpools-core v3.1.0
+ */
+import type { createSolanaRpc, Address } from '@solana/kit';
+import { getTickArrayAddress, fetchAllTickArray } from '@orca-so/whirlpools-client';
+import {
+  getTickArrayStartTickIndex,
+  getTickIndexInArray,
+  collectFeesQuote,
+  collectRewardsQuote,
+} from '@orca-so/whirlpools-core';
+
+import type { PositionFees, PositionRewardInfo } from '@clmm/domain';
+import { KNOWN_TOKENS } from '../price/known-tokens.js';
+
+type Rpc = ReturnType<typeof createSolanaRpc>;
+
+export type FeeRewardQuoteResult =
+  | { kind: 'ok'; fees: PositionFees }
+  | {
+      kind: 'unavailable';
+      reason:
+        | 'tick-array-fetch-failed'
+        | 'tick-data-missing'
+        | 'fee-quote-failed'
+        | 'reward-quote-failed';
+      errorName?: string;
+      errorMessage?: string;
+    };
+
+type OrcaPosition = {
+  tickLowerIndex: number;
+  tickUpperIndex: number;
+  liquidity: bigint;
+  feeGrowthCheckpointA: bigint;
+  feeGrowthCheckpointB: bigint;
+  feeOwedA: bigint;
+  feeOwedB: bigint;
+  rewardInfos: ReadonlyArray<{ amountOwed: bigint; growthInsideCheckpoint: bigint }>;
+};
+
+type OrcaWhirlpool = {
+  tokenMintA: { toString: () => string };
+  tokenMintB: { toString: () => string };
+  tickSpacing: number;
+  feeRate: number;
+  liquidity: bigint;
+  sqrtPrice: bigint;
+  tickCurrentIndex: number;
+  feeGrowthGlobalA: bigint;
+  feeGrowthGlobalB: bigint;
+  rewardLastUpdatedTimestamp: bigint;
+  rewardInfos: ReadonlyArray<{ mint: { toString: () => string } }>;
+};
+
+export type QuoteArgs = {
+  readonly rpc: Rpc;
+  readonly position: OrcaPosition;
+  readonly positionMint: string;
+  readonly whirlpool: OrcaWhirlpool;
+  readonly whirlpoolAddress: Address | string;
+};
+
+const ERROR_MESSAGE_MAX_LENGTH = 200;
+
+function describeError(err: unknown): { errorName?: string; errorMessage?: string } {
+  if (err instanceof Error) {
+    return {
+      errorName: err.name,
+      errorMessage: err.message.slice(0, ERROR_MESSAGE_MAX_LENGTH),
+    };
+  }
+  return { errorMessage: String(err).slice(0, ERROR_MESSAGE_MAX_LENGTH) };
+}
+
+export class OrcaPositionFeeRewardQuoteHelper {
+  async quote(args: QuoteArgs): Promise<FeeRewardQuoteResult> {
+    const { rpc, position, whirlpool, whirlpoolAddress } = args;
+
+    const lowerStart = getTickArrayStartTickIndex(position.tickLowerIndex, whirlpool.tickSpacing);
+    const upperStart = getTickArrayStartTickIndex(position.tickUpperIndex, whirlpool.tickSpacing);
+
+    let lowerTickArray: { data: { ticks: ReadonlyArray<unknown> } };
+    let upperTickArray: { data: { ticks: ReadonlyArray<unknown> } };
+    try {
+      const [lowerAddr] = await getTickArrayAddress(whirlpoolAddress as Address, lowerStart);
+      const [upperAddr] = await getTickArrayAddress(whirlpoolAddress as Address, upperStart);
+      const [lower, upper] = await fetchAllTickArray(rpc, [lowerAddr, upperAddr]);
+      lowerTickArray = lower as never;
+      upperTickArray = upper as never;
+    } catch (err) {
+      return { kind: 'unavailable', reason: 'tick-array-fetch-failed', ...describeError(err) };
+    }
+
+    const lowerIdx = getTickIndexInArray(
+      position.tickLowerIndex,
+      lowerStart,
+      whirlpool.tickSpacing,
+    );
+    const upperIdx = getTickIndexInArray(
+      position.tickUpperIndex,
+      upperStart,
+      whirlpool.tickSpacing,
+    );
+    const lowerTick = lowerTickArray.data.ticks[lowerIdx];
+    const upperTick = upperTickArray.data.ticks[upperIdx];
+    if (lowerTick == null || upperTick == null) {
+      return { kind: 'unavailable', reason: 'tick-data-missing' };
+    }
+
+    let feesQuote: { feeOwedA: bigint; feeOwedB: bigint };
+    try {
+      feesQuote = collectFeesQuote(
+        whirlpool as never,
+        position as never,
+        lowerTick as never,
+        upperTick as never,
+      );
+    } catch (err) {
+      return { kind: 'unavailable', reason: 'fee-quote-failed', ...describeError(err) };
+    }
+
+    let rewardsQuote: { rewards: ReadonlyArray<{ rewardsOwed: bigint }> };
+    try {
+      const currentUnixTimestamp = BigInt(Math.floor(Date.now() / 1000));
+      rewardsQuote = collectRewardsQuote(
+        whirlpool as never,
+        position as never,
+        lowerTick as never,
+        upperTick as never,
+        currentUnixTimestamp,
+      );
+    } catch (err) {
+      return { kind: 'unavailable', reason: 'reward-quote-failed', ...describeError(err) };
+    }
+
+    const rewardInfos: PositionRewardInfo[] = position.rewardInfos.map((_, idx) => {
+      const poolReward = whirlpool.rewardInfos[idx];
+      const rewardMint = poolReward?.mint?.toString() ?? '';
+      const known = KNOWN_TOKENS[rewardMint];
+      const rewardsOwed = rewardsQuote.rewards[idx]?.rewardsOwed ?? 0n;
+      return {
+        mint: rewardMint,
+        amountOwed: rewardMint === '' ? 0n : rewardsOwed,
+        decimals: known?.decimals ?? null,
+      };
+    });
+
+    const fees: PositionFees = {
+      feeOwedA: feesQuote.feeOwedA,
+      feeOwedB: feesQuote.feeOwedB,
+      rewardInfos,
+    };
+
+    return { kind: 'ok', fees };
+  }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm --filter @clmm/adapters test -- OrcaPositionFeeRewardQuoteHelper`
+Expected: PASS — 1 test in 1 file.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/adapters/src/outbound/solana-position-reads/OrcaPositionFeeRewardQuoteHelper.ts \
+        packages/adapters/src/outbound/solana-position-reads/OrcaPositionFeeRewardQuoteHelper.test.ts
+git commit -m "feat(adapters): add Orca live fee/reward quote helper (ok path)"
+```
+
+---
+
+### Task 2: Quote helper — tick-array fetch failure
+
+**Files:**
+
+- Modify: `packages/adapters/src/outbound/solana-position-reads/OrcaPositionFeeRewardQuoteHelper.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Inside the existing `describe('quote', ...)` block, add:
+
+```ts
+it('returns unavailable with reason "tick-array-fetch-failed" when fetchAllTickArray throws', async () => {
+  const { getTickArrayAddress, fetchAllTickArray } = await import('@orca-so/whirlpools-client');
+  const { getTickArrayStartTickIndex } = await import('@orca-so/whirlpools-core');
+
+  vi.mocked(getTickArrayStartTickIndex).mockReturnValueOnce(-22528).mockReturnValueOnce(-22528);
+  vi.mocked(getTickArrayAddress)
+    .mockResolvedValueOnce(['LowerTickArrayAddr1' as never] as never)
+    .mockResolvedValueOnce(['UpperTickArrayAddr1' as never] as never);
+  vi.mocked(fetchAllTickArray).mockRejectedValue(new Error('rpc 429'));
+
+  const helper = new OrcaPositionFeeRewardQuoteHelper();
+  const result = await helper.quote({
+    rpc: mockRpc,
+    position: makePosition(),
+    positionMint: MOCK_POSITION_MINT,
+    whirlpool: makeWhirlpool(),
+    whirlpoolAddress: MOCK_WHIRLPOOL,
+  });
+
+  expect(result.kind).toBe('unavailable');
+  if (result.kind !== 'unavailable') throw new Error('expected unavailable');
+  expect(result.reason).toBe('tick-array-fetch-failed');
+  expect(result.errorName).toBe('Error');
+  expect(result.errorMessage).toBe('rpc 429');
+});
+```
+
+- [ ] **Step 2: Run test to verify it passes (already implemented in Task 1)**
+
+Run: `pnpm --filter @clmm/adapters test -- OrcaPositionFeeRewardQuoteHelper`
+Expected: PASS — 2 tests.
+
+If it fails, the catch block in `quote` is missing or routes the wrong reason; fix in helper to match.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/adapters/src/outbound/solana-position-reads/OrcaPositionFeeRewardQuoteHelper.test.ts
+git commit -m "test(adapters): cover tick-array-fetch-failed quote helper path"
+```
+
+---
+
+### Task 3: Quote helper — missing lower or upper tick data
+
+**Files:**
+
+- Modify: `packages/adapters/src/outbound/solana-position-reads/OrcaPositionFeeRewardQuoteHelper.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Append inside `describe('quote', ...)`:
+
+```ts
+it('returns unavailable with reason "tick-data-missing" when ticks[idx] is undefined', async () => {
+  const { getTickArrayAddress, fetchAllTickArray } = await import('@orca-so/whirlpools-client');
+  const { getTickArrayStartTickIndex, getTickIndexInArray } =
+    await import('@orca-so/whirlpools-core');
+
+  vi.mocked(getTickArrayStartTickIndex).mockReturnValueOnce(-22528).mockReturnValueOnce(-22528);
+  vi.mocked(getTickArrayAddress)
+    .mockResolvedValueOnce(['LowerTickArrayAddr1' as never] as never)
+    .mockResolvedValueOnce(['UpperTickArrayAddr1' as never] as never);
+  vi.mocked(getTickIndexInArray).mockReturnValueOnce(0).mockReturnValueOnce(99);
+  vi.mocked(fetchAllTickArray).mockResolvedValue([
+    { data: { ticks: [{ initialized: true, liquidityNet: 0n }] } },
+    { data: { ticks: [{ initialized: true, liquidityNet: 0n }] } },
+  ] as never);
+
+  const helper = new OrcaPositionFeeRewardQuoteHelper();
+  const result = await helper.quote({
+    rpc: mockRpc,
+    position: makePosition(),
+    positionMint: MOCK_POSITION_MINT,
+    whirlpool: makeWhirlpool(),
+    whirlpoolAddress: MOCK_WHIRLPOOL,
+  });
+
+  expect(result.kind).toBe('unavailable');
+  if (result.kind !== 'unavailable') throw new Error('expected unavailable');
+  expect(result.reason).toBe('tick-data-missing');
+});
+```
+
+- [ ] **Step 2: Run test to verify it passes**
+
+Run: `pnpm --filter @clmm/adapters test -- OrcaPositionFeeRewardQuoteHelper`
+Expected: PASS — 3 tests.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/adapters/src/outbound/solana-position-reads/OrcaPositionFeeRewardQuoteHelper.test.ts
+git commit -m "test(adapters): cover tick-data-missing quote helper path"
+```
+
+---
+
+### Task 4: Quote helper — fee quote failure
+
+**Files:**
+
+- Modify: `packages/adapters/src/outbound/solana-position-reads/OrcaPositionFeeRewardQuoteHelper.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Append:
+
+```ts
+it('returns unavailable with reason "fee-quote-failed" when collectFeesQuote throws', async () => {
+  const { getTickArrayAddress, fetchAllTickArray } = await import('@orca-so/whirlpools-client');
+  const { getTickArrayStartTickIndex, getTickIndexInArray, collectFeesQuote } =
+    await import('@orca-so/whirlpools-core');
+
+  vi.mocked(getTickArrayStartTickIndex).mockReturnValueOnce(-22528).mockReturnValueOnce(-22528);
+  vi.mocked(getTickArrayAddress)
+    .mockResolvedValueOnce(['LowerTickArrayAddr1' as never] as never)
+    .mockResolvedValueOnce(['UpperTickArrayAddr1' as never] as never);
+  vi.mocked(getTickIndexInArray).mockReturnValueOnce(0).mockReturnValueOnce(0);
+  vi.mocked(fetchAllTickArray).mockResolvedValue([
+    { data: { ticks: [{ initialized: true, liquidityNet: 0n }] } },
+    { data: { ticks: [{ initialized: true, liquidityNet: 0n }] } },
+  ] as never);
+  vi.mocked(collectFeesQuote).mockImplementation(() => {
+    throw new Error('wasm overflow');
+  });
+
+  const helper = new OrcaPositionFeeRewardQuoteHelper();
+  const result = await helper.quote({
+    rpc: mockRpc,
+    position: makePosition(),
+    positionMint: MOCK_POSITION_MINT,
+    whirlpool: makeWhirlpool(),
+    whirlpoolAddress: MOCK_WHIRLPOOL,
+  });
+
+  expect(result.kind).toBe('unavailable');
+  if (result.kind !== 'unavailable') throw new Error('expected unavailable');
+  expect(result.reason).toBe('fee-quote-failed');
+  expect(result.errorMessage).toBe('wasm overflow');
+});
+```
+
+- [ ] **Step 2: Run test to verify it passes**
+
+Run: `pnpm --filter @clmm/adapters test -- OrcaPositionFeeRewardQuoteHelper`
+Expected: PASS — 4 tests.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/adapters/src/outbound/solana-position-reads/OrcaPositionFeeRewardQuoteHelper.test.ts
+git commit -m "test(adapters): cover fee-quote-failed quote helper path"
+```
+
+---
+
+### Task 5: Quote helper — reward quote failure
+
+**Files:**
+
+- Modify: `packages/adapters/src/outbound/solana-position-reads/OrcaPositionFeeRewardQuoteHelper.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Append:
+
+```ts
+it('returns unavailable with reason "reward-quote-failed" when collectRewardsQuote throws', async () => {
+  const { getTickArrayAddress, fetchAllTickArray } = await import('@orca-so/whirlpools-client');
+  const { getTickArrayStartTickIndex, getTickIndexInArray, collectFeesQuote, collectRewardsQuote } =
+    await import('@orca-so/whirlpools-core');
+
+  vi.mocked(getTickArrayStartTickIndex).mockReturnValueOnce(-22528).mockReturnValueOnce(-22528);
+  vi.mocked(getTickArrayAddress)
+    .mockResolvedValueOnce(['LowerTickArrayAddr1' as never] as never)
+    .mockResolvedValueOnce(['UpperTickArrayAddr1' as never] as never);
+  vi.mocked(getTickIndexInArray).mockReturnValueOnce(0).mockReturnValueOnce(0);
+  vi.mocked(fetchAllTickArray).mockResolvedValue([
+    { data: { ticks: [{ initialized: true, liquidityNet: 0n }] } },
+    { data: { ticks: [{ initialized: true, liquidityNet: 0n }] } },
+  ] as never);
+  vi.mocked(collectFeesQuote).mockReturnValue({ feeOwedA: 1n, feeOwedB: 2n } as never);
+  vi.mocked(collectRewardsQuote).mockImplementation(() => {
+    throw new Error('rewards bug');
+  });
+
+  const helper = new OrcaPositionFeeRewardQuoteHelper();
+  const result = await helper.quote({
+    rpc: mockRpc,
+    position: makePosition(),
+    positionMint: MOCK_POSITION_MINT,
+    whirlpool: makeWhirlpool(),
+    whirlpoolAddress: MOCK_WHIRLPOOL,
+  });
+
+  expect(result.kind).toBe('unavailable');
+  if (result.kind !== 'unavailable') throw new Error('expected unavailable');
+  expect(result.reason).toBe('reward-quote-failed');
+  expect(result.errorMessage).toBe('rewards bug');
+});
+```
+
+- [ ] **Step 2: Run test to verify it passes**
+
+Run: `pnpm --filter @clmm/adapters test -- OrcaPositionFeeRewardQuoteHelper`
+Expected: PASS — 5 tests.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/adapters/src/outbound/solana-position-reads/OrcaPositionFeeRewardQuoteHelper.test.ts
+git commit -m "test(adapters): cover reward-quote-failed quote helper path"
+```
+
+---
+
+### Task 6: Quote helper — preserve inactive/empty reward mints without fake entries
+
+**Files:**
+
+- Modify: `packages/adapters/src/outbound/solana-position-reads/OrcaPositionFeeRewardQuoteHelper.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Append:
+
+```ts
+it('keeps empty/inactive reward slots with mint="", decimals=null, amountOwed=0n even when quote returns nonzero', async () => {
+  const { getTickArrayAddress, fetchAllTickArray } = await import('@orca-so/whirlpools-client');
+  const { getTickArrayStartTickIndex, getTickIndexInArray, collectFeesQuote, collectRewardsQuote } =
+    await import('@orca-so/whirlpools-core');
+
+  vi.mocked(getTickArrayStartTickIndex).mockReturnValueOnce(-22528).mockReturnValueOnce(-22528);
+  vi.mocked(getTickArrayAddress)
+    .mockResolvedValueOnce(['LowerTickArrayAddr1' as never] as never)
+    .mockResolvedValueOnce(['UpperTickArrayAddr1' as never] as never);
+  vi.mocked(getTickIndexInArray).mockReturnValueOnce(0).mockReturnValueOnce(0);
+  vi.mocked(fetchAllTickArray).mockResolvedValue([
+    { data: { ticks: [{ initialized: true, liquidityNet: 0n }] } },
+    { data: { ticks: [{ initialized: true, liquidityNet: 0n }] } },
+  ] as never);
+  vi.mocked(collectFeesQuote).mockReturnValue({ feeOwedA: 0n, feeOwedB: 0n } as never);
+  vi.mocked(collectRewardsQuote).mockReturnValue({
+    rewards: [{ rewardsOwed: 50n }, { rewardsOwed: 50n }, { rewardsOwed: 50n }],
+  } as never);
+
+  const helper = new OrcaPositionFeeRewardQuoteHelper();
+  const result = await helper.quote({
+    rpc: mockRpc,
+    position: makePosition(),
+    positionMint: MOCK_POSITION_MINT,
+    whirlpool: makeWhirlpool({
+      rewardInfos: [
+        { mint: { toString: () => '' } },
+        { mint: { toString: () => '' } },
+        { mint: { toString: () => '' } },
+      ],
+    }),
+    whirlpoolAddress: MOCK_WHIRLPOOL,
+  });
+
+  expect(result.kind).toBe('ok');
+  if (result.kind !== 'ok') throw new Error('expected ok');
+  expect(result.fees.rewardInfos.length).toBe(3);
+  for (const ri of result.fees.rewardInfos) {
+    expect(ri.mint).toBe('');
+    expect(ri.decimals).toBeNull();
+    expect(ri.amountOwed).toBe(0n);
+  }
+});
+```
+
+- [ ] **Step 2: Run test to verify it passes**
+
+Run: `pnpm --filter @clmm/adapters test -- OrcaPositionFeeRewardQuoteHelper`
+Expected: PASS — 6 tests.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/adapters/src/outbound/solana-position-reads/OrcaPositionFeeRewardQuoteHelper.test.ts
+git commit -m "test(adapters): preserve empty reward slots in quote helper"
+```
+
+---
+
+### Task 7: Wire helper into reader; log warning; return null on unavailable
+
+**Files:**
+
+- Modify: `packages/adapters/src/outbound/solana-position-reads/SolanaPositionSnapshotReader.ts`
+- Modify: `packages/adapters/src/outbound/solana-position-reads/SolanaPositionSnapshotReader.test.ts`
+
+- [ ] **Step 1: Write the failing test (ok path through reader → helper)**
+
+Append to `SolanaPositionSnapshotReader.test.ts` (inside the top-level `describe('SolanaPositionSnapshotReader', ...)`):
+
+```ts
+describe('fetchPositionDetail', () => {
+  const SOL_MINT = 'So11111111111111111111111111111111111111112';
+  const USDC_MINT = 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v';
+
+  function setupHappyMocks() {
+    return import('@orca-so/whirlpools-client').then(
+      ({ getPositionAddress, fetchPosition, fetchWhirlpool }) => {
+        vi.mocked(getPositionAddress).mockResolvedValue([
+          address(MOCK_POSITION_PDA),
+        ] as unknown as Awaited<ReturnType<typeof getPositionAddress>>);
+        vi.mocked(fetchPosition).mockResolvedValue({
+          data: {
+            whirlpool: address(MOCK_WHIRLPOOL),
+            tickLowerIndex: -18304,
+            tickUpperIndex: -17956,
+            liquidity: 1000n,
+            feeGrowthCheckpointA: 0n,
+            feeGrowthCheckpointB: 0n,
+            feeOwedA: 9999n,
+            feeOwedB: 8888n,
+            positionMint: address(MOCK_POSITION_MINT),
+            rewardInfos: [
+              { amountOwed: 7777n, growthInsideCheckpoint: 0n },
+              { amountOwed: 0n, growthInsideCheckpoint: 0n },
+              { amountOwed: 0n, growthInsideCheckpoint: 0n },
+            ],
+          },
+        } as unknown as Awaited<ReturnType<typeof fetchPosition>>);
+        vi.mocked(fetchWhirlpool).mockResolvedValue({
+          data: {
+            tickCurrentIndex: -18130,
+            sqrtPrice: 184467440737095516n,
+            tokenMintA: { toString: () => SOL_MINT },
+            tokenMintB: { toString: () => USDC_MINT },
+            feeRate: 1000,
+            tickSpacing: 64,
+            liquidity: 2400000000n,
+            rewardInfos: [
+              { mint: { toString: () => SOL_MINT } },
+              { mint: { toString: () => '11111111111111111111111111111111' } },
+              { mint: { toString: () => '11111111111111111111111111111111' } },
+            ],
+          },
+        } as unknown as Awaited<ReturnType<typeof fetchWhirlpool>>);
+      },
+    );
+  }
+
+  it('returns detail with live fees from helper when quote succeeds', async () => {
+    await setupHappyMocks();
+
+    const helper = {
+      quote: vi.fn().mockResolvedValue({
+        kind: 'ok',
+        fees: {
+          feeOwedA: 12345n,
+          feeOwedB: 67890n,
+          rewardInfos: [{ mint: SOL_MINT, amountOwed: 11111n, decimals: 9 }],
+        },
+      }),
+    };
+    const reader = new SolanaPositionSnapshotReader(mockRpcUrl, undefined, helper as never);
+    const result = await reader.fetchPositionDetail(
+      mockRpcWithOwnership as never,
+      MOCK_POSITION_MINT,
+      MOCK_WALLET,
+    );
+
+    expect(result).not.toBeNull();
+    expect(result!.fees.feeOwedA).toBe(12345n);
+    expect(result!.fees.feeOwedB).toBe(67890n);
+    expect(helper.quote).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns null and logs orca_position_fee_reward_quote_unavailable warn when helper returns unavailable', async () => {
+    await setupHappyMocks();
+
+    const helper = {
+      quote: vi.fn().mockResolvedValue({
+        kind: 'unavailable',
+        reason: 'fee-quote-failed',
+        errorName: 'Error',
+        errorMessage: 'wasm overflow',
+      }),
+    };
+    const observability = {
+      log: vi.fn(),
+      recordTiming: vi.fn(),
+      recordDetectionTiming: vi.fn(),
+      recordDeliveryTiming: vi.fn(),
+    };
+    const reader = new SolanaPositionSnapshotReader(
+      mockRpcUrl,
+      observability as never,
+      helper as never,
+    );
+    const result = await reader.fetchPositionDetail(
+      mockRpcWithOwnership as never,
+      MOCK_POSITION_MINT,
+      MOCK_WALLET,
+    );
+
+    expect(result).toBeNull();
+    expect(observability.log).toHaveBeenCalledTimes(1);
+    expect(observability.log).toHaveBeenCalledWith(
+      'warn',
+      'orca_position_fee_reward_quote_unavailable',
+      expect.objectContaining({
+        positionId: MOCK_POSITION_MINT,
+        walletId: MOCK_WALLET,
+        poolId: MOCK_WHIRLPOOL,
+        lowerTick: -18304,
+        upperTick: -17956,
+        tickSpacing: 64,
+        reason: 'fee-quote-failed',
+        errorName: 'Error',
+        errorMessage: 'wasm overflow',
+      }),
+    );
+  });
+
+  it('does not fall back to checkpointed pos.feeOwedA / pos.feeOwedB / pos.rewardInfos[].amountOwed on quote failure', async () => {
+    await setupHappyMocks();
+
+    const helper = {
+      quote: vi.fn().mockResolvedValue({
+        kind: 'unavailable',
+        reason: 'tick-array-fetch-failed',
+      }),
+    };
+    const observability = {
+      log: vi.fn(),
+      recordTiming: vi.fn(),
+      recordDetectionTiming: vi.fn(),
+      recordDeliveryTiming: vi.fn(),
+    };
+    const reader = new SolanaPositionSnapshotReader(
+      mockRpcUrl,
+      observability as never,
+      helper as never,
+    );
+    const result = await reader.fetchPositionDetail(
+      mockRpcWithOwnership as never,
+      MOCK_POSITION_MINT,
+      MOCK_WALLET,
+    );
+
+    expect(result).toBeNull();
+    const stringified = JSON.stringify(observability.log.mock.calls, (_k, v) =>
+      typeof v === 'bigint' ? v.toString() : v,
+    );
+    expect(stringified).not.toContain('9999');
+    expect(stringified).not.toContain('8888');
+    expect(stringified).not.toContain('7777');
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pnpm --filter @clmm/adapters test -- SolanaPositionSnapshotReader`
+Expected: FAIL — `SolanaPositionSnapshotReader` constructor takes only `rpcUrl`; passing extra args is a TS error or ignored at runtime, and `fetchPositionDetail` still maps raw fields.
+
+- [ ] **Step 3: Update reader to accept observability + helper and delegate**
+
+Replace `SolanaPositionSnapshotReader.ts` with:
+
+```ts
+/**
+ * SolanaPositionSnapshotReader
+ *
+ * Fetches a single position snapshot from Solana using @solana/kit and @orca-so/whirlpools-client.
+ * This reader is used for detailed position inspection and is not responsible for
+ * determining breach direction or exit posture - that lives in packages/domain.
+ *
+ * Live fee/reward computation for fetchPositionDetail is delegated to
+ * OrcaPositionFeeRewardQuoteHelper. Checkpointed fields on the Orca position
+ * account are NEVER mapped into returned PositionFees; quote failures fail
+ * closed (return null) and emit a single structured warning via the
+ * ObservabilityPort, when one is supplied.
+ *
+ * Docs: @solana/kit v6, @orca-so/whirlpools-client v6.2.1
+ */
+import { createSolanaRpc, address } from '@solana/kit';
+import { getPositionAddress, fetchPosition, fetchWhirlpool } from '@orca-so/whirlpools-client';
+
+import type { ObservabilityPort } from '@clmm/application';
+import type { LiquidityPosition, WalletId, PositionId, PoolData, PositionFees } from '@clmm/domain';
+import { makePoolId, makeClockTimestamp, evaluateRangeState } from '@clmm/domain';
+import { KNOWN_TOKENS } from '../price/known-tokens.js';
+import { OrcaPositionFeeRewardQuoteHelper } from './OrcaPositionFeeRewardQuoteHelper.js';
+
+export type WhirlpoolData = {
+  tickCurrentIndex: number;
+  sqrtPrice: bigint;
+  tokenMintA: string;
+  tokenMintB: string;
+  feeRate: number;
+  tickSpacing: number;
+  liquidity: bigint;
+};
+
+export class SolanaPositionSnapshotReader {
+  constructor(
+    private readonly rpcUrl: string,
+    private readonly observability?: ObservabilityPort,
+    private readonly quoteHelper: OrcaPositionFeeRewardQuoteHelper = new OrcaPositionFeeRewardQuoteHelper(),
+  ) {}
+
+  getRpc() {
+    return createSolanaRpc(this.rpcUrl);
+  }
+
+  async fetchSinglePosition(
+    rpc: ReturnType<typeof createSolanaRpc>,
+    positionId: PositionId,
+    walletId: WalletId,
+  ): Promise<LiquidityPosition | null> {
+    try {
+      const positionMint = address(positionId);
+      const [positionAddress] = await getPositionAddress(positionMint);
+      const positionAccount = await fetchPosition(rpc, positionAddress);
+      const position = positionAccount.data;
+
+      const isOwner = await this.verifyOwnership(rpc, walletId, positionId);
+      if (!isOwner) {
+        return null;
+      }
+
+      const whirlpoolAddress = position.whirlpool;
+      const whirlpoolAccount = await fetchWhirlpool(rpc, whirlpoolAddress);
+      const whirlpool = whirlpoolAccount.data;
+
+      const bounds = {
+        lowerBound: position.tickLowerIndex,
+        upperBound: position.tickUpperIndex,
+      };
+
+      const currentTick = whirlpool.tickCurrentIndex;
+      const rangeState = evaluateRangeState(bounds, currentTick);
+
+      return {
+        positionId,
+        walletId,
+        poolId: makePoolId(whirlpoolAddress.toString()),
+        bounds,
+        lastObservedAt: makeClockTimestamp(Date.now()),
+        rangeState,
+        monitoringReadiness: { kind: 'active' },
+      };
+    } catch {
+      return null;
+    }
+  }
+
+  async verifyOwnership(
+    rpc: ReturnType<typeof createSolanaRpc>,
+    walletId: WalletId,
+    positionId: PositionId,
+  ): Promise<boolean> {
+    try {
+      const ownerAddress = address(walletId);
+      const mintAddress = address(positionId);
+
+      const response = await rpc
+        .getTokenAccountsByOwner(ownerAddress, { mint: mintAddress }, { encoding: 'jsonParsed' })
+        .send();
+
+      return response.value.some(
+        (account) => BigInt(account.account.data.parsed.info.tokenAmount.amount) > 0n,
+      );
+    } catch {
+      return false;
+    }
+  }
+
+  async fetchWhirlpoolsBatched(
+    rpc: ReturnType<typeof createSolanaRpc>,
+    whirlpoolAddresses: string[],
+  ): Promise<Map<string, WhirlpoolData>> {
+    const uniqueAddresses = [...new Set(whirlpoolAddresses)];
+    const results = new Map<string, WhirlpoolData>();
+
+    if (uniqueAddresses.length === 0) {
+      return results;
+    }
+
+    const WHIRLPOOL_FETCH_BATCH_SIZE = 2;
+
+    for (let i = 0; i < uniqueAddresses.length; i += WHIRLPOOL_FETCH_BATCH_SIZE) {
+      const batch = uniqueAddresses.slice(i, i + WHIRLPOOL_FETCH_BATCH_SIZE);
+
+      await Promise.all(
+        batch.map(async (addr) => {
+          try {
+            const whirlpoolAccount = await fetchWhirlpool(rpc, address(addr));
+            const w = whirlpoolAccount.data;
+            results.set(addr, {
+              tickCurrentIndex: w.tickCurrentIndex,
+              sqrtPrice: w.sqrtPrice,
+              tokenMintA: w.tokenMintA.toString(),
+              tokenMintB: w.tokenMintB.toString(),
+              feeRate: w.feeRate,
+              tickSpacing: w.tickSpacing,
+              liquidity: w.liquidity,
+            });
+          } catch {
+            // Skip failed fetches — positions referencing this pool will be excluded.
+          }
+        }),
+      );
+    }
+
+    return results;
+  }
+
+  async fetchPositionDetail(
+    rpc: ReturnType<typeof createSolanaRpc>,
+    positionId: PositionId,
+    walletId: WalletId,
+  ): Promise<{
+    position: LiquidityPosition;
+    poolData: PoolData;
+    fees: PositionFees;
+    positionLiquidity: bigint;
+  } | null> {
+    let positionMint;
+    let positionAddress;
+    let positionAccount;
+    try {
+      positionMint = address(positionId);
+      [positionAddress] = await getPositionAddress(positionMint);
+      positionAccount = await fetchPosition(rpc, positionAddress);
+    } catch {
+      return null;
+    }
+    const pos = positionAccount.data;
+
+    const isOwner = await this.verifyOwnership(rpc, walletId, positionId);
+    if (!isOwner) {
+      return null;
+    }
+
+    let whirlpoolAddress;
+    let whirlpoolAccount;
+    try {
+      whirlpoolAddress = pos.whirlpool;
+      whirlpoolAccount = await fetchWhirlpool(rpc, whirlpoolAddress);
+    } catch {
+      return null;
+    }
+    const w = whirlpoolAccount.data;
+
+    const poolIdStr = whirlpoolAddress.toString();
+    const mintA = w.tokenMintA.toString();
+    const mintB = w.tokenMintB.toString();
+    const knownA = KNOWN_TOKENS[mintA];
+    const knownB = KNOWN_TOKENS[mintB];
+
+    const poolData: PoolData = {
+      poolId: makePoolId(poolIdStr),
+      tokenPair: {
+        mintA,
+        mintB,
+        symbolA: knownA?.symbol ?? mintA,
+        symbolB: knownB?.symbol ?? mintB,
+        decimalsA: knownA?.decimals ?? null,
+        decimalsB: knownB?.decimals ?? null,
+      },
+      sqrtPrice: w.sqrtPrice,
+      feeRate: w.feeRate,
+      tickSpacing: w.tickSpacing,
+      liquidity: w.liquidity,
+      tickCurrentIndex: w.tickCurrentIndex,
+    };
+
+    const quote = await this.quoteHelper.quote({
+      rpc,
+      position: pos as never,
+      positionMint: positionId,
+      whirlpool: w as never,
+      whirlpoolAddress,
+    });
+
+    if (quote.kind !== 'ok') {
+      this.observability?.log('warn', 'orca_position_fee_reward_quote_unavailable', {
+        positionId,
+        walletId,
+        poolId: poolIdStr,
+        lowerTick: pos.tickLowerIndex,
+        upperTick: pos.tickUpperIndex,
+        tickSpacing: w.tickSpacing,
+        reason: quote.reason,
+        ...(quote.errorName !== undefined ? { errorName: quote.errorName } : {}),
+        ...(quote.errorMessage !== undefined ? { errorMessage: quote.errorMessage } : {}),
+      });
+      return null;
+    }
+
+    const bounds = {
+      lowerBound: pos.tickLowerIndex,
+      upperBound: pos.tickUpperIndex,
+    };
+
+    const rangeState = evaluateRangeState(bounds, w.tickCurrentIndex);
+
+    const position: LiquidityPosition = {
+      positionId,
+      walletId,
+      poolId: makePoolId(poolIdStr),
+      bounds,
+      lastObservedAt: makeClockTimestamp(Date.now()),
+      rangeState,
+      monitoringReadiness: { kind: 'active' },
+    };
+
+    return {
+      position,
+      poolData,
+      fees: quote.fees,
+      positionLiquidity: pos.liquidity,
+    };
+  }
+}
+```
+
+- [ ] **Step 4: Run reader tests to verify they pass**
+
+Run: `pnpm --filter @clmm/adapters test -- SolanaPositionSnapshotReader`
+Expected: PASS — pre-existing tests + 3 new `fetchPositionDetail` tests.
+
+- [ ] **Step 5: Run the full adapter package test suite to catch regressions**
+
+Run: `pnpm --filter @clmm/adapters test`
+Expected: PASS. If `OrcaPositionReadAdapter.test.ts` or other reader callers break, they'd be due to constructor positional-arg confusion — fix call sites, not the new optional-arg signature.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/adapters/src/outbound/solana-position-reads/SolanaPositionSnapshotReader.ts \
+        packages/adapters/src/outbound/solana-position-reads/SolanaPositionSnapshotReader.test.ts
+git commit -m "feat(adapters): delegate fetchPositionDetail fees/rewards to live quote helper"
+```
+
+---
+
+### Task 8: Wire ObservabilityPort through composition
+
+**Files:**
+
+- Modify: `packages/adapters/src/composition/AdaptersModule.ts:61`
+- Modify: `packages/adapters/src/inbound/http/AppModule.ts:92`
+
+- [ ] **Step 1: Update `AppModule.ts`**
+
+In `packages/adapters/src/inbound/http/AppModule.ts`, the order of `const telemetry = new TelemetryAdapter();` is currently after `snapshotReader` is constructed. Move the telemetry instantiation up so it can be passed in. Replace lines 92 and the surrounding telemetry init:
+
+Find:
+
+```ts
+const snapshotReader = new SolanaPositionSnapshotReader(rpcUrl);
+```
+
+Replace with:
+
+```ts
+const telemetryEarly = new TelemetryAdapter();
+const snapshotReader = new SolanaPositionSnapshotReader(rpcUrl, telemetryEarly);
+```
+
+Then find the existing `const telemetry = new TelemetryAdapter();` later in the file and replace with:
+
+```ts
+const telemetry = telemetryEarly;
+```
+
+This keeps a single shared `TelemetryAdapter` instance for both the reader and the DI container.
+
+- [ ] **Step 2: Update `AdaptersModule.ts`**
+
+In `packages/adapters/src/composition/AdaptersModule.ts`, do the same. Find:
+
+```ts
+const snapshotReader = new SolanaPositionSnapshotReader(rpcUrl);
+```
+
+Replace with:
+
+```ts
+const telemetryEarly = new TelemetryAdapter();
+const snapshotReader = new SolanaPositionSnapshotReader(rpcUrl, telemetryEarly);
+```
+
+Then find the existing `const telemetry = new TelemetryAdapter();` and replace with:
+
+```ts
+const telemetry = telemetryEarly;
+```
+
+- [ ] **Step 3: Run adapter typecheck and tests**
+
+Run: `pnpm --filter @clmm/adapters typecheck && pnpm --filter @clmm/adapters test`
+Expected: PASS for both.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/adapters/src/composition/AdaptersModule.ts \
+        packages/adapters/src/inbound/http/AppModule.ts
+git commit -m "feat(adapters): wire ObservabilityPort into SolanaPositionSnapshotReader"
+```
+
+---
+
+### Task 9: Verify insights endpoints still surface 503 position_detail_unavailable
+
+**Files:**
+
+- Read-only: `packages/adapters/src/inbound/http/InsightsDataController.test.ts:167-186` (single-position case)
+- Read-only: `packages/adapters/src/inbound/http/InsightsDataController.test.ts:227-246` (bundle case)
+
+- [ ] **Step 1: Run the insights controller test suite directly**
+
+Run: `pnpm --filter @clmm/adapters test -- InsightsDataController`
+Expected: PASS — both `position_detail_unavailable` cases still return HTTP 503 because the controller branches on `getPositionDetail` returning `null`/throwing, and the reader continues to return `null` on quote failure.
+
+- [ ] **Step 2: Run application package tests**
+
+Run: `pnpm --filter @clmm/application test`
+Expected: PASS — domain DTO shapes (`PositionFees`, `PositionDetail`) are unchanged, so application use-cases compile and behave identically.
+
+No commit on this task; it is verification only. If a test fails, treat it as a regression and fix the implementation before proceeding.
+
+---
+
+### Task 10: Verify root typecheck and document fence completion
+
+**Files:** none modified.
+
+- [ ] **Step 1: Run root typecheck**
+
+Run: `pnpm typecheck`
+Expected: PASS. Domain types and exported adapter types are unchanged; only the internal reader constructor gained two optional params.
+
+- [ ] **Step 2: Run the full adapter package test suite one more time**
+
+Run: `pnpm --filter @clmm/adapters test`
+Expected: PASS — confirms helper tests, reader tests, and existing controller tests all green.
+
+- [ ] **Step 3: Spot-verify no leftover stale-field reads in fetchPositionDetail**
+
+Run: `grep -n "feeOwedA\\|feeOwedB\\|amountOwed" packages/adapters/src/outbound/solana-position-reads/SolanaPositionSnapshotReader.ts`
+Expected: empty output (no matches). The helper still reads `feeOwedA`/`feeOwedB` from the SDK's `CollectFeesQuote`, but the reader no longer references those names directly.
+
+If the grep matches, find the source location and remove the stale-field mapping — failing closed is the rule.
+
+- [ ] **Step 4: No commit needed if verification passes; otherwise fix and recommit per task above.**
+
+---
+
+## Spec Coverage Summary
+
+- Helper at `packages/adapters/src/outbound/solana-position-reads/OrcaPositionFeeRewardQuoteHelper.ts` — Task 1.
+- Helper wired only into `fetchPositionDetail` — Task 7.
+- Domain `PositionFees` shape preserved — types in Task 1 use existing exports unchanged.
+- Application DTOs and HTTP contracts preserved — verified Task 9; no controller code is touched.
+- Structured observability for quote failures (`orca_position_fee_reward_quote_unavailable` warn with documented context) — Task 7 + Task 8 wires it.
+- Adapter and existing endpoint behavior tests — Tasks 1–7, 9, 10.
+- Out-of-scope items (no `harvestPositionInstructions`, no `feeQuoteStatus`, no list-card changes, no summary fee/reward fields) — none added.
+
+## Self-Review Notes
+
+- All `kind` arms of `FeeRewardQuoteResult` (`ok`, four `unavailable` reasons) are covered by tests in Tasks 1–6.
+- Reader constructor adds `observability?` and `quoteHelper` with default — backwards-compatible for any caller that constructs with `(rpcUrl)` alone (`SolanaExecutionPreparationAdapter` is unaffected).
+- Task 7 explicitly asserts no checkpointed `9999n / 8888n / 7777n` value leaks into either the returned detail (it's `null`) or the log payload, satisfying the "do not fall back to stale fields" requirement.
+- Inactive reward mints get `mint='', decimals=null, amountOwed=0n` — Task 6 pins this behavior.
+- Log context fields match the spec exactly: `positionId`, `walletId`, `poolId`, `lowerTick`, `upperTick`, `tickSpacing`, `reason`, optional `errorName`, optional capped `errorMessage` (200-char cap implemented in helper).

--- a/docs/superpowers/specs/2026-05-07-orca-live-fee-reward-quotes-design.md
+++ b/docs/superpowers/specs/2026-05-07-orca-live-fee-reward-quotes-design.md
@@ -1,0 +1,169 @@
+# Orca Live Fee And Reward Quotes Design
+
+## Goal
+
+Fix issue #61 by stopping the detail and insights read paths from exposing Orca checkpointed fee and reward account fields as if they were current unclaimed values.
+
+The fix computes live fee and reward quotes for position detail reads using Orca's direct quote path. If live quote computation cannot complete, the detail read fails closed for that request. It must not fall back to stale `feeOwedA`, `feeOwedB`, or `rewardInfos[].amountOwed` values from the Orca position account.
+
+## Scope
+
+In scope:
+
+- Add a reusable adapter-local live quote helper.
+- Wire the helper only into `SolanaPositionSnapshotReader.fetchPositionDetail`.
+- Preserve the existing domain-facing `PositionFees` shape.
+- Preserve existing application DTOs and HTTP contracts.
+- Add structured observability for quote computation failures.
+- Add focused adapter and existing endpoint behavior tests.
+
+Out of scope:
+
+- Redesigning `listSupportedPositions`.
+- Adding fee or reward data to summary DTOs.
+- Changing list-card API contracts.
+- Introducing partial detail responses or `feeQuoteStatus`.
+- Using `harvestPositionInstructions` or harvest instruction generation for this read path.
+
+## Current Problem
+
+`packages/adapters/src/outbound/solana-position-reads/SolanaPositionSnapshotReader.ts` currently maps raw Orca position account fields into returned `PositionFees`:
+
+```ts
+feeOwedA: pos.feeOwedA,
+feeOwedB: pos.feeOwedB,
+```
+
+It also maps `pos.rewardInfos[].amountOwed` into reward entries. These fields are checkpointed on-chain values. They only reflect fees and rewards recorded during the last position-modifying interaction or fee/reward update. Between interactions they can remain zero even when the Orca app shows pending fees or rewards.
+
+The affected read path feeds:
+
+- `GET /positions/:walletId/:positionId`
+- `GET /insights/sol-usdc/positions/:walletId`
+- `GET /insights/sol-usdc/bundle/:walletId`
+
+## Architecture
+
+Keep the fix entirely in `packages/adapters`.
+
+`packages/domain` continues to own only the existing `PositionFees` shape. `packages/application` continues to consume `PositionDetail` without knowing how Orca live fee/reward quotes are computed.
+
+Add a small adapter-local helper near the existing Solana position reader:
+
+```text
+packages/adapters/src/outbound/solana-position-reads/OrcaPositionFeeRewardQuoteHelper.ts
+```
+
+The helper accepts the RPC client plus already-fetched Orca position and whirlpool data. It derives and fetches the lower and upper tick data required by Orca's quote utilities, calls the direct fee and reward quote path, and maps successful output into the existing domain-facing `PositionFees` shape.
+
+`SolanaPositionSnapshotReader.fetchPositionDetail` delegates fee/reward computation to this helper. It may still fetch and pass the Orca position account, but it must no longer map raw checkpointed `pos.feeOwedA`, `pos.feeOwedB`, or `pos.rewardInfos[].amountOwed` into returned detail data.
+
+`listSupportedPositions`, summary DTOs, and list-card contracts remain unchanged.
+
+Quote failure fails closed. The helper returns an explicit result union. On unavailable quote computation, the detail read path logs structured context and returns unavailable/null through the existing contract. It must not fall back to stale Orca account owed fields.
+
+Composition changes are limited to giving the detail read path a lightweight logger/observability dependency, preferably by passing the existing `ObservabilityPort` from the adapter composition layer. No domain/application DTO contract changes are introduced in this issue.
+
+## Components And Data Flow
+
+The helper exposes one method with this result union:
+
+```ts
+type FeeRewardQuoteResult =
+  | { kind: 'ok'; fees: PositionFees }
+  | {
+      kind: 'unavailable';
+      reason:
+        | 'tick-array-fetch-failed'
+        | 'tick-data-missing'
+        | 'fee-quote-failed'
+        | 'reward-quote-failed';
+      errorName?: string;
+      errorMessage?: string;
+    };
+```
+
+`fetchPositionDetail` flow becomes:
+
+1. Fetch position PDA/account and verify wallet ownership.
+2. Fetch whirlpool account and build `PoolData` as it does today.
+3. Call `OrcaPositionFeeRewardQuoteHelper.quote({ rpc, position: pos, positionMint, whirlpool: w, whirlpoolAddress })`.
+4. If `ok`, use `fees` in the returned `PositionDetail`.
+5. If `unavailable`, log a structured warning from the caller with `positionId`, `walletId`, `poolId`, `lowerTick`, `upperTick`, `tickSpacing`, `reason`, and sanitized `errorName`/`errorMessage` if available, then return `null`.
+
+The helper owns all Orca-specific quote plumbing:
+
+- tick-array address derivation
+- lower/upper tick extraction
+- `collectFeesQuote`
+- `collectRewardsQuote`
+- conversion of reward quote entries into `PositionRewardInfo[]` using pool reward mints and `KNOWN_TOKENS` decimals
+
+Inactive or empty reward mints preserve the existing empty-mint/null-decimals behavior and must not create fake reward entries.
+
+No raw checkpointed `pos.feeOwedA`, `pos.feeOwedB`, or `pos.rewardInfos[].amountOwed` values are mapped into returned `PositionFees`.
+
+## Error Handling And Observability
+
+Fail closed is the behavioral rule. Any inability to compute the live quote makes the detail unavailable for that read, even if the raw Orca position account has checkpointed values.
+
+The helper catches expected quote plumbing failures and classifies them into the result-union reasons. Unexpected Orca/RPC/SDK errors inside the quote helper are also classified as `unavailable`; they do not fall through to stale field mapping.
+
+The helper should avoid logging itself unless there is a strong local reason. The caller has the request context and emits the operational log once.
+
+The structured warning uses the existing `ObservabilityPort.log('warn', ...)` path with this stable event name:
+
+```text
+orca_position_fee_reward_quote_unavailable
+```
+
+The log context should include:
+
+- `positionId`
+- `walletId`
+- `poolId`
+- `lowerTick`
+- `upperTick`
+- `tickSpacing`
+- `reason`
+- `errorName`, if available
+- sanitized, length-capped `errorMessage`, if available
+
+Do not log raw RPC responses, SDK response blobs, account data, or full error objects.
+
+Existing endpoint behavior remains:
+
+- `/positions/:walletId/:positionId`: quote failure currently flows through the existing `null` contract and is returned as 404. This is a known semantic compromise to avoid widening the contract in this issue. Operational logs must distinguish quote failure from true position absence.
+- `/insights/sol-usdc/positions/:walletId` and `/insights/sol-usdc/bundle/:walletId`: position detail unavailable maps to the existing 503 `position_detail_unavailable`.
+
+This issue does not introduce `feeQuoteStatus`, partial detail responses, or a new HTTP status contract. That belongs in a later API-contract issue.
+
+## Testing
+
+Testing stays narrow and mostly adapter-level. No live Orca or Solana RPC calls in tests.
+
+Required tests:
+
+- quote helper returns `ok` with `PositionFees` built from mocked `collectFeesQuote` and `collectRewardsQuote`
+- quote helper returns `unavailable` for tick-array fetch failure
+- quote helper returns `unavailable` for missing lower or upper tick data
+- quote helper returns `unavailable` for fee quote failure
+- quote helper returns `unavailable` for reward quote failure
+- quote helper preserves inactive/empty reward mints without fake reward entries
+- `fetchPositionDetail` returns `null` when the helper returns `unavailable`
+- raw checkpointed Orca `pos.feeOwedA`, `pos.feeOwedB`, and `pos.rewardInfos[].amountOwed` are not used as fallback when quote fails
+- caller emits exactly one `orca_position_fee_reward_quote_unavailable` warning with identifiers, reason, and capped sanitized error fields
+- insights positions and bundle preserve existing 503 `position_detail_unavailable` behavior when detail is unavailable
+
+Suggested verification:
+
+- `pnpm --filter @clmm/adapters test`
+- `pnpm --filter @clmm/application test`
+- `pnpm --filter @clmm/adapters typecheck`
+- `pnpm typecheck` if implementation touches shared exported types or composition in a way that broadens risk
+
+## References
+
+- GitHub issue: `https://github.com/opsclawd/clmm-v2/issues/61`
+- Orca harvest docs: `https://github.com/orca-so/whirlpools/blob/main/docs/whirlpool/docs/03-SDKs/04-Position%20Management/03-Harvest.mdx`
+- Orca Whirlpools SDK README: `https://github.com/orca-so/whirlpools/blob/main/ts-sdk/whirlpool/README.md`

--- a/packages/adapters/package.json
+++ b/packages/adapters/package.json
@@ -25,6 +25,7 @@
     "@nestjs/platform-fastify": "^10.0.0",
     "@orca-so/whirlpools": "^7.0.2",
     "@orca-so/whirlpools-client": "^6.2.1",
+    "@orca-so/whirlpools-core": "3.1.0",
     "@solana-mobile/mobile-wallet-adapter-protocol": "^2.2.6",
     "@solana-mobile/mobile-wallet-adapter-protocol-kit": "^0.2.3",
     "@solana/kit": "^6.5.0",

--- a/packages/adapters/src/composition/AdaptersModule.ts
+++ b/packages/adapters/src/composition/AdaptersModule.ts
@@ -58,7 +58,8 @@ const systemIds: IdGeneratorPort = {
   generateId: () => `${Date.now()}-${++_idCounter}`,
 };
 
-const snapshotReader = new SolanaPositionSnapshotReader(rpcUrl);
+const telemetryEarly = new TelemetryAdapter();
+const snapshotReader = new SolanaPositionSnapshotReader(rpcUrl, telemetryEarly);
 const orcaPositionRead = new OrcaPositionReadAdapter(rpcUrl, snapshotReader, db);
 const rangeObservation = new SolanaRangeObservationAdapter(rpcUrl);
 const operationalStorage = new OperationalStorageAdapter(db, systemIds);
@@ -68,7 +69,7 @@ const notificationDedupStorage = new NotificationDedupStorageAdapter(db);
 const solanaPreparation = new SolanaExecutionPreparationAdapter(rpcUrl, snapshotReader);
 const solanaSubmission = new SolanaExecutionSubmissionAdapter(rpcUrl);
 const durableNotificationEvent = new DurableNotificationEventAdapter(db, systemIds);
-const telemetry = new TelemetryAdapter();
+const telemetry = telemetryEarly;
 const regimeEngineBaseUrl =
   (process.env as Record<string, string | undefined>)['REGIME_ENGINE_BASE_URL'] ?? null;
 const regimeEngineInternalToken =

--- a/packages/adapters/src/inbound/http/AppModule.ts
+++ b/packages/adapters/src/inbound/http/AppModule.ts
@@ -89,7 +89,8 @@ const systemIds: IdGeneratorPort = {
   generateId: () => `${Date.now()}-${++_idCounter}`,
 };
 
-const snapshotReader = new SolanaPositionSnapshotReader(rpcUrl);
+const telemetryEarly = new TelemetryAdapter();
+const snapshotReader = new SolanaPositionSnapshotReader(rpcUrl, telemetryEarly);
 const poolDataCacheTtlMs = parsePoolDataCacheTtlMs(
   (process.env as Record<string, string | undefined>)['CLMM_POOL_DATA_CACHE_TTL_MS'],
 );
@@ -106,7 +107,7 @@ const solanaPreparation = new SolanaExecutionPreparationAdapter(rpcUrl, snapshot
 const solanaSubmission = new SolanaExecutionSubmissionAdapter(rpcUrl);
 const monitoredWalletStorage = new MonitoredWalletStorageAdapter(db);
 const walletChallengeStorage = new WalletChallengePostgresAdapter(db);
-const telemetry = new TelemetryAdapter();
+const telemetry = telemetryEarly;
 const regimeEngineBaseUrl =
   (process.env as Record<string, string | undefined>)['REGIME_ENGINE_BASE_URL'] ?? null;
 const regimeEngineInternalToken =

--- a/packages/adapters/src/outbound/solana-position-reads/OrcaPositionFeeRewardQuoteHelper.test.ts
+++ b/packages/adapters/src/outbound/solana-position-reads/OrcaPositionFeeRewardQuoteHelper.test.ts
@@ -314,5 +314,29 @@ describe('OrcaPositionFeeRewardQuoteHelper', () => {
         expect(ri.amountOwed).toBe(0n);
       }
     });
+
+    it('returns unavailable with reason "fee-quote-failed" when an unexpected error escapes the inner catch blocks', async () => {
+      const { getTickArrayStartTickIndex } = await import('@orca-so/whirlpools-core');
+
+      // getTickArrayStartTickIndex is called before any inner try/catch — if it throws,
+      // the outer catch in quote() must classify it as fee-quote-failed rather than rejecting.
+      vi.mocked(getTickArrayStartTickIndex).mockImplementation(() => {
+        throw new Error('unsupported tick index derivation');
+      });
+
+      const helper = new OrcaPositionFeeRewardQuoteHelper();
+      const result = await helper.quote({
+        rpc: mockRpc,
+        position: makePosition(),
+        whirlpool: makeWhirlpool(),
+        whirlpoolAddress: MOCK_WHIRLPOOL,
+      });
+
+      expect(result.kind).toBe('unavailable');
+      if (result.kind !== 'unavailable') throw new Error('expected unavailable');
+      expect(result.reason).toBe('fee-quote-failed');
+      expect(result.errorName).toBe('Error');
+      expect(result.errorMessage).toBe('unsupported tick index derivation');
+    });
   });
 });

--- a/packages/adapters/src/outbound/solana-position-reads/OrcaPositionFeeRewardQuoteHelper.test.ts
+++ b/packages/adapters/src/outbound/solana-position-reads/OrcaPositionFeeRewardQuoteHelper.test.ts
@@ -1,0 +1,325 @@
+/**
+ * OrcaPositionFeeRewardQuoteHelper TDD tests
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { OrcaPositionFeeRewardQuoteHelper } from './OrcaPositionFeeRewardQuoteHelper';
+import type { createSolanaRpc } from '@solana/kit';
+
+vi.mock('@orca-so/whirlpools-client', () => ({
+  getTickArrayAddress: vi.fn(),
+  fetchAllTickArray: vi.fn(),
+}));
+
+vi.mock('@orca-so/whirlpools-core', () => ({
+  getTickArrayStartTickIndex: vi.fn(),
+  getTickIndexInArray: vi.fn(),
+  collectFeesQuote: vi.fn(),
+  collectRewardsQuote: vi.fn(),
+}));
+
+const MOCK_WHIRLPOOL = '7qbRF6YsyGuLUVs6Y1q64bdVrfe4ZcUUz1JRdoVNUJnm';
+const MOCK_POSITION_MINT = '2Wgh4mq6rp1q6H1G6K3ZsR3LBdqT5qVJb5KfF3U7Y2hX';
+const SOL_MINT = 'So11111111111111111111111111111111111111112';
+const USDC_MINT = 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v';
+
+type MockRpc = ReturnType<typeof createSolanaRpc>;
+
+function makePosition(
+  overrides: Partial<{
+    tickLowerIndex: number;
+    tickUpperIndex: number;
+    liquidity: bigint;
+    feeOwedA: bigint;
+    feeOwedB: bigint;
+    rewardInfos: Array<{ amountOwed: bigint; growthInsideCheckpoint: bigint }>;
+  }> = {},
+) {
+  return {
+    whirlpool: MOCK_WHIRLPOOL,
+    tickLowerIndex: -18304,
+    tickUpperIndex: -17956,
+    liquidity: 100000n,
+    feeGrowthCheckpointA: 0n,
+    feeGrowthCheckpointB: 0n,
+    feeOwedA: 999n,
+    feeOwedB: 888n,
+    rewardInfos: [
+      { amountOwed: 777n, growthInsideCheckpoint: 0n },
+      { amountOwed: 0n, growthInsideCheckpoint: 0n },
+      { amountOwed: 0n, growthInsideCheckpoint: 0n },
+    ],
+    ...overrides,
+  };
+}
+
+function makeWhirlpool(
+  overrides: Partial<{
+    tickSpacing: number;
+    rewardInfos: Array<{ mint: { toString: () => string } }>;
+  }> = {},
+) {
+  return {
+    tokenMintA: { toString: () => SOL_MINT },
+    tokenMintB: { toString: () => USDC_MINT },
+    tickSpacing: 64,
+    feeRate: 1000,
+    liquidity: 2400000000n,
+    sqrtPrice: 184467440737095516n,
+    tickCurrentIndex: -18130,
+    feeGrowthGlobalA: 0n,
+    feeGrowthGlobalB: 0n,
+    rewardLastUpdatedTimestamp: 0n,
+    rewardInfos: [
+      { mint: { toString: () => SOL_MINT } },
+      { mint: { toString: () => '11111111111111111111111111111111' } },
+      { mint: { toString: () => '11111111111111111111111111111111' } },
+    ],
+    ...overrides,
+  };
+}
+
+describe('OrcaPositionFeeRewardQuoteHelper', () => {
+  let mockRpc: MockRpc;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRpc = {} as MockRpc;
+  });
+
+  describe('quote', () => {
+    it('returns ok with PositionFees built from collectFeesQuote and collectRewardsQuote', async () => {
+      const { getTickArrayAddress, fetchAllTickArray } = await import('@orca-so/whirlpools-client');
+      const {
+        getTickArrayStartTickIndex,
+        getTickIndexInArray,
+        collectFeesQuote,
+        collectRewardsQuote,
+      } = await import('@orca-so/whirlpools-core');
+
+      vi.mocked(getTickArrayStartTickIndex).mockReturnValueOnce(-22528).mockReturnValueOnce(-22528);
+      vi.mocked(getTickArrayAddress)
+        .mockResolvedValueOnce(['LowerTickArrayAddr1' as never] as never)
+        .mockResolvedValueOnce(['UpperTickArrayAddr1' as never] as never);
+      vi.mocked(getTickIndexInArray).mockReturnValueOnce(5).mockReturnValueOnce(10);
+
+      const lowerTick = { initialized: true, liquidityNet: 0n };
+      const upperTick = { initialized: true, liquidityNet: 0n };
+      vi.mocked(fetchAllTickArray).mockResolvedValue([
+        {
+          data: {
+            ticks: Array.from({ length: 88 }, (_, i) =>
+              i === 5 ? lowerTick : { initialized: false },
+            ),
+          },
+        },
+        {
+          data: {
+            ticks: Array.from({ length: 88 }, (_, i) =>
+              i === 10 ? upperTick : { initialized: false },
+            ),
+          },
+        },
+      ] as never);
+
+      vi.mocked(collectFeesQuote).mockReturnValue({ feeOwedA: 12345n, feeOwedB: 67890n } as never);
+      vi.mocked(collectRewardsQuote).mockReturnValue({
+        rewards: [{ rewardsOwed: 11111n }, { rewardsOwed: 0n }, { rewardsOwed: 0n }],
+      } as never);
+
+      const helper = new OrcaPositionFeeRewardQuoteHelper();
+      const result = await helper.quote({
+        rpc: mockRpc,
+        position: makePosition(),
+        positionMint: MOCK_POSITION_MINT,
+        whirlpool: makeWhirlpool(),
+        whirlpoolAddress: MOCK_WHIRLPOOL,
+      });
+
+      expect(result.kind).toBe('ok');
+      if (result.kind !== 'ok') throw new Error('expected ok');
+      expect(result.fees.feeOwedA).toBe(12345n);
+      expect(result.fees.feeOwedB).toBe(67890n);
+      expect(result.fees.rewardInfos.length).toBe(3);
+      expect(result.fees.rewardInfos[0]!.mint).toBe(SOL_MINT);
+      expect(result.fees.rewardInfos[0]!.amountOwed).toBe(11111n);
+      expect(result.fees.rewardInfos[0]!.decimals).toBe(9);
+      expect(result.fees.rewardInfos[1]!.mint).toBe('11111111111111111111111111111111');
+      expect(result.fees.rewardInfos[1]!.amountOwed).toBe(0n);
+      expect(result.fees.rewardInfos[1]!.decimals).toBeNull();
+    });
+
+    it('returns unavailable with reason "tick-array-fetch-failed" when fetchAllTickArray throws', async () => {
+      const { getTickArrayAddress, fetchAllTickArray } = await import('@orca-so/whirlpools-client');
+      const { getTickArrayStartTickIndex } = await import('@orca-so/whirlpools-core');
+
+      vi.mocked(getTickArrayStartTickIndex).mockReturnValueOnce(-22528).mockReturnValueOnce(-22528);
+      vi.mocked(getTickArrayAddress)
+        .mockResolvedValueOnce(['LowerTickArrayAddr1' as never] as never)
+        .mockResolvedValueOnce(['UpperTickArrayAddr1' as never] as never);
+      vi.mocked(fetchAllTickArray).mockRejectedValue(new Error('rpc 429'));
+
+      const helper = new OrcaPositionFeeRewardQuoteHelper();
+      const result = await helper.quote({
+        rpc: mockRpc,
+        position: makePosition(),
+        positionMint: MOCK_POSITION_MINT,
+        whirlpool: makeWhirlpool(),
+        whirlpoolAddress: MOCK_WHIRLPOOL,
+      });
+
+      expect(result.kind).toBe('unavailable');
+      if (result.kind !== 'unavailable') throw new Error('expected unavailable');
+      expect(result.reason).toBe('tick-array-fetch-failed');
+      expect(result.errorName).toBe('Error');
+      expect(result.errorMessage).toBe('rpc 429');
+    });
+
+    it('returns unavailable with reason "tick-data-missing" when ticks[idx] is undefined', async () => {
+      const { getTickArrayAddress, fetchAllTickArray } = await import('@orca-so/whirlpools-client');
+      const { getTickArrayStartTickIndex, getTickIndexInArray } =
+        await import('@orca-so/whirlpools-core');
+
+      vi.mocked(getTickArrayStartTickIndex).mockReturnValueOnce(-22528).mockReturnValueOnce(-22528);
+      vi.mocked(getTickArrayAddress)
+        .mockResolvedValueOnce(['LowerTickArrayAddr1' as never] as never)
+        .mockResolvedValueOnce(['UpperTickArrayAddr1' as never] as never);
+      vi.mocked(getTickIndexInArray).mockReturnValueOnce(0).mockReturnValueOnce(99);
+      vi.mocked(fetchAllTickArray).mockResolvedValue([
+        { data: { ticks: [{ initialized: true, liquidityNet: 0n }] } },
+        { data: { ticks: [{ initialized: true, liquidityNet: 0n }] } },
+      ] as never);
+
+      const helper = new OrcaPositionFeeRewardQuoteHelper();
+      const result = await helper.quote({
+        rpc: mockRpc,
+        position: makePosition(),
+        positionMint: MOCK_POSITION_MINT,
+        whirlpool: makeWhirlpool(),
+        whirlpoolAddress: MOCK_WHIRLPOOL,
+      });
+
+      expect(result.kind).toBe('unavailable');
+      if (result.kind !== 'unavailable') throw new Error('expected unavailable');
+      expect(result.reason).toBe('tick-data-missing');
+    });
+
+    it('returns unavailable with reason "fee-quote-failed" when collectFeesQuote throws', async () => {
+      const { getTickArrayAddress, fetchAllTickArray } = await import('@orca-so/whirlpools-client');
+      const { getTickArrayStartTickIndex, getTickIndexInArray, collectFeesQuote } =
+        await import('@orca-so/whirlpools-core');
+
+      vi.mocked(getTickArrayStartTickIndex).mockReturnValueOnce(-22528).mockReturnValueOnce(-22528);
+      vi.mocked(getTickArrayAddress)
+        .mockResolvedValueOnce(['LowerTickArrayAddr1' as never] as never)
+        .mockResolvedValueOnce(['UpperTickArrayAddr1' as never] as never);
+      vi.mocked(getTickIndexInArray).mockReturnValueOnce(0).mockReturnValueOnce(0);
+      vi.mocked(fetchAllTickArray).mockResolvedValue([
+        { data: { ticks: [{ initialized: true, liquidityNet: 0n }] } },
+        { data: { ticks: [{ initialized: true, liquidityNet: 0n }] } },
+      ] as never);
+      vi.mocked(collectFeesQuote).mockImplementation(() => {
+        throw new Error('wasm overflow');
+      });
+
+      const helper = new OrcaPositionFeeRewardQuoteHelper();
+      const result = await helper.quote({
+        rpc: mockRpc,
+        position: makePosition(),
+        positionMint: MOCK_POSITION_MINT,
+        whirlpool: makeWhirlpool(),
+        whirlpoolAddress: MOCK_WHIRLPOOL,
+      });
+
+      expect(result.kind).toBe('unavailable');
+      if (result.kind !== 'unavailable') throw new Error('expected unavailable');
+      expect(result.reason).toBe('fee-quote-failed');
+      expect(result.errorMessage).toBe('wasm overflow');
+    });
+
+    it('returns unavailable with reason "reward-quote-failed" when collectRewardsQuote throws', async () => {
+      const { getTickArrayAddress, fetchAllTickArray } = await import('@orca-so/whirlpools-client');
+      const {
+        getTickArrayStartTickIndex,
+        getTickIndexInArray,
+        collectFeesQuote,
+        collectRewardsQuote,
+      } = await import('@orca-so/whirlpools-core');
+
+      vi.mocked(getTickArrayStartTickIndex).mockReturnValueOnce(-22528).mockReturnValueOnce(-22528);
+      vi.mocked(getTickArrayAddress)
+        .mockResolvedValueOnce(['LowerTickArrayAddr1' as never] as never)
+        .mockResolvedValueOnce(['UpperTickArrayAddr1' as never] as never);
+      vi.mocked(getTickIndexInArray).mockReturnValueOnce(0).mockReturnValueOnce(0);
+      vi.mocked(fetchAllTickArray).mockResolvedValue([
+        { data: { ticks: [{ initialized: true, liquidityNet: 0n }] } },
+        { data: { ticks: [{ initialized: true, liquidityNet: 0n }] } },
+      ] as never);
+      vi.mocked(collectFeesQuote).mockReturnValue({ feeOwedA: 1n, feeOwedB: 2n } as never);
+      vi.mocked(collectRewardsQuote).mockImplementation(() => {
+        throw new Error('rewards bug');
+      });
+
+      const helper = new OrcaPositionFeeRewardQuoteHelper();
+      const result = await helper.quote({
+        rpc: mockRpc,
+        position: makePosition(),
+        positionMint: MOCK_POSITION_MINT,
+        whirlpool: makeWhirlpool(),
+        whirlpoolAddress: MOCK_WHIRLPOOL,
+      });
+
+      expect(result.kind).toBe('unavailable');
+      if (result.kind !== 'unavailable') throw new Error('expected unavailable');
+      expect(result.reason).toBe('reward-quote-failed');
+      expect(result.errorMessage).toBe('rewards bug');
+    });
+
+    it('keeps empty/inactive reward slots with mint="", decimals=null, amountOwed=0n even when quote returns nonzero', async () => {
+      const { getTickArrayAddress, fetchAllTickArray } = await import('@orca-so/whirlpools-client');
+      const {
+        getTickArrayStartTickIndex,
+        getTickIndexInArray,
+        collectFeesQuote,
+        collectRewardsQuote,
+      } = await import('@orca-so/whirlpools-core');
+
+      vi.mocked(getTickArrayStartTickIndex).mockReturnValueOnce(-22528).mockReturnValueOnce(-22528);
+      vi.mocked(getTickArrayAddress)
+        .mockResolvedValueOnce(['LowerTickArrayAddr1' as never] as never)
+        .mockResolvedValueOnce(['UpperTickArrayAddr1' as never] as never);
+      vi.mocked(getTickIndexInArray).mockReturnValueOnce(0).mockReturnValueOnce(0);
+      vi.mocked(fetchAllTickArray).mockResolvedValue([
+        { data: { ticks: [{ initialized: true, liquidityNet: 0n }] } },
+        { data: { ticks: [{ initialized: true, liquidityNet: 0n }] } },
+      ] as never);
+      vi.mocked(collectFeesQuote).mockReturnValue({ feeOwedA: 0n, feeOwedB: 0n } as never);
+      vi.mocked(collectRewardsQuote).mockReturnValue({
+        rewards: [{ rewardsOwed: 50n }, { rewardsOwed: 50n }, { rewardsOwed: 50n }],
+      } as never);
+
+      const helper = new OrcaPositionFeeRewardQuoteHelper();
+      const result = await helper.quote({
+        rpc: mockRpc,
+        position: makePosition(),
+        positionMint: MOCK_POSITION_MINT,
+        whirlpool: makeWhirlpool({
+          rewardInfos: [
+            { mint: { toString: () => '' } },
+            { mint: { toString: () => '' } },
+            { mint: { toString: () => '' } },
+          ],
+        }),
+        whirlpoolAddress: MOCK_WHIRLPOOL,
+      });
+
+      expect(result.kind).toBe('ok');
+      if (result.kind !== 'ok') throw new Error('expected ok');
+      expect(result.fees.rewardInfos.length).toBe(3);
+      for (const ri of result.fees.rewardInfos) {
+        expect(ri.mint).toBe('');
+        expect(ri.decimals).toBeNull();
+        expect(ri.amountOwed).toBe(0n);
+      }
+    });
+  });
+});

--- a/packages/adapters/src/outbound/solana-position-reads/OrcaPositionFeeRewardQuoteHelper.test.ts
+++ b/packages/adapters/src/outbound/solana-position-reads/OrcaPositionFeeRewardQuoteHelper.test.ts
@@ -18,7 +18,6 @@ vi.mock('@orca-so/whirlpools-core', () => ({
 }));
 
 const MOCK_WHIRLPOOL = '7qbRF6YsyGuLUVs6Y1q64bdVrfe4ZcUUz1JRdoVNUJnm';
-const MOCK_POSITION_MINT = '2Wgh4mq6rp1q6H1G6K3ZsR3LBdqT5qVJb5KfF3U7Y2hX';
 const SOL_MINT = 'So11111111111111111111111111111111111111112';
 const USDC_MINT = 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v';
 
@@ -130,7 +129,6 @@ describe('OrcaPositionFeeRewardQuoteHelper', () => {
       const result = await helper.quote({
         rpc: mockRpc,
         position: makePosition(),
-        positionMint: MOCK_POSITION_MINT,
         whirlpool: makeWhirlpool(),
         whirlpoolAddress: MOCK_WHIRLPOOL,
       });
@@ -162,7 +160,6 @@ describe('OrcaPositionFeeRewardQuoteHelper', () => {
       const result = await helper.quote({
         rpc: mockRpc,
         position: makePosition(),
-        positionMint: MOCK_POSITION_MINT,
         whirlpool: makeWhirlpool(),
         whirlpoolAddress: MOCK_WHIRLPOOL,
       });
@@ -193,7 +190,6 @@ describe('OrcaPositionFeeRewardQuoteHelper', () => {
       const result = await helper.quote({
         rpc: mockRpc,
         position: makePosition(),
-        positionMint: MOCK_POSITION_MINT,
         whirlpool: makeWhirlpool(),
         whirlpoolAddress: MOCK_WHIRLPOOL,
       });
@@ -225,7 +221,6 @@ describe('OrcaPositionFeeRewardQuoteHelper', () => {
       const result = await helper.quote({
         rpc: mockRpc,
         position: makePosition(),
-        positionMint: MOCK_POSITION_MINT,
         whirlpool: makeWhirlpool(),
         whirlpoolAddress: MOCK_WHIRLPOOL,
       });
@@ -263,7 +258,6 @@ describe('OrcaPositionFeeRewardQuoteHelper', () => {
       const result = await helper.quote({
         rpc: mockRpc,
         position: makePosition(),
-        positionMint: MOCK_POSITION_MINT,
         whirlpool: makeWhirlpool(),
         whirlpoolAddress: MOCK_WHIRLPOOL,
       });
@@ -301,7 +295,6 @@ describe('OrcaPositionFeeRewardQuoteHelper', () => {
       const result = await helper.quote({
         rpc: mockRpc,
         position: makePosition(),
-        positionMint: MOCK_POSITION_MINT,
         whirlpool: makeWhirlpool({
           rewardInfos: [
             { mint: { toString: () => '' } },

--- a/packages/adapters/src/outbound/solana-position-reads/OrcaPositionFeeRewardQuoteHelper.ts
+++ b/packages/adapters/src/outbound/solana-position-reads/OrcaPositionFeeRewardQuoteHelper.ts
@@ -1,0 +1,163 @@
+/**
+ * OrcaPositionFeeRewardQuoteHelper
+ *
+ * Computes live fee + reward quotes for an Orca position using the Whirlpools
+ * SDK direct quote path. Returns a discriminated `FeeRewardQuoteResult` union;
+ * the caller decides what to log and how to surface unavailability.
+ *
+ * Docs: @orca-so/whirlpools-client v6.2.1, @orca-so/whirlpools-core v3.1.0
+ */
+import type { createSolanaRpc, Address } from '@solana/kit';
+import { getTickArrayAddress, fetchAllTickArray } from '@orca-so/whirlpools-client';
+import {
+  getTickArrayStartTickIndex,
+  getTickIndexInArray,
+  collectFeesQuote,
+  collectRewardsQuote,
+} from '@orca-so/whirlpools-core';
+
+import type { PositionFees, PositionRewardInfo } from '@clmm/domain';
+import { KNOWN_TOKENS } from '../price/known-tokens.js';
+
+type Rpc = ReturnType<typeof createSolanaRpc>;
+
+export type FeeRewardQuoteResult =
+  | { kind: 'ok'; fees: PositionFees }
+  | {
+      kind: 'unavailable';
+      reason:
+        | 'tick-array-fetch-failed'
+        | 'tick-data-missing'
+        | 'fee-quote-failed'
+        | 'reward-quote-failed';
+      errorName?: string;
+      errorMessage?: string;
+    };
+
+type OrcaPosition = {
+  tickLowerIndex: number;
+  tickUpperIndex: number;
+  liquidity: bigint;
+  feeGrowthCheckpointA: bigint;
+  feeGrowthCheckpointB: bigint;
+  feeOwedA: bigint;
+  feeOwedB: bigint;
+  rewardInfos: ReadonlyArray<{ amountOwed: bigint; growthInsideCheckpoint: bigint }>;
+};
+
+type OrcaWhirlpool = {
+  tokenMintA: { toString: () => string };
+  tokenMintB: { toString: () => string };
+  tickSpacing: number;
+  feeRate: number;
+  liquidity: bigint;
+  sqrtPrice: bigint;
+  tickCurrentIndex: number;
+  feeGrowthGlobalA: bigint;
+  feeGrowthGlobalB: bigint;
+  rewardLastUpdatedTimestamp: bigint;
+  rewardInfos: ReadonlyArray<{ mint: { toString: () => string } }>;
+};
+
+export type QuoteArgs = {
+  readonly rpc: Rpc;
+  readonly position: OrcaPosition;
+  readonly positionMint: string;
+  readonly whirlpool: OrcaWhirlpool;
+  readonly whirlpoolAddress: Address | string;
+};
+
+const ERROR_MESSAGE_MAX_LENGTH = 200;
+
+function describeError(err: unknown): { errorName?: string; errorMessage?: string } {
+  if (err instanceof Error) {
+    return {
+      errorName: err.name,
+      errorMessage: err.message.slice(0, ERROR_MESSAGE_MAX_LENGTH),
+    };
+  }
+  return { errorMessage: String(err).slice(0, ERROR_MESSAGE_MAX_LENGTH) };
+}
+
+export class OrcaPositionFeeRewardQuoteHelper {
+  async quote(args: QuoteArgs): Promise<FeeRewardQuoteResult> {
+    const { rpc, position, whirlpool, whirlpoolAddress } = args;
+
+    const lowerStart = getTickArrayStartTickIndex(position.tickLowerIndex, whirlpool.tickSpacing);
+    const upperStart = getTickArrayStartTickIndex(position.tickUpperIndex, whirlpool.tickSpacing);
+
+    let lowerTickArray: { data: { ticks: ReadonlyArray<unknown> } };
+    let upperTickArray: { data: { ticks: ReadonlyArray<unknown> } };
+    try {
+      const [lowerAddr] = await getTickArrayAddress(whirlpoolAddress as Address, lowerStart);
+      const [upperAddr] = await getTickArrayAddress(whirlpoolAddress as Address, upperStart);
+      const [lower, upper] = await fetchAllTickArray(rpc, [lowerAddr, upperAddr]);
+      lowerTickArray = lower as never;
+      upperTickArray = upper as never;
+    } catch (err) {
+      return { kind: 'unavailable', reason: 'tick-array-fetch-failed', ...describeError(err) };
+    }
+
+    const lowerIdx = getTickIndexInArray(
+      position.tickLowerIndex,
+      lowerStart,
+      whirlpool.tickSpacing,
+    );
+    const upperIdx = getTickIndexInArray(
+      position.tickUpperIndex,
+      upperStart,
+      whirlpool.tickSpacing,
+    );
+    const lowerTick = lowerTickArray.data.ticks[lowerIdx];
+    const upperTick = upperTickArray.data.ticks[upperIdx];
+    if (lowerTick == null || upperTick == null) {
+      return { kind: 'unavailable', reason: 'tick-data-missing' };
+    }
+
+    let feesQuote: { feeOwedA: bigint; feeOwedB: bigint };
+    try {
+      feesQuote = collectFeesQuote(
+        whirlpool as never,
+        position as never,
+        lowerTick as never,
+        upperTick as never,
+      );
+    } catch (err) {
+      return { kind: 'unavailable', reason: 'fee-quote-failed', ...describeError(err) };
+    }
+
+    let rewardsQuote: { rewards: ReadonlyArray<{ rewardsOwed: bigint }> };
+    try {
+      const currentUnixTimestamp = BigInt(Math.floor(Date.now() / 1000));
+      rewardsQuote = collectRewardsQuote(
+        whirlpool as never,
+        position as never,
+        lowerTick as never,
+        upperTick as never,
+        currentUnixTimestamp,
+      );
+    } catch (err) {
+      return { kind: 'unavailable', reason: 'reward-quote-failed', ...describeError(err) };
+    }
+
+    const rewardInfos: PositionRewardInfo[] = position.rewardInfos.map((_, idx) => {
+      const poolReward = whirlpool.rewardInfos[idx];
+      const rewardMint = poolReward?.mint?.toString() ?? '';
+      const known = KNOWN_TOKENS[rewardMint];
+      const rewardsOwed = rewardsQuote.rewards[idx]?.rewardsOwed ?? 0n;
+      return {
+        mint: rewardMint,
+        amountOwed: rewardMint === '' ? 0n : rewardsOwed,
+        decimals: known?.decimals ?? null,
+      };
+    });
+
+    const fees: PositionFees = {
+      feeOwedA: feesQuote.feeOwedA,
+      feeOwedB: feesQuote.feeOwedB,
+      rewardInfos,
+    };
+
+    return { kind: 'ok', fees };
+  }
+}

--- a/packages/adapters/src/outbound/solana-position-reads/OrcaPositionFeeRewardQuoteHelper.ts
+++ b/packages/adapters/src/outbound/solana-position-reads/OrcaPositionFeeRewardQuoteHelper.ts
@@ -80,6 +80,14 @@ function describeError(err: unknown): { errorName?: string; errorMessage?: strin
 
 export class OrcaPositionFeeRewardQuoteHelper {
   async quote(args: QuoteArgs): Promise<FeeRewardQuoteResult> {
+    try {
+      return await this.#quote(args);
+    } catch (err) {
+      return { kind: 'unavailable', reason: 'fee-quote-failed', ...describeError(err) };
+    }
+  }
+
+  async #quote(args: QuoteArgs): Promise<FeeRewardQuoteResult> {
     const { rpc, position, whirlpool, whirlpoolAddress } = args;
 
     const lowerStart = getTickArrayStartTickIndex(position.tickLowerIndex, whirlpool.tickSpacing);

--- a/packages/adapters/src/outbound/solana-position-reads/OrcaPositionFeeRewardQuoteHelper.ts
+++ b/packages/adapters/src/outbound/solana-position-reads/OrcaPositionFeeRewardQuoteHelper.ts
@@ -62,7 +62,6 @@ type OrcaWhirlpool = {
 export type QuoteArgs = {
   readonly rpc: Rpc;
   readonly position: OrcaPosition;
-  readonly positionMint: string;
   readonly whirlpool: OrcaWhirlpool;
   readonly whirlpoolAddress: Address | string;
 };

--- a/packages/adapters/src/outbound/solana-position-reads/SolanaPositionSnapshotReader.test.ts
+++ b/packages/adapters/src/outbound/solana-position-reads/SolanaPositionSnapshotReader.test.ts
@@ -365,4 +365,162 @@ describe('SolanaPositionSnapshotReader', () => {
       expect(maxInFlight).toBeLessThanOrEqual(2);
     });
   });
+
+  describe('fetchPositionDetail', () => {
+    const SOL_MINT = 'So11111111111111111111111111111111111111112';
+    const USDC_MINT = 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v';
+
+    function setupHappyMocks() {
+      return import('@orca-so/whirlpools-client').then(
+        ({ getPositionAddress, fetchPosition, fetchWhirlpool }) => {
+          vi.mocked(getPositionAddress).mockResolvedValue([
+            address(MOCK_POSITION_PDA),
+          ] as unknown as Awaited<ReturnType<typeof getPositionAddress>>);
+          vi.mocked(fetchPosition).mockResolvedValue({
+            data: {
+              whirlpool: address(MOCK_WHIRLPOOL),
+              tickLowerIndex: -18304,
+              tickUpperIndex: -17956,
+              liquidity: 1000n,
+              feeGrowthCheckpointA: 0n,
+              feeGrowthCheckpointB: 0n,
+              feeOwedA: 9999n,
+              feeOwedB: 8888n,
+              positionMint: address(MOCK_POSITION_MINT),
+              rewardInfos: [
+                { amountOwed: 7777n, growthInsideCheckpoint: 0n },
+                { amountOwed: 0n, growthInsideCheckpoint: 0n },
+                { amountOwed: 0n, growthInsideCheckpoint: 0n },
+              ],
+            },
+          } as unknown as Awaited<ReturnType<typeof fetchPosition>>);
+          vi.mocked(fetchWhirlpool).mockResolvedValue({
+            data: {
+              tickCurrentIndex: -18130,
+              sqrtPrice: 184467440737095516n,
+              tokenMintA: { toString: () => SOL_MINT },
+              tokenMintB: { toString: () => USDC_MINT },
+              feeRate: 1000,
+              tickSpacing: 64,
+              liquidity: 2400000000n,
+              rewardInfos: [
+                { mint: { toString: () => SOL_MINT } },
+                { mint: { toString: () => '11111111111111111111111111111111' } },
+                { mint: { toString: () => '11111111111111111111111111111111' } },
+              ],
+            },
+          } as unknown as Awaited<ReturnType<typeof fetchWhirlpool>>);
+        },
+      );
+    }
+
+    it('returns detail with live fees from helper when quote succeeds', async () => {
+      await setupHappyMocks();
+
+      const helper = {
+        quote: vi.fn().mockResolvedValue({
+          kind: 'ok',
+          fees: {
+            feeOwedA: 12345n,
+            feeOwedB: 67890n,
+            rewardInfos: [{ mint: SOL_MINT, amountOwed: 11111n, decimals: 9 }],
+          },
+        }),
+      };
+      const reader = new SolanaPositionSnapshotReader(mockRpcUrl, undefined, helper as never);
+      const result = await reader.fetchPositionDetail(
+        mockRpcWithOwnership as never,
+        MOCK_POSITION_MINT,
+        MOCK_WALLET,
+      );
+
+      expect(result).not.toBeNull();
+      expect(result!.fees.feeOwedA).toBe(12345n);
+      expect(result!.fees.feeOwedB).toBe(67890n);
+      expect(helper.quote).toHaveBeenCalledTimes(1);
+    });
+
+    it('returns null and logs orca_position_fee_reward_quote_unavailable warn when helper returns unavailable', async () => {
+      await setupHappyMocks();
+
+      const helper = {
+        quote: vi.fn().mockResolvedValue({
+          kind: 'unavailable',
+          reason: 'fee-quote-failed',
+          errorName: 'Error',
+          errorMessage: 'wasm overflow',
+        }),
+      };
+      const observability = {
+        log: vi.fn(),
+        recordTiming: vi.fn(),
+        recordDetectionTiming: vi.fn(),
+        recordDeliveryTiming: vi.fn(),
+      };
+      const reader = new SolanaPositionSnapshotReader(
+        mockRpcUrl,
+        observability as never,
+        helper as never,
+      );
+      const result = await reader.fetchPositionDetail(
+        mockRpcWithOwnership as never,
+        MOCK_POSITION_MINT,
+        MOCK_WALLET,
+      );
+
+      expect(result).toBeNull();
+      expect(observability.log).toHaveBeenCalledTimes(1);
+      expect(observability.log).toHaveBeenCalledWith(
+        'warn',
+        'orca_position_fee_reward_quote_unavailable',
+        expect.objectContaining({
+          positionId: MOCK_POSITION_MINT,
+          walletId: MOCK_WALLET,
+          poolId: MOCK_WHIRLPOOL,
+          lowerTick: -18304,
+          upperTick: -17956,
+          tickSpacing: 64,
+          reason: 'fee-quote-failed',
+          errorName: 'Error',
+          errorMessage: 'wasm overflow',
+        }),
+      );
+    });
+
+    it('does not fall back to checkpointed pos.feeOwedA / pos.feeOwedB / pos.rewardInfos[].amountOwed on quote failure', async () => {
+      await setupHappyMocks();
+
+      const helper = {
+        quote: vi.fn().mockResolvedValue({
+          kind: 'unavailable',
+          reason: 'tick-array-fetch-failed',
+        }),
+      };
+      const observability = {
+        log: vi.fn(),
+        recordTiming: vi.fn(),
+        recordDetectionTiming: vi.fn(),
+        recordDeliveryTiming: vi.fn(),
+      };
+      const reader = new SolanaPositionSnapshotReader(
+        mockRpcUrl,
+        observability as never,
+        helper as never,
+      );
+      const result = await reader.fetchPositionDetail(
+        mockRpcWithOwnership as never,
+        MOCK_POSITION_MINT,
+        MOCK_WALLET,
+      );
+
+      expect(result).toBeNull();
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+      const replacer = (_k: string, v: unknown): unknown =>
+        typeof v === 'bigint' ? v.toString() : v;
+      const stringified = JSON.stringify(observability.log.mock.calls, replacer);
+      expect(stringified).not.toContain('9999');
+      expect(stringified).not.toContain('8888');
+      expect(stringified).not.toContain('7777');
+    });
+  });
 });

--- a/packages/adapters/src/outbound/solana-position-reads/SolanaPositionSnapshotReader.ts
+++ b/packages/adapters/src/outbound/solana-position-reads/SolanaPositionSnapshotReader.ts
@@ -209,7 +209,6 @@ export class SolanaPositionSnapshotReader {
     const quote = await this.quoteHelper.quote({
       rpc,
       position: pos as never,
-      positionMint: positionId,
       whirlpool: w as never,
       whirlpoolAddress,
     });

--- a/packages/adapters/src/outbound/solana-position-reads/SolanaPositionSnapshotReader.ts
+++ b/packages/adapters/src/outbound/solana-position-reads/SolanaPositionSnapshotReader.ts
@@ -5,21 +5,22 @@
  * This reader is used for detailed position inspection and is not responsible for
  * determining breach direction or exit posture - that lives in packages/domain.
  *
- * Docs: @solana/kit v6, @orca-so/whirlpools-client
+ * Live fee/reward computation for fetchPositionDetail is delegated to
+ * OrcaPositionFeeRewardQuoteHelper. Checkpointed fields on the Orca position
+ * account are NEVER mapped into returned PositionFees; quote failures fail
+ * closed (return null) and emit a single structured warning via the
+ * ObservabilityPort, when one is supplied.
+ *
+ * Docs: @solana/kit v6, @orca-so/whirlpools-client v6.2.1
  */
 import { createSolanaRpc, address } from '@solana/kit';
 import { getPositionAddress, fetchPosition, fetchWhirlpool } from '@orca-so/whirlpools-client';
 
-import type {
-  LiquidityPosition,
-  WalletId,
-  PositionId,
-  PoolData,
-  PositionFees,
-  PositionRewardInfo,
-} from '@clmm/domain';
+import type { ObservabilityPort } from '@clmm/application';
+import type { LiquidityPosition, WalletId, PositionId, PoolData, PositionFees } from '@clmm/domain';
 import { makePoolId, makeClockTimestamp, evaluateRangeState } from '@clmm/domain';
 import { KNOWN_TOKENS } from '../price/known-tokens.js';
+import { OrcaPositionFeeRewardQuoteHelper } from './OrcaPositionFeeRewardQuoteHelper.js';
 
 export type WhirlpoolData = {
   tickCurrentIndex: number;
@@ -32,7 +33,11 @@ export type WhirlpoolData = {
 };
 
 export class SolanaPositionSnapshotReader {
-  constructor(private readonly rpcUrl: string) {}
+  constructor(
+    private readonly rpcUrl: string,
+    private readonly observability?: ObservabilityPort,
+    private readonly quoteHelper: OrcaPositionFeeRewardQuoteHelper = new OrcaPositionFeeRewardQuoteHelper(),
+  ) {}
 
   getRpc() {
     return createSolanaRpc(this.rpcUrl);
@@ -151,86 +156,101 @@ export class SolanaPositionSnapshotReader {
     fees: PositionFees;
     positionLiquidity: bigint;
   } | null> {
+    let positionMint;
+    let positionAddress;
+    let positionAccount;
     try {
-      const positionMint = address(positionId);
-      const [positionAddress] = await getPositionAddress(positionMint);
-      const positionAccount = await fetchPosition(rpc, positionAddress);
-      const pos = positionAccount.data;
-
-      const isOwner = await this.verifyOwnership(rpc, walletId, positionId);
-      if (!isOwner) {
-        return null;
-      }
-
-      const whirlpoolAddress = pos.whirlpool;
-      const whirlpoolAccount = await fetchWhirlpool(rpc, whirlpoolAddress);
-      const w = whirlpoolAccount.data;
-
-      const poolIdStr = whirlpoolAddress.toString();
-      const mintA = w.tokenMintA.toString();
-      const mintB = w.tokenMintB.toString();
-      const knownA = KNOWN_TOKENS[mintA];
-      const knownB = KNOWN_TOKENS[mintB];
-
-      const poolData: PoolData = {
-        poolId: makePoolId(poolIdStr),
-        tokenPair: {
-          mintA,
-          mintB,
-          symbolA: knownA?.symbol ?? mintA,
-          symbolB: knownB?.symbol ?? mintB,
-          decimalsA: knownA?.decimals ?? null,
-          decimalsB: knownB?.decimals ?? null,
-        },
-        sqrtPrice: w.sqrtPrice,
-        feeRate: w.feeRate,
-        tickSpacing: w.tickSpacing,
-        liquidity: w.liquidity,
-        tickCurrentIndex: w.tickCurrentIndex,
-      };
-
-      const rewardInfos: PositionRewardInfo[] = pos.rewardInfos.map((ri, idx) => {
-        const poolReward = w.rewardInfos[idx];
-        const rewardMint = poolReward?.mint?.toString() ?? '';
-        const known = KNOWN_TOKENS[rewardMint];
-        return {
-          mint: rewardMint,
-          amountOwed: ri.amountOwed,
-          decimals: known?.decimals ?? null,
-        };
-      });
-
-      const fees: PositionFees = {
-        feeOwedA: pos.feeOwedA,
-        feeOwedB: pos.feeOwedB,
-        rewardInfos,
-      };
-
-      const bounds = {
-        lowerBound: pos.tickLowerIndex,
-        upperBound: pos.tickUpperIndex,
-      };
-
-      const rangeState = evaluateRangeState(bounds, w.tickCurrentIndex);
-
-      const position: LiquidityPosition = {
-        positionId,
-        walletId,
-        poolId: makePoolId(poolIdStr),
-        bounds,
-        lastObservedAt: makeClockTimestamp(Date.now()),
-        rangeState,
-        monitoringReadiness: { kind: 'active' },
-      };
-
-      return {
-        position,
-        poolData,
-        fees,
-        positionLiquidity: pos.liquidity,
-      };
+      positionMint = address(positionId);
+      [positionAddress] = await getPositionAddress(positionMint);
+      positionAccount = await fetchPosition(rpc, positionAddress);
     } catch {
       return null;
     }
+    const pos = positionAccount.data;
+
+    const isOwner = await this.verifyOwnership(rpc, walletId, positionId);
+    if (!isOwner) {
+      return null;
+    }
+
+    let whirlpoolAddress;
+    let whirlpoolAccount;
+    try {
+      whirlpoolAddress = pos.whirlpool;
+      whirlpoolAccount = await fetchWhirlpool(rpc, whirlpoolAddress);
+    } catch {
+      return null;
+    }
+    const w = whirlpoolAccount.data;
+
+    const poolIdStr = whirlpoolAddress.toString();
+    const mintA = w.tokenMintA.toString();
+    const mintB = w.tokenMintB.toString();
+    const knownA = KNOWN_TOKENS[mintA];
+    const knownB = KNOWN_TOKENS[mintB];
+
+    const poolData: PoolData = {
+      poolId: makePoolId(poolIdStr),
+      tokenPair: {
+        mintA,
+        mintB,
+        symbolA: knownA?.symbol ?? mintA,
+        symbolB: knownB?.symbol ?? mintB,
+        decimalsA: knownA?.decimals ?? null,
+        decimalsB: knownB?.decimals ?? null,
+      },
+      sqrtPrice: w.sqrtPrice,
+      feeRate: w.feeRate,
+      tickSpacing: w.tickSpacing,
+      liquidity: w.liquidity,
+      tickCurrentIndex: w.tickCurrentIndex,
+    };
+
+    const quote = await this.quoteHelper.quote({
+      rpc,
+      position: pos as never,
+      positionMint: positionId,
+      whirlpool: w as never,
+      whirlpoolAddress,
+    });
+
+    if (quote.kind !== 'ok') {
+      this.observability?.log('warn', 'orca_position_fee_reward_quote_unavailable', {
+        positionId,
+        walletId,
+        poolId: poolIdStr,
+        lowerTick: pos.tickLowerIndex,
+        upperTick: pos.tickUpperIndex,
+        tickSpacing: w.tickSpacing,
+        reason: quote.reason,
+        ...(quote.errorName !== undefined ? { errorName: quote.errorName } : {}),
+        ...(quote.errorMessage !== undefined ? { errorMessage: quote.errorMessage } : {}),
+      });
+      return null;
+    }
+
+    const bounds = {
+      lowerBound: pos.tickLowerIndex,
+      upperBound: pos.tickUpperIndex,
+    };
+
+    const rangeState = evaluateRangeState(bounds, w.tickCurrentIndex);
+
+    const position: LiquidityPosition = {
+      positionId,
+      walletId,
+      poolId: makePoolId(poolIdStr),
+      bounds,
+      lastObservedAt: makeClockTimestamp(Date.now()),
+      rangeState,
+      monitoringReadiness: { kind: 'active' },
+    };
+
+    return {
+      position,
+      poolData,
+      fees: quote.fees,
+      positionLiquidity: pos.liquidity,
+    };
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -186,6 +186,9 @@ importers:
       '@orca-so/whirlpools-client':
         specifier: ^6.2.1
         version: 6.2.1(@solana/kit@6.5.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6))
+      '@orca-so/whirlpools-core':
+        specifier: 3.1.0
+        version: 3.1.0
       '@solana-mobile/mobile-wallet-adapter-protocol':
         specifier: ^2.2.6
         version: 2.2.8(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@13.6.4(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.2(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(typescript@5.9.3)


### PR DESCRIPTION
## Summary

Replaces stale on-chain `feeOwedA`/`feeOwedB`/`amountOwed` accumulator fields with live computed fee and reward quotes from Orca tick data. When quotes are unavailable (tick array fetch failure, missing tick data, SDK errors), the adapter logs a structured observability event and returns `null`, which propagates through the existing 503 error path — so the UI shows "temporarily unavailable" instead of misleading stale numbers.

## Changes

- **OrcaPositionFeeRewardQuoteHelper** — stateless helper with `quote()` returning a discriminated `FeeRewardQuoteResult` union (`ok` | `tick-array-fetch-failed` | `tick-data-missing` | `fee-quote-failed` | `reward-quote-failed`)
- **SolanaPositionSnapshotReader** — delegates fee/reward computation to the helper; on unavailable result, logs `'orca_position_fee_reward_quote_unavailable'` via `ObservabilityPort` and returns `null`
- **Composition wiring** — `ObservabilityPort` threaded through `AdaptersModule` and `AppModule`
- **Inactive reward mints** — slots with `mint = ''` receive `amountOwed = 0n, decimals = null` instead of crashing
- **Compound doc** — pattern documented in `docs/solutions/best-practices/`

## Test plan

- 6 helper unit tests covering all result-union arms (ok, tick-array-fetch-failed, tick-data-missing, fee-quote-failed, reward-quote-failed, inactive reward mints)
- 3 reader integration tests (ok path, unavailable+log, no-fallback assertion)
- Full adapters suite: 420/420 passing
- Full application suite: 158/158 passing
- Root typecheck: clean

Closes #61

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Claude_Code-GLM_5.1-D97757?logo=claude&logoColor=white)