### PR TITLE
fix(ui): render Regime freshness thresholds as exact minutes

### DIFF
--- a/docs/solutions/ui-bugs/regime-threshold-hours-vs-minutes-2026-05-09.md
+++ b/docs/solutions/ui-bugs/regime-threshold-hours-vs-minutes-2026-05-09.md
@@ -1,0 +1,65 @@
+---
+title: Regime freshness thresholds displayed hours instead of comparable minutes
+date: 2026-05-09
+category: ui-bugs
+module: '@clmm/ui'
+problem_type: ui_bug
+component: tooling
+symptoms:
+  - Soft stale threshold of 4500s (75min) displayed as "1h" instead of "75m"
+  - Hard stale threshold of 5400s (90min) displayed as "2h" instead of "90m"
+root_cause: logic_error
+resolution_type: code_fix
+severity: medium
+tags: [regime, freshness, formatting, view-model, threshold]
+---
+
+# Regime freshness thresholds displayed hours instead of comparable minutes
+
+## Problem
+
+Regime card freshness thresholds (soft/hard stale) were rendered as hours (`1h`, `2h`) once the value exceeded 60 minutes, making them incomparable with the adjacent "Latest candle" row that always displays age as `Xm old`. A threshold of 90 minutes showing as `2h` is visually inconsistent and harder for users to compare against `90m old`.
+
+## Symptoms
+
+- Soft stale threshold (4500s = 75min) showed `1h` instead of `75m`
+- Hard stale threshold (5400s = 90min) showed `2h` instead of `90m`
+- Any threshold >= 60 minutes was formatted in hours, losing minute precision
+
+## Solution
+
+Replaced `formatSecondsThreshold` (which switched to hours past 60 minutes) with `formatFreshnessThresholdSeconds` (which always returns minutes):
+
+**Before:**
+
+```ts
+function formatSecondsThreshold(seconds: number): string {
+  const minutes = Math.round(seconds / 60);
+  if (minutes < 60) return `${minutes}m`;
+  const hours = Math.round(minutes / 60);
+  return `${hours}h`;
+}
+```
+
+**After:**
+
+```ts
+function formatFreshnessThresholdSeconds(seconds: number): string {
+  return `${Math.round(seconds / 60)}m`;
+}
+```
+
+Both call sites in `buildFreshnessRows` updated. The function is module-private — no exports changed, no other packages touched.
+
+## Why This Works
+
+The hour-switching logic was technically correct for general time display, but the freshness rows need all values in the same unit for visual comparison. The "Latest candle" row already uses `Xm old`, so thresholds must also use minutes to be directly comparable. The new helper is intentionally named `formatFreshnessThresholdSeconds` to signal its specific purpose — not a general-purpose time formatter.
+
+## Prevention
+
+- When displaying related values in a UI, ensure all values use the same unit for comparability
+- Name formatting helpers after their domain (e.g., `formatFreshnessThresholdSeconds`) rather than generic names (e.g., `formatSecondsThreshold`) to prevent reuse in inappropriate contexts
+
+## Related Issues
+
+- GitHub: https://github.com/opsclawd/clmm-v2/issues/86

--- a/docs/superpowers/plans/2026-05-09-regime-threshold-formatting.md
+++ b/docs/superpowers/plans/2026-05-09-regime-threshold-formatting.md
@@ -1,0 +1,257 @@
+# Regime Threshold Formatting Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Render Regime card freshness thresholds (soft/hard stale) as exact minute labels (e.g. `90m`) so they are directly comparable to the existing `Xm old` latest-candle label.
+
+**Architecture:** Replace the existing `formatSecondsThreshold` helper in `packages/ui/src/view-models/RegimeViewModel.ts` (which switches to hours past 60 minutes) with a narrow `formatFreshnessThresholdSeconds` helper that always returns minutes. Only `buildFreshnessRows` consumes the helper, so no component, DTO, adapter, or domain code is touched. Tests are colocated in `RegimeViewModel.test.ts`.
+
+**Tech Stack:** TypeScript, Vitest, pnpm workspaces (`@clmm/ui`).
+
+---
+
+## Spec Reference
+
+Source spec: `docs/superpowers/specs/2026-05-09-regime-threshold-formatting-design.md`
+Source GitHub issue: https://github.com/opsclawd/clmm-v2/issues/86
+
+## File Structure
+
+- Modify: `packages/ui/src/view-models/RegimeViewModel.ts` (lines 81–86 helper, lines 192–199 call sites)
+- Modify: `packages/ui/src/view-models/RegimeViewModel.test.ts` (add tests inside the existing `buildRegimeViewModelBlock — expanded rows` describe block at line 298)
+
+No new files. No exports change. The helper stays module-private (not exported).
+
+---
+
+## Task 1: Add failing tests for minute-only threshold formatting
+
+**Files:**
+
+- Modify: `packages/ui/src/view-models/RegimeViewModel.test.ts` (append new tests inside the `buildRegimeViewModelBlock — expanded rows` describe block, after the existing `expandedFreshnessRows computes candle age from live clock` test ending at line 359)
+
+- [ ] **Step 1: Open the test file and locate the insertion point**
+
+Open `packages/ui/src/view-models/RegimeViewModel.test.ts`. Find the closing `});` of the test `expandedFreshnessRows computes candle age from live clock, not cached ageSeconds` (around line 359), which is the last test inside the `buildRegimeViewModelBlock — expanded rows` describe block. Insert the new tests **before** the describe block's closing `});` (around line 360).
+
+The existing `makeBlock` helper at the top of the file already accepts a `freshness` override and is what the new tests will use.
+
+- [ ] **Step 2: Add the failing tests**
+
+Insert this code block before the closing `});` of the `buildRegimeViewModelBlock — expanded rows` describe block:
+
+```ts
+it('renders soft stale threshold as exact minutes (75m, not 1h)', () => {
+  const vm = buildRegimeViewModelBlock(
+    makeBlock({
+      freshness: {
+        generatedAtUnixMs: GENERATED,
+        lastCandleUnixMs: LAST_CANDLE,
+        ageSeconds: 60,
+        softStale: false,
+        hardStale: false,
+        softStaleSeconds: 4500,
+        hardStaleSeconds: 5400,
+      },
+    }),
+    GENERATED,
+  );
+  const soft = vm.expandedFreshnessRows.find((r) => r.label === 'Soft stale threshold');
+  expect(soft?.value).toBe('75m');
+});
+
+it('renders hard stale threshold as exact minutes (90m, not 2h)', () => {
+  const vm = buildRegimeViewModelBlock(
+    makeBlock({
+      freshness: {
+        generatedAtUnixMs: GENERATED,
+        lastCandleUnixMs: LAST_CANDLE,
+        ageSeconds: 60,
+        softStale: false,
+        hardStale: false,
+        softStaleSeconds: 4500,
+        hardStaleSeconds: 5400,
+      },
+    }),
+    GENERATED,
+  );
+  const hard = vm.expandedFreshnessRows.find((r) => r.label === 'Hard stale threshold');
+  expect(hard?.value).toBe('90m');
+});
+
+it('renders 7200s as 120m (not 2h) for the hard stale threshold', () => {
+  const vm = buildRegimeViewModelBlock(
+    makeBlock({
+      freshness: {
+        generatedAtUnixMs: GENERATED,
+        lastCandleUnixMs: LAST_CANDLE,
+        ageSeconds: 60,
+        softStale: false,
+        hardStale: false,
+        softStaleSeconds: 4500,
+        hardStaleSeconds: 7200,
+      },
+    }),
+    GENERATED,
+  );
+  const hard = vm.expandedFreshnessRows.find((r) => r.label === 'Hard stale threshold');
+  expect(hard?.value).toBe('120m');
+});
+
+it('renders 9000s as 150m (not 3h) for the hard stale threshold', () => {
+  const vm = buildRegimeViewModelBlock(
+    makeBlock({
+      freshness: {
+        generatedAtUnixMs: GENERATED,
+        lastCandleUnixMs: LAST_CANDLE,
+        ageSeconds: 60,
+        softStale: false,
+        hardStale: false,
+        softStaleSeconds: 4500,
+        hardStaleSeconds: 9000,
+      },
+    }),
+    GENERATED,
+  );
+  const hard = vm.expandedFreshnessRows.find((r) => r.label === 'Hard stale threshold');
+  expect(hard?.value).toBe('150m');
+});
+
+it('rounds threshold seconds with Math.round at the minute boundary', () => {
+  const vm = buildRegimeViewModelBlock(
+    makeBlock({
+      freshness: {
+        generatedAtUnixMs: GENERATED,
+        lastCandleUnixMs: LAST_CANDLE,
+        ageSeconds: 60,
+        softStale: false,
+        hardStale: false,
+        softStaleSeconds: 4529,
+        hardStaleSeconds: 4531,
+      },
+    }),
+    GENERATED,
+  );
+  const soft = vm.expandedFreshnessRows.find((r) => r.label === 'Soft stale threshold');
+  const hard = vm.expandedFreshnessRows.find((r) => r.label === 'Hard stale threshold');
+  expect(soft?.value).toBe('75m');
+  expect(hard?.value).toBe('76m');
+});
+```
+
+- [ ] **Step 3: Run the new tests to verify they fail**
+
+Run: `pnpm --filter @clmm/ui test -- RegimeViewModel`
+
+Expected: all five new tests fail. The current `formatSecondsThreshold` returns minutes only when `minutes < 60` and otherwise switches to `Math.round(minutes / 60)` hours, so:
+
+- 4500s (75 min) → received `1h`, expected `75m`
+- 5400s (90 min) → received `2h`, expected `90m`
+- 7200s (120 min) → received `2h`, expected `120m`
+- 9000s (150 min) → received `3h`, expected `150m`
+- 4529s/4531s (~75/76 min) → received `1h`/`1h`, expected `75m`/`76m`
+
+If any test unexpectedly passes, double-check that the new tests are inside the `expanded rows` describe block (not after the file's final `});`) and that vitest is actually picking them up.
+
+- [ ] **Step 4: Commit the failing tests**
+
+```bash
+git add packages/ui/src/view-models/RegimeViewModel.test.ts
+git commit -m "test(ui): pin Regime freshness thresholds to exact minutes"
+```
+
+---
+
+## Task 2: Replace `formatSecondsThreshold` with `formatFreshnessThresholdSeconds`
+
+**Files:**
+
+- Modify: `packages/ui/src/view-models/RegimeViewModel.ts:81-86` (replace helper)
+- Modify: `packages/ui/src/view-models/RegimeViewModel.ts:193,198` (update call sites in `buildFreshnessRows`)
+
+- [ ] **Step 1: Replace the helper definition**
+
+In `packages/ui/src/view-models/RegimeViewModel.ts`, replace the `formatSecondsThreshold` function (lines 81–86):
+
+```ts
+function formatSecondsThreshold(seconds: number): string {
+  const minutes = Math.round(seconds / 60);
+  if (minutes < 60) return `${minutes}m`;
+  const hours = Math.round(minutes / 60);
+  return `${hours}h`;
+}
+```
+
+with:
+
+```ts
+function formatFreshnessThresholdSeconds(seconds: number): string {
+  return `${Math.round(seconds / 60)}m`;
+}
+```
+
+The new helper is intentionally specific to Regime freshness thresholds — do not generalize it, do not switch to hours, do not add mixed units. The point is comparability with the existing `Xm old` candle-age label.
+
+- [ ] **Step 2: Update the two call sites in `buildFreshnessRows`**
+
+Inside `buildFreshnessRows` (around lines 193 and 198), change both call sites from `formatSecondsThreshold(...)` to `formatFreshnessThresholdSeconds(...)`. After the edit, the relevant section looks like:
+
+```ts
+    {
+      label: 'Soft stale threshold',
+      value: formatFreshnessThresholdSeconds(block.freshness.softStaleSeconds),
+      tone: 'muted',
+    },
+    {
+      label: 'Hard stale threshold',
+      value: formatFreshnessThresholdSeconds(block.freshness.hardStaleSeconds),
+      tone: 'muted',
+    },
+```
+
+There are no other call sites for `formatSecondsThreshold` in the file or repo (the helper was module-private). After this edit, the old name should appear nowhere.
+
+- [ ] **Step 3: Verify the old helper name is gone**
+
+Run: `grep -n "formatSecondsThreshold" packages/ui/src/view-models/RegimeViewModel.ts`
+
+Expected: no matches. If any matches remain, finish renaming them — leaving the old name behind would be a rename oversight, not a deliberate alias.
+
+- [ ] **Step 4: Run the targeted tests to verify they pass**
+
+Run: `pnpm --filter @clmm/ui test -- RegimeViewModel`
+
+Expected: all `RegimeViewModel` tests pass, including the five added in Task 1.
+
+- [ ] **Step 5: Run the UI typecheck**
+
+Run: `pnpm --filter @clmm/ui typecheck`
+
+Expected: clean. The signature `(seconds: number) => string` is unchanged, so call sites remain type-correct.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/ui/src/view-models/RegimeViewModel.ts
+git commit -m "fix(ui): render Regime freshness thresholds as exact minutes"
+```
+
+---
+
+## Verification (final)
+
+These are the narrow UI checks the spec calls out. Run both before declaring the change complete.
+
+- [ ] **Step 1: Run the full RegimeViewModel test file**
+
+Run: `pnpm --filter @clmm/ui test -- RegimeViewModel`
+
+Expected: all tests pass, including the five added in Task 1 and the existing data-quality, label, display-reason, and expanded-row tests.
+
+- [ ] **Step 2: Run the UI typecheck**
+
+Run: `pnpm --filter @clmm/ui typecheck`
+
+Expected: clean.
+
+If either fails, do not push or open a PR — diagnose first. Per the spec, broader cross-package checks are not required because this change is confined to the view model and its tests; if you ended up touching DTOs, adapters, components, or app code, escalate to the full repo checks listed in `AGENTS.md`.

--- a/docs/superpowers/specs/2026-05-09-regime-threshold-formatting-design.md
+++ b/docs/superpowers/specs/2026-05-09-regime-threshold-formatting-design.md
@@ -1,0 +1,92 @@
+# Regime Threshold Formatting Design
+
+## Source
+
+GitHub issue: https://github.com/opsclawd/clmm-v2/issues/86
+
+## Goal
+
+Fix the Regime card freshness threshold labels so they are directly comparable to the latest candle age. The card currently shows latest candle age in minutes, but rounds freshness thresholds into whole hours. That makes a correct hard-stale classification appear contradictory when a 90-minute threshold renders as `2h`.
+
+The UI should render Regime freshness thresholds as exact minute labels:
+
+```text
+Latest candle: 110m old
+Soft stale threshold: 75m
+Hard stale threshold: 90m
+```
+
+## Scope
+
+In scope:
+
+- Update Regime freshness threshold formatting in `packages/ui/src/view-models/RegimeViewModel.ts`.
+- Keep formatting ownership in the Regime view model.
+- Update Regime view-model tests to cover threshold labels for 75m, 90m, 120m, and 150m.
+- Optionally cover rounding behavior around minute boundaries.
+
+Out of scope:
+
+- No adapter, DTO, component, domain, or execution-policy changes.
+- No shared or general human-readable duration formatter.
+- No changes to `packages/ui/src/components/RegimeSection.tsx`; it already renders precomputed freshness rows.
+- No changes to `DirectionalExitPolicyService` or directional exit mapping.
+
+## Design
+
+Replace the existing Regime threshold formatter with a narrow helper in `RegimeViewModel.ts`:
+
+```ts
+function formatFreshnessThresholdSeconds(seconds: number): string {
+  return `${Math.round(seconds / 60)}m`;
+}
+```
+
+This helper is intentionally specific to Regime freshness thresholds. It does not format general durations, and it must not switch to hours or mixed units. The purpose is comparability with the existing latest-candle age label, which is formatted as `Xm old`.
+
+`buildFreshnessRows` continues to own the expanded freshness rows:
+
+- `Latest candle`
+- `Soft stale threshold`
+- `Hard stale threshold`
+
+Only the threshold row values change. `RegimeSection.tsx` remains a thin renderer of view-model output.
+
+## Expected Formatting
+
+Required cases:
+
+- `4500s -> 75m`
+- `5400s -> 90m`
+- `7200s -> 120m`
+- `9000s -> 150m`
+
+Optional rounding cases:
+
+- `4529s -> 75m`
+- `4531s -> 76m`
+
+## Testing
+
+Update `packages/ui/src/view-models/RegimeViewModel.test.ts` with a focused test that builds Regime view models using different `softStaleSeconds` and `hardStaleSeconds` values, then asserts the corresponding `expandedFreshnessRows` values.
+
+The tests should verify:
+
+- `softStaleSeconds = 4500` renders `75m`, not `1h`.
+- `hardStaleSeconds = 5400` renders `90m`, not `2h`.
+- `7200` renders `120m`.
+- `9000` renders `150m`.
+- Optional: second rounding behavior follows `Math.round(seconds / 60)`.
+
+No component test is required for this change because `RegimeSection.tsx` renders the view-model rows without interpreting threshold values.
+
+## Verification
+
+Run the narrow UI checks after implementation:
+
+```text
+pnpm --filter @clmm/ui test -- RegimeViewModel
+pnpm --filter @clmm/ui typecheck
+```
+
+If implementation stays limited to the view-model and its tests, full cross-package checks are not required for confidence. If the implementation touches any exported DTO, adapter, component, or app code, escalate verification to the broader repo checks from `AGENTS.md`.

--- a/packages/ui/src/view-models/RegimeViewModel.test.ts
+++ b/packages/ui/src/view-models/RegimeViewModel.test.ts
@@ -357,4 +357,101 @@ describe('buildRegimeViewModelBlock — expanded rows', () => {
     const candleRow = vm.expandedFreshnessRows.find((r) => r.label === 'Latest candle');
     expect(candleRow?.value).toBe('150m old');
   });
+
+  it('renders soft stale threshold as exact minutes (75m, not 1h)', () => {
+    const vm = buildRegimeViewModelBlock(
+      makeBlock({
+        freshness: {
+          generatedAtUnixMs: GENERATED,
+          lastCandleUnixMs: LAST_CANDLE,
+          ageSeconds: 60,
+          softStale: false,
+          hardStale: false,
+          softStaleSeconds: 4500,
+          hardStaleSeconds: 5400,
+        },
+      }),
+      GENERATED,
+    );
+    const soft = vm.expandedFreshnessRows.find((r) => r.label === 'Soft stale threshold');
+    expect(soft?.value).toBe('75m');
+  });
+
+  it('renders hard stale threshold as exact minutes (90m, not 2h)', () => {
+    const vm = buildRegimeViewModelBlock(
+      makeBlock({
+        freshness: {
+          generatedAtUnixMs: GENERATED,
+          lastCandleUnixMs: LAST_CANDLE,
+          ageSeconds: 60,
+          softStale: false,
+          hardStale: false,
+          softStaleSeconds: 4500,
+          hardStaleSeconds: 5400,
+        },
+      }),
+      GENERATED,
+    );
+    const hard = vm.expandedFreshnessRows.find((r) => r.label === 'Hard stale threshold');
+    expect(hard?.value).toBe('90m');
+  });
+
+  it('renders 7200s as 120m (not 2h) for the hard stale threshold', () => {
+    const vm = buildRegimeViewModelBlock(
+      makeBlock({
+        freshness: {
+          generatedAtUnixMs: GENERATED,
+          lastCandleUnixMs: LAST_CANDLE,
+          ageSeconds: 60,
+          softStale: false,
+          hardStale: false,
+          softStaleSeconds: 4500,
+          hardStaleSeconds: 7200,
+        },
+      }),
+      GENERATED,
+    );
+    const hard = vm.expandedFreshnessRows.find((r) => r.label === 'Hard stale threshold');
+    expect(hard?.value).toBe('120m');
+  });
+
+  it('renders 9000s as 150m (not 3h) for the hard stale threshold', () => {
+    const vm = buildRegimeViewModelBlock(
+      makeBlock({
+        freshness: {
+          generatedAtUnixMs: GENERATED,
+          lastCandleUnixMs: LAST_CANDLE,
+          ageSeconds: 60,
+          softStale: false,
+          hardStale: false,
+          softStaleSeconds: 4500,
+          hardStaleSeconds: 9000,
+        },
+      }),
+      GENERATED,
+    );
+    const hard = vm.expandedFreshnessRows.find((r) => r.label === 'Hard stale threshold');
+    expect(hard?.value).toBe('150m');
+  });
+
+  it('rounds threshold seconds with Math.round at the minute boundary', () => {
+    const vm = buildRegimeViewModelBlock(
+      makeBlock({
+        freshness: {
+          generatedAtUnixMs: GENERATED,
+          lastCandleUnixMs: LAST_CANDLE,
+          ageSeconds: 60,
+          softStale: false,
+          hardStale: false,
+          softStaleSeconds: 4529,
+          hardStaleSeconds: 4531,
+        },
+      }),
+      GENERATED,
+    );
+    const soft = vm.expandedFreshnessRows.find((r) => r.label === 'Soft stale threshold');
+    const hard = vm.expandedFreshnessRows.find((r) => r.label === 'Hard stale threshold');
+    expect(soft?.value).toBe('75m');
+    expect(hard?.value).toBe('76m');
+  });
 });

--- a/packages/ui/src/view-models/RegimeViewModel.ts
+++ b/packages/ui/src/view-models/RegimeViewModel.ts
@@ -78,11 +78,8 @@ function formatMinutesAgo(elapsedMs: number): string {
   return `${minutes}m`;
 }
 
-function formatSecondsThreshold(seconds: number): string {
-  const minutes = Math.round(seconds / 60);
-  if (minutes < 60) return `${minutes}m`;
-  const hours = Math.round(minutes / 60);
-  return `${hours}h`;
+function formatFreshnessThresholdSeconds(seconds: number): string {
+  return `${Math.round(seconds / 60)}m`;
 }
 
 function trendQualitative(strength: number): string {
@@ -190,12 +187,12 @@ function buildFreshnessRows(block: RegimeBlock, now: number): RegimeDetailRow[] 
     },
     {
       label: 'Soft stale threshold',
-      value: formatSecondsThreshold(block.freshness.softStaleSeconds),
+      value: formatFreshnessThresholdSeconds(block.freshness.softStaleSeconds),
       tone: 'muted',
     },
     {
       label: 'Hard stale threshold',
-      value: formatSecondsThreshold(block.freshness.hardStaleSeconds),
+      value: formatFreshnessThresholdSeconds(block.freshness.hardStaleSeconds),
       tone: 'muted',
     },
   ];


### PR DESCRIPTION
Fixes #86

Regime card freshness thresholds (soft/hard stale) now render as exact minute labels (e.g. `90m`) instead of switching to hours (`2h`) past 60 minutes. This makes them directly comparable to the `Xm old` latest-candle age label.

## Changes

- Replaced `formatSecondsThreshold` (which switched to hours ≥ 60min) with `formatFreshnessThresholdSeconds` (always minutes) in `packages/ui/src/view-models/RegimeViewModel.ts`
- Added 5 tests covering 75m, 90m, 120m, 150m, and minute-boundary rounding

No component, DTO, adapter, or domain changes. The helper stays module-private.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![OpenCode](https://img.shields.io/badge/OpenCode-GLM_5.1-0A0A0A?logo=data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjAiIGhlaWdodD0iMjAiIHZpZXdCb3g9IjAgMCAyMCAyMCIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj48Y2lyY2xlIGN4PSIxMCIgY3k9IjEwIiByPSIxMCIgZmlsbD0iIzBBMEEwQSIvPjwvc3ZnPg==&logoColor=white)